### PR TITLE
improvement: section test and ref check

### DIFF
--- a/src/final-JATS-schematron.sch
+++ b/src/final-JATS-schematron.sch
@@ -3136,6 +3136,8 @@
     <assert test="title" role="error" id="sec-test-1">[sec-test-1] sec must have a title</assert>
       
       <assert test="$child-count gt 0" role="error" id="sec-test-2">[sec-test-2] sec appears to contain no content. This cannot be correct.</assert>
+      
+      <report test="count(ancestor::sec) ge 5" role="error" id="sec-test-5">[sec-test-5] Level <value-of select="count(ancestor::sec) + 1"/> sections are not allowed. Please either make this a level 5 heading, or capture the title as a bolded paragraph in its parent section.</report>
     </rule>
   </pattern>
   <pattern id="res-data-sec-pattern">
@@ -5506,7 +5508,7 @@
   </pattern>
   
   <pattern id="org-ref-article-book-title-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">	
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">	
       <let name="lc" value="lower-case(.)"/>
       
       <report test="matches($lc,'b\.\s?subtilis') and not(italic[contains(text() ,'B. subtilis')])" role="info" id="bssubtilis-ref-article-title-check">[bssubtilis-ref-article-title-check] ref <value-of select="ancestor::ref/@id"/> references an organism - 'B. subtilis' - but there is no italic element with that correct capitalisation or spacing.</report>

--- a/src/final-package-JATS-schematron.sch
+++ b/src/final-package-JATS-schematron.sch
@@ -3237,6 +3237,8 @@
     <assert test="title" role="error" id="sec-test-1">sec must have a title</assert>
       
       <assert test="$child-count gt 0" role="error" id="sec-test-2">sec appears to contain no content. This cannot be correct.</assert>
+      
+      <report test="count(ancestor::sec) ge 5" role="error" id="sec-test-5">Level <value-of select="count(ancestor::sec) + 1"/> sections are not allowed. Please either make this a level 5 heading, or capture the title as a bolded paragraph in its parent section.</report>
     </rule>
   </pattern>
   <pattern id="res-data-sec-pattern">
@@ -5651,7 +5653,7 @@
   </pattern>
   
   <pattern id="org-ref-article-book-title-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">	
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">	
       <let name="lc" value="lower-case(.)"/>
       
       <report test="matches($lc,'b\.\s?subtilis') and not(italic[contains(text() ,'B. subtilis')])" role="info" id="bssubtilis-ref-article-title-check">ref <value-of select="ancestor::ref/@id"/> references an organism - 'B. subtilis' - but there is no italic element with that correct capitalisation or spacing.</report>

--- a/src/pre-JATS-schematron.sch
+++ b/src/pre-JATS-schematron.sch
@@ -3134,6 +3134,8 @@
     <assert test="title" role="error" id="sec-test-1">[sec-test-1] sec must have a title</assert>
       
       <assert test="$child-count gt 0" role="error" id="sec-test-2">[sec-test-2] sec appears to contain no content. This cannot be correct.</assert>
+      
+      <report test="count(ancestor::sec) ge 5" role="error" id="sec-test-5">[sec-test-5] Level <value-of select="count(ancestor::sec) + 1"/> sections are not allowed. Please either make this a level 5 heading, or capture the title as a bolded paragraph in its parent section.</report>
     </rule>
   </pattern>
   <pattern id="res-data-sec-pattern">
@@ -5504,7 +5506,7 @@
   </pattern>
   
   <pattern id="org-ref-article-book-title-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">	
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">	
       <let name="lc" value="lower-case(.)"/>
       
       <report test="matches($lc,'b\.\s?subtilis') and not(italic[contains(text() ,'B. subtilis')])" role="info" id="bssubtilis-ref-article-title-check">[bssubtilis-ref-article-title-check] ref <value-of select="ancestor::ref/@id"/> references an organism - 'B. subtilis' - but there is no italic element with that correct capitalisation or spacing.</report>

--- a/src/schematron.sch
+++ b/src/schematron.sch
@@ -4444,6 +4444,10 @@
       <assert test="$child-count gt 0"
         role="error"
         id="sec-test-2">sec appears to contain no content. This cannot be correct.</assert>
+      
+      <report test="count(ancestor::sec) ge 5"
+        role="error"
+        id="sec-test-5">Level <value-of select="count(ancestor::sec) + 1"/> sections are not allowed. Please either make this a level 5 heading, or capture the title as a bolded paragraph in its parent section.</report>
     </rule>
     
     <rule context="article[@article-type='research-article']//sec[not(@sec-type) and not(descendant::xref[@ref-type='bibr']) and not(matches(.,'[Gg]ithub|[Gg]itlab|[Cc]ode[Pp]lex|[Ss]ource[Ff]orge|[Bb]it[Bb]ucket'))]"
@@ -7559,7 +7563,7 @@
   <pattern
     id="org-pattern">
     
-    <rule context="element-citation[@publication-type='journal']/article-title"
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title"
       id="org-ref-article-book-title">	
       <let name="lc" value="lower-case(.)"/>
       

--- a/test/tests/gen/org-ref-article-book-title/arabidopsissthaliana-ref-article-title-check/arabidopsissthaliana-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/arabidopsissthaliana-ref-article-title-check/arabidopsissthaliana-ref-article-title-check.sch
@@ -790,14 +790,14 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'arabidopsis\s?thaliana') and not(italic[contains(text() ,'Arabidopsis thaliana')])" role="info" id="arabidopsissthaliana-ref-article-title-check">ref <value-of select="ancestor::ref/@id"/> references an organism - 'Arabidopsis thaliana' - but there is no italic element with that correct capitalisation or spacing.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/arabidopsissthaliana-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/arabidopsissthaliana-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="arabidopsissthaliana-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'arabidopsis\s?thaliana') and not(italic[contains(text() ,'Arabidopsis thaliana')])
 Message: ref  references an organism - 'Arabidopsis thaliana' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/arabidopsissthaliana-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/arabidopsissthaliana-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="arabidopsissthaliana-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'arabidopsis\s?thaliana') and not(italic[contains(text() ,'Arabidopsis thaliana')])
 Message: ref  references an organism - 'Arabidopsis thaliana' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/asthaliana-ref-article-title-check/asthaliana-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/asthaliana-ref-article-title-check/asthaliana-ref-article-title-check.sch
@@ -790,14 +790,14 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'a\.\s?thaliana') and not(italic[contains(text() ,'A. thaliana')])" role="info" id="asthaliana-ref-article-title-check">ref <value-of select="ancestor::ref/@id"/> references an organism - 'A. thaliana' - but there is no italic element with that correct capitalisation or spacing.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/asthaliana-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/asthaliana-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="asthaliana-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'a\.\s?thaliana') and not(italic[contains(text() ,'A. thaliana')])
 Message: ref  references an organism - 'A. thaliana' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/asthaliana-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/asthaliana-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="asthaliana-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'a\.\s?thaliana') and not(italic[contains(text() ,'A. thaliana')])
 Message: ref  references an organism - 'A. thaliana' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/bacillusssubtilis-ref-article-title-check/bacillusssubtilis-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/bacillusssubtilis-ref-article-title-check/bacillusssubtilis-ref-article-title-check.sch
@@ -790,14 +790,14 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'bacillus\s?subtilis') and not(italic[contains(text() ,'Bacillus subtilis')])" role="info" id="bacillusssubtilis-ref-article-title-check">ref <value-of select="ancestor::ref/@id"/> references an organism - 'Bacillus subtilis' - but there is no italic element with that correct capitalisation or spacing.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/bacillusssubtilis-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/bacillusssubtilis-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="bacillusssubtilis-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'bacillus\s?subtilis') and not(italic[contains(text() ,'Bacillus subtilis')])
 Message: ref  references an organism - 'Bacillus subtilis' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/bacillusssubtilis-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/bacillusssubtilis-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="bacillusssubtilis-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'bacillus\s?subtilis') and not(italic[contains(text() ,'Bacillus subtilis')])
 Message: ref  references an organism - 'Bacillus subtilis' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/bssubtilis-ref-article-title-check/bssubtilis-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/bssubtilis-ref-article-title-check/bssubtilis-ref-article-title-check.sch
@@ -790,14 +790,14 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'b\.\s?subtilis') and not(italic[contains(text() ,'B. subtilis')])" role="info" id="bssubtilis-ref-article-title-check">ref <value-of select="ancestor::ref/@id"/> references an organism - 'B. subtilis' - but there is no italic element with that correct capitalisation or spacing.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/bssubtilis-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/bssubtilis-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="bssubtilis-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'b\.\s?subtilis') and not(italic[contains(text() ,'B. subtilis')])
 Message: ref  references an organism - 'B. subtilis' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/bssubtilis-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/bssubtilis-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="bssubtilis-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'b\.\s?subtilis') and not(italic[contains(text() ,'B. subtilis')])
 Message: ref  references an organism - 'B. subtilis' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/caenorhabditisselegans-ref-article-title-check/caenorhabditisselegans-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/caenorhabditisselegans-ref-article-title-check/caenorhabditisselegans-ref-article-title-check.sch
@@ -790,14 +790,14 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'caenorhabditis\s?elegans') and not(italic[contains(text() ,'Caenorhabditis elegans')])" role="info" id="caenorhabditisselegans-ref-article-title-check">ref <value-of select="ancestor::ref/@id"/> references an organism - 'Caenorhabditis elegans' - but there is no italic element with that correct capitalisation or spacing.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/caenorhabditisselegans-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/caenorhabditisselegans-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="caenorhabditisselegans-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'caenorhabditis\s?elegans') and not(italic[contains(text() ,'Caenorhabditis elegans')])
 Message: ref  references an organism - 'Caenorhabditis elegans' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/caenorhabditisselegans-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/caenorhabditisselegans-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="caenorhabditisselegans-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'caenorhabditis\s?elegans') and not(italic[contains(text() ,'Caenorhabditis elegans')])
 Message: ref  references an organism - 'Caenorhabditis elegans' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/chlamydiatrachomatis-ref-article-title-check/chlamydiatrachomatis-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/chlamydiatrachomatis-ref-article-title-check/chlamydiatrachomatis-ref-article-title-check.sch
@@ -790,14 +790,14 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'chlamydia\s?trachomatis') and not(italic[contains(text() ,'Chlamydia trachomatis')])" role="info" id="chlamydiatrachomatis-ref-article-title-check">ref <value-of select="ancestor::ref/@id"/> references an organism - 'Chlamydia trachomatis' - but there is no italic element with that correct capitalisation or spacing.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/chlamydiatrachomatis-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/chlamydiatrachomatis-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="chlamydiatrachomatis-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'chlamydia\s?trachomatis') and not(italic[contains(text() ,'Chlamydia trachomatis')])
 Message: ref  references an organism - 'Chlamydia trachomatis' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/chlamydiatrachomatis-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/chlamydiatrachomatis-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="chlamydiatrachomatis-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'chlamydia\s?trachomatis') and not(italic[contains(text() ,'Chlamydia trachomatis')])
 Message: ref  references an organism - 'Chlamydia trachomatis' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/chlamydomonassreinhardtii-ref-article-title-check/chlamydomonassreinhardtii-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/chlamydomonassreinhardtii-ref-article-title-check/chlamydomonassreinhardtii-ref-article-title-check.sch
@@ -790,14 +790,14 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'chlamydomonas\s?reinhardtii') and not(italic[contains(text() ,'Chlamydomonas reinhardtii')])" role="info" id="chlamydomonassreinhardtii-ref-article-title-check">ref <value-of select="ancestor::ref/@id"/> references an organism - 'Chlamydomonas reinhardtii' - but there is no italic element with that correct capitalisation or spacing.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/chlamydomonassreinhardtii-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/chlamydomonassreinhardtii-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="chlamydomonassreinhardtii-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'chlamydomonas\s?reinhardtii') and not(italic[contains(text() ,'Chlamydomonas reinhardtii')])
 Message: ref  references an organism - 'Chlamydomonas reinhardtii' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/chlamydomonassreinhardtii-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/chlamydomonassreinhardtii-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="chlamydomonassreinhardtii-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'chlamydomonas\s?reinhardtii') and not(italic[contains(text() ,'Chlamydomonas reinhardtii')])
 Message: ref  references an organism - 'Chlamydomonas reinhardtii' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/cionasintestinalis-ref-article-title-check/cionasintestinalis-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/cionasintestinalis-ref-article-title-check/cionasintestinalis-ref-article-title-check.sch
@@ -790,14 +790,14 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'ciona\s?intestinalis') and not(italic[contains(text() ,'Ciona intestinalis')])" role="info" id="cionasintestinalis-ref-article-title-check">ref <value-of select="ancestor::ref/@id"/> references an organism - 'Ciona intestinalis' - but there is no italic element with that correct capitalisation or spacing.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/cionasintestinalis-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/cionasintestinalis-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="cionasintestinalis-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'ciona\s?intestinalis') and not(italic[contains(text() ,'Ciona intestinalis')])
 Message: ref  references an organism - 'Ciona intestinalis' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/cionasintestinalis-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/cionasintestinalis-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="cionasintestinalis-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'ciona\s?intestinalis') and not(italic[contains(text() ,'Ciona intestinalis')])
 Message: ref  references an organism - 'Ciona intestinalis' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/cselegans-ref-article-title-check/cselegans-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/cselegans-ref-article-title-check/cselegans-ref-article-title-check.sch
@@ -790,14 +790,14 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'c\.\s?elegans') and not(italic[contains(text() ,'C. elegans')])" role="info" id="cselegans-ref-article-title-check">ref <value-of select="ancestor::ref/@id"/> references an organism - 'C. elegans' - but there is no italic element with that correct capitalisation or spacing.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/cselegans-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/cselegans-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="cselegans-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'c\.\s?elegans') and not(italic[contains(text() ,'C. elegans')])
 Message: ref  references an organism - 'C. elegans' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/cselegans-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/cselegans-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="cselegans-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'c\.\s?elegans') and not(italic[contains(text() ,'C. elegans')])
 Message: ref  references an organism - 'C. elegans' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/csintestinalis-ref-article-title-check/csintestinalis-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/csintestinalis-ref-article-title-check/csintestinalis-ref-article-title-check.sch
@@ -790,14 +790,14 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'c\.\s?intestinalis') and not(italic[contains(text() ,'C. intestinalis')])" role="info" id="csintestinalis-ref-article-title-check">ref <value-of select="ancestor::ref/@id"/> references an organism - 'C. intestinalis' - but there is no italic element with that correct capitalisation or spacing.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/csintestinalis-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/csintestinalis-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="csintestinalis-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'c\.\s?intestinalis') and not(italic[contains(text() ,'C. intestinalis')])
 Message: ref  references an organism - 'C. intestinalis' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/csintestinalis-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/csintestinalis-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="csintestinalis-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'c\.\s?intestinalis') and not(italic[contains(text() ,'C. intestinalis')])
 Message: ref  references an organism - 'C. intestinalis' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/csreinhardtii-ref-article-title-check/csreinhardtii-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/csreinhardtii-ref-article-title-check/csreinhardtii-ref-article-title-check.sch
@@ -790,14 +790,14 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'c\.\s?reinhardtii') and not(italic[contains(text() ,'C. reinhardtii')])" role="info" id="csreinhardtii-ref-article-title-check">ref <value-of select="ancestor::ref/@id"/> references an organism - 'C. reinhardtii' - but there is no italic element with that correct capitalisation or spacing.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/csreinhardtii-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/csreinhardtii-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="csreinhardtii-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'c\.\s?reinhardtii') and not(italic[contains(text() ,'C. reinhardtii')])
 Message: ref  references an organism - 'C. reinhardtii' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/csreinhardtii-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/csreinhardtii-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="csreinhardtii-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'c\.\s?reinhardtii') and not(italic[contains(text() ,'C. reinhardtii')])
 Message: ref  references an organism - 'C. reinhardtii' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/ctrachomatis-ref-article-title-check/ctrachomatis-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/ctrachomatis-ref-article-title-check/ctrachomatis-ref-article-title-check.sch
@@ -790,14 +790,14 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'c\.\s?trachomatis') and not(italic[contains(text() ,'C. trachomatis')])" role="info" id="ctrachomatis-ref-article-title-check">ref <value-of select="ancestor::ref/@id"/> references an organism - 'C. trachomatis' - but there is no italic element with that correct capitalisation or spacing.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/ctrachomatis-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/ctrachomatis-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="ctrachomatis-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'c\.\s?trachomatis') and not(italic[contains(text() ,'C. trachomatis')])
 Message: ref  references an organism - 'C. trachomatis' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/ctrachomatis-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/ctrachomatis-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="ctrachomatis-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'c\.\s?trachomatis') and not(italic[contains(text() ,'C. trachomatis')])
 Message: ref  references an organism - 'C. trachomatis' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/daffinis-ref-article-title-check/daffinis-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/daffinis-ref-article-title-check/daffinis-ref-article-title-check.sch
@@ -790,7 +790,7 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'d\.\s?affinis') and not(italic[contains(text() ,'D. affinis')])" role="info" id="daffinis-ref-article-title-check">
         <name/> contains an organism - 'D. affinis' - but there is no italic element with that correct capitalisation or spacing.</report>
@@ -798,7 +798,7 @@
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/daffinis-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/daffinis-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="daffinis-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'d\.\s?affinis') and not(italic[contains(text() ,'D. affinis')])
 Message:  contains an organism - 'D. affinis' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/daffinis-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/daffinis-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="daffinis-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'d\.\s?affinis') and not(italic[contains(text() ,'D. affinis')])
 Message:  contains an organism - 'D. affinis' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/daniorerio-ref-article-title-check/daniorerio-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/daniorerio-ref-article-title-check/daniorerio-ref-article-title-check.sch
@@ -790,7 +790,7 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'danio\s?rerio') and not(italic[contains(text() ,'Danio rerio')])" role="info" id="daniorerio-ref-article-title-check">
         <name/> contains an organism - 'Danio rerio' - but there is no italic element with that correct capitalisation or spacing.</report>
@@ -798,7 +798,7 @@
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/daniorerio-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/daniorerio-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="daniorerio-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'danio\s?rerio') and not(italic[contains(text() ,'Danio rerio')])
 Message:  contains an organism - 'Danio rerio' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/daniorerio-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/daniorerio-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="daniorerio-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'danio\s?rerio') and not(italic[contains(text() ,'Danio rerio')])
 Message:  contains an organism - 'Danio rerio' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/dictyostelium-ref-article-title-check/dictyostelium-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/dictyostelium-ref-article-title-check/dictyostelium-ref-article-title-check.sch
@@ -790,14 +790,14 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'dictyostelium') and not(italic[contains(text() ,'Dictyostelium')])" role="info" id="dictyostelium-ref-article-title-check">ref <value-of select="ancestor::ref/@id"/> references an organism - 'Dictyostelium' - but there is no italic element with that correct capitalisation or spacing.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/dictyostelium-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/dictyostelium-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="dictyostelium-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'dictyostelium') and not(italic[contains(text() ,'Dictyostelium')])
 Message: ref  references an organism - 'Dictyostelium' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/dictyostelium-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/dictyostelium-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="dictyostelium-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'dictyostelium') and not(italic[contains(text() ,'Dictyostelium')])
 Message: ref  references an organism - 'Dictyostelium' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/dimmigrans-ref-article-title-check/dimmigrans-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/dimmigrans-ref-article-title-check/dimmigrans-ref-article-title-check.sch
@@ -790,7 +790,7 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'d\.\s?immigrans') and not(italic[contains(text() ,'D. immigrans')])" role="info" id="dimmigrans-ref-article-title-check">
         <name/> contains an organism - 'D. immigrans' - but there is no italic element with that correct capitalisation or spacing.</report>
@@ -798,7 +798,7 @@
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/dimmigrans-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/dimmigrans-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="dimmigrans-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'d\.\s?immigrans') and not(italic[contains(text() ,'D. immigrans')])
 Message:  contains an organism - 'D. immigrans' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/dimmigrans-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/dimmigrans-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="dimmigrans-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'d\.\s?immigrans') and not(italic[contains(text() ,'D. immigrans')])
 Message:  contains an organism - 'D. immigrans' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/dobscura-ref-article-title-check/dobscura-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/dobscura-ref-article-title-check/dobscura-ref-article-title-check.sch
@@ -790,7 +790,7 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'d\.\s?obscura') and not(italic[contains(text() ,'D. obscura')])" role="info" id="dobscura-ref-article-title-check">
         <name/> contains an organism - 'D. obscura' - but there is no italic element with that correct capitalisation or spacing.</report>
@@ -798,7 +798,7 @@
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/dobscura-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/dobscura-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="dobscura-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'d\.\s?obscura') and not(italic[contains(text() ,'D. obscura')])
 Message:  contains an organism - 'D. obscura' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/dobscura-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/dobscura-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="dobscura-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'d\.\s?obscura') and not(italic[contains(text() ,'D. obscura')])
 Message:  contains an organism - 'D. obscura' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/drerio-ref-article-title-check/drerio-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/drerio-ref-article-title-check/drerio-ref-article-title-check.sch
@@ -790,7 +790,7 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'d\.\s?rerio') and not(italic[contains(text() ,'D. rerio')])" role="info" id="drerio-ref-article-title-check">
         <name/> contains an organism - 'D. rerio' - but there is no italic element with that correct capitalisation or spacing.</report>
@@ -798,7 +798,7 @@
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/drerio-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/drerio-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="drerio-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'d\.\s?rerio') and not(italic[contains(text() ,'D. rerio')])
 Message:  contains an organism - 'D. rerio' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/drerio-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/drerio-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="drerio-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'d\.\s?rerio') and not(italic[contains(text() ,'D. rerio')])
 Message:  contains an organism - 'D. rerio' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/drosophila-ref-article-title-check/drosophila-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/drosophila-ref-article-title-check/drosophila-ref-article-title-check.sch
@@ -790,14 +790,14 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'drosophila') and not(italic[contains(text(),'Drosophila')])" role="info" id="drosophila-ref-article-title-check">ref <value-of select="ancestor::ref/@id"/> references an organism - 'Drosophila' - but there is no italic element with that correct capitalisation or spacing.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/drosophila-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/drosophila-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="drosophila-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'drosophila') and not(italic[contains(text(),'Drosophila')])
 Message: ref  references an organism - 'Drosophila' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/drosophila-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/drosophila-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="drosophila-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'drosophila') and not(italic[contains(text(),'Drosophila')])
 Message: ref  references an organism - 'Drosophila' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/drosophilaaffinis-ref-article-title-check/drosophilaaffinis-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/drosophilaaffinis-ref-article-title-check/drosophilaaffinis-ref-article-title-check.sch
@@ -790,7 +790,7 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'drosophila\s?affinis') and not(italic[contains(text() ,'Drosophila affinis')])" role="info" id="drosophilaaffinis-ref-article-title-check">
         <name/> contains an organism - 'Drosophila affinis' - but there is no italic element with that correct capitalisation or spacing.</report>
@@ -798,7 +798,7 @@
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/drosophilaaffinis-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/drosophilaaffinis-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="drosophilaaffinis-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'drosophila\s?affinis') and not(italic[contains(text() ,'Drosophila affinis')])
 Message:  contains an organism - 'Drosophila affinis' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/drosophilaaffinis-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/drosophilaaffinis-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="drosophilaaffinis-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'drosophila\s?affinis') and not(italic[contains(text() ,'Drosophila affinis')])
 Message:  contains an organism - 'Drosophila affinis' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/drosophilaimmigrans-ref-article-title-check/drosophilaimmigrans-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/drosophilaimmigrans-ref-article-title-check/drosophilaimmigrans-ref-article-title-check.sch
@@ -790,7 +790,7 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'drosophila\s?immigrans') and not(italic[contains(text() ,'Drosophila immigrans')])" role="info" id="drosophilaimmigrans-ref-article-title-check">
         <name/> contains an organism - 'Drosophila immigrans' - but there is no italic element with that correct capitalisation or spacing.</report>
@@ -798,7 +798,7 @@
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/drosophilaimmigrans-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/drosophilaimmigrans-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="drosophilaimmigrans-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'drosophila\s?immigrans') and not(italic[contains(text() ,'Drosophila immigrans')])
 Message:  contains an organism - 'Drosophila immigrans' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/drosophilaimmigrans-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/drosophilaimmigrans-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="drosophilaimmigrans-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'drosophila\s?immigrans') and not(italic[contains(text() ,'Drosophila immigrans')])
 Message:  contains an organism - 'Drosophila immigrans' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/drosophilaobscura-ref-article-title-check/drosophilaobscura-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/drosophilaobscura-ref-article-title-check/drosophilaobscura-ref-article-title-check.sch
@@ -790,7 +790,7 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'drosophila\s?obscura') and not(italic[contains(text() ,'Drosophila obscura')])" role="info" id="drosophilaobscura-ref-article-title-check">
         <name/> contains an organism - 'Drosophila obscura' - but there is no italic element with that correct capitalisation or spacing.</report>
@@ -798,7 +798,7 @@
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/drosophilaobscura-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/drosophilaobscura-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="drosophilaobscura-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'drosophila\s?obscura') and not(italic[contains(text() ,'Drosophila obscura')])
 Message:  contains an organism - 'Drosophila obscura' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/drosophilaobscura-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/drosophilaobscura-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="drosophilaobscura-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'drosophila\s?obscura') and not(italic[contains(text() ,'Drosophila obscura')])
 Message:  contains an organism - 'Drosophila obscura' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/drosophilasmelanogaster-ref-article-title-check/drosophilasmelanogaster-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/drosophilasmelanogaster-ref-article-title-check/drosophilasmelanogaster-ref-article-title-check.sch
@@ -790,14 +790,14 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'drosophila\s?melanogaster') and not(italic[contains(text() ,'Drosophila melanogaster')])" role="info" id="drosophilasmelanogaster-ref-article-title-check">ref <value-of select="ancestor::ref/@id"/> references an organism - 'Drosophila melanogaster' - but there is no italic element with that correct capitalisation or spacing.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/drosophilasmelanogaster-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/drosophilasmelanogaster-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="drosophilasmelanogaster-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'drosophila\s?melanogaster') and not(italic[contains(text() ,'Drosophila melanogaster')])
 Message: ref  references an organism - 'Drosophila melanogaster' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/drosophilasmelanogaster-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/drosophilasmelanogaster-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="drosophilasmelanogaster-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'drosophila\s?melanogaster') and not(italic[contains(text() ,'Drosophila melanogaster')])
 Message: ref  references an organism - 'Drosophila melanogaster' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/drosophilasubobscura-ref-article-title-check/drosophilasubobscura-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/drosophilasubobscura-ref-article-title-check/drosophilasubobscura-ref-article-title-check.sch
@@ -790,7 +790,7 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'drosophila\s?subobscura') and not(italic[contains(text() ,'Drosophila subobscura')])" role="info" id="drosophilasubobscura-ref-article-title-check">
         <name/> contains an organism - 'Drosophila subobscura' - but there is no italic element with that correct capitalisation or spacing.</report>
@@ -798,7 +798,7 @@
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/drosophilasubobscura-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/drosophilasubobscura-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="drosophilasubobscura-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'drosophila\s?subobscura') and not(italic[contains(text() ,'Drosophila subobscura')])
 Message:  contains an organism - 'Drosophila subobscura' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/drosophilasubobscura-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/drosophilasubobscura-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="drosophilasubobscura-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'drosophila\s?subobscura') and not(italic[contains(text() ,'Drosophila subobscura')])
 Message:  contains an organism - 'Drosophila subobscura' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/dsmelanogaster-ref-article-title-check/dsmelanogaster-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/dsmelanogaster-ref-article-title-check/dsmelanogaster-ref-article-title-check.sch
@@ -790,14 +790,14 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'d\.\s?melanogaster') and not(italic[contains(text() ,'D. melanogaster')])" role="info" id="dsmelanogaster-ref-article-title-check">ref <value-of select="ancestor::ref/@id"/> references an organism - 'D. melanogaster' - but there is no italic element with that correct capitalisation or spacing.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/dsmelanogaster-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/dsmelanogaster-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="dsmelanogaster-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'d\.\s?melanogaster') and not(italic[contains(text() ,'D. melanogaster')])
 Message: ref  references an organism - 'D. melanogaster' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/dsmelanogaster-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/dsmelanogaster-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="dsmelanogaster-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'d\.\s?melanogaster') and not(italic[contains(text() ,'D. melanogaster')])
 Message: ref  references an organism - 'D. melanogaster' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/dsubobscura-ref-article-title-check/dsubobscura-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/dsubobscura-ref-article-title-check/dsubobscura-ref-article-title-check.sch
@@ -790,7 +790,7 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'d\.\s?subobscura') and not(italic[contains(text() ,'D. subobscura')])" role="info" id="dsubobscura-ref-article-title-check">
         <name/> contains an organism - 'D. subobscura' - but there is no italic element with that correct capitalisation or spacing.</report>
@@ -798,7 +798,7 @@
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/dsubobscura-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/dsubobscura-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="dsubobscura-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'d\.\s?subobscura') and not(italic[contains(text() ,'D. subobscura')])
 Message:  contains an organism - 'D. subobscura' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/dsubobscura-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/dsubobscura-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="dsubobscura-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'d\.\s?subobscura') and not(italic[contains(text() ,'D. subobscura')])
 Message:  contains an organism - 'D. subobscura' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/encephalitozoonscuniculi-ref-article-title-check/encephalitozoonscuniculi-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/encephalitozoonscuniculi-ref-article-title-check/encephalitozoonscuniculi-ref-article-title-check.sch
@@ -790,14 +790,14 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'encephalitozoon\s?cuniculi') and not(italic[contains(text() ,'Encephalitozoon cuniculi')])" role="info" id="encephalitozoonscuniculi-ref-article-title-check">ref <value-of select="ancestor::ref/@id"/> references an organism - 'Encephalitozoon cuniculi' - but there is no italic element with that correct capitalisation or spacing.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/encephalitozoonscuniculi-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/encephalitozoonscuniculi-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="encephalitozoonscuniculi-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'encephalitozoon\s?cuniculi') and not(italic[contains(text() ,'Encephalitozoon cuniculi')])
 Message: ref  references an organism - 'Encephalitozoon cuniculi' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/encephalitozoonscuniculi-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/encephalitozoonscuniculi-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="encephalitozoonscuniculi-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'encephalitozoon\s?cuniculi') and not(italic[contains(text() ,'Encephalitozoon cuniculi')])
 Message: ref  references an organism - 'Encephalitozoon cuniculi' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/enterococcussfaecalis-ref-article-title-check/enterococcussfaecalis-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/enterococcussfaecalis-ref-article-title-check/enterococcussfaecalis-ref-article-title-check.sch
@@ -790,14 +790,14 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'enterococcus\s?faecalis') and not(italic[contains(text() ,'Enterococcus faecalis')])" role="info" id="enterococcussfaecalis-ref-article-title-check">ref <value-of select="ancestor::ref/@id"/> references an organism - 'Enterococcus faecalis' - but there is no italic element with that correct capitalisation or spacing.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/enterococcussfaecalis-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/enterococcussfaecalis-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="enterococcussfaecalis-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'enterococcus\s?faecalis') and not(italic[contains(text() ,'Enterococcus faecalis')])
 Message: ref  references an organism - 'Enterococcus faecalis' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/enterococcussfaecalis-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/enterococcussfaecalis-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="enterococcussfaecalis-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'enterococcus\s?faecalis') and not(italic[contains(text() ,'Enterococcus faecalis')])
 Message: ref  references an organism - 'Enterococcus faecalis' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/erwiniascarotovora-ref-article-title-check/erwiniascarotovora-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/erwiniascarotovora-ref-article-title-check/erwiniascarotovora-ref-article-title-check.sch
@@ -790,14 +790,14 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'erwinia\s?carotovora') and not(italic[contains(text() ,'Erwinia carotovora')])" role="info" id="erwiniascarotovora-ref-article-title-check">ref <value-of select="ancestor::ref/@id"/> references an organism - 'Erwinia carotovora' - but there is no italic element with that correct capitalisation or spacing.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/erwiniascarotovora-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/erwiniascarotovora-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="erwiniascarotovora-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'erwinia\s?carotovora') and not(italic[contains(text() ,'Erwinia carotovora')])
 Message: ref  references an organism - 'Erwinia carotovora' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/erwiniascarotovora-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/erwiniascarotovora-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="erwiniascarotovora-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'erwinia\s?carotovora') and not(italic[contains(text() ,'Erwinia carotovora')])
 Message: ref  references an organism - 'Erwinia carotovora' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/escarotovora-ref-article-title-check/escarotovora-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/escarotovora-ref-article-title-check/escarotovora-ref-article-title-check.sch
@@ -790,14 +790,14 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'e\.\s?carotovora') and not(italic[contains(text() ,'E. carotovora')])" role="info" id="escarotovora-ref-article-title-check">ref <value-of select="ancestor::ref/@id"/> references an organism - 'E. carotovora' - but there is no italic element with that correct capitalisation or spacing.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/escarotovora-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/escarotovora-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="escarotovora-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'e\.\s?carotovora') and not(italic[contains(text() ,'E. carotovora')])
 Message: ref  references an organism - 'E. carotovora' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/escarotovora-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/escarotovora-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="escarotovora-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'e\.\s?carotovora') and not(italic[contains(text() ,'E. carotovora')])
 Message: ref  references an organism - 'E. carotovora' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/escherichiascoli-ref-article-title-check/escherichiascoli-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/escherichiascoli-ref-article-title-check/escherichiascoli-ref-article-title-check.sch
@@ -790,14 +790,14 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'escherichia\s?coli') and not(italic[contains(text() ,'Escherichia coli')])" role="info" id="escherichiascoli-ref-article-title-check">ref <value-of select="ancestor::ref/@id"/> references an organism - 'Escherichia coli' - but there is no italic element with that correct capitalisation or spacing.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/escherichiascoli-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/escherichiascoli-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="escherichiascoli-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'escherichia\s?coli') and not(italic[contains(text() ,'Escherichia coli')])
 Message: ref  references an organism - 'Escherichia coli' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/escherichiascoli-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/escherichiascoli-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="escherichiascoli-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'escherichia\s?coli') and not(italic[contains(text() ,'Escherichia coli')])
 Message: ref  references an organism - 'Escherichia coli' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/escoli-ref-article-title-check/escoli-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/escoli-ref-article-title-check/escoli-ref-article-title-check.sch
@@ -790,14 +790,14 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'e\.\s?coli') and not(italic[contains(text() ,'E. coli')])" role="info" id="escoli-ref-article-title-check">ref <value-of select="ancestor::ref/@id"/> references an organism - 'E. coli' - but there is no italic element with that correct capitalisation or spacing.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/escoli-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/escoli-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="escoli-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'e\.\s?coli') and not(italic[contains(text() ,'E. coli')])
 Message: ref  references an organism - 'E. coli' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/escoli-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/escoli-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="escoli-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'e\.\s?coli') and not(italic[contains(text() ,'E. coli')])
 Message: ref  references an organism - 'E. coli' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/escuniculi-ref-article-title-check/escuniculi-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/escuniculi-ref-article-title-check/escuniculi-ref-article-title-check.sch
@@ -790,14 +790,14 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'e\.\s?cuniculi') and not(italic[contains(text() ,'E. cuniculi')])" role="info" id="escuniculi-ref-article-title-check">ref <value-of select="ancestor::ref/@id"/> references an organism - 'E. cuniculi' - but there is no italic element with that correct capitalisation or spacing.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/escuniculi-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/escuniculi-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="escuniculi-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'e\.\s?cuniculi') and not(italic[contains(text() ,'E. cuniculi')])
 Message: ref  references an organism - 'E. cuniculi' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/escuniculi-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/escuniculi-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="escuniculi-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'e\.\s?cuniculi') and not(italic[contains(text() ,'E. cuniculi')])
 Message: ref  references an organism - 'E. cuniculi' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/esfaecalis-ref-article-title-check/esfaecalis-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/esfaecalis-ref-article-title-check/esfaecalis-ref-article-title-check.sch
@@ -790,14 +790,14 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'e\.\s?faecalis') and not(italic[contains(text() ,'E. faecalis')])" role="info" id="esfaecalis-ref-article-title-check">ref <value-of select="ancestor::ref/@id"/> references an organism - 'E. faecalis' - but there is no italic element with that correct capitalisation or spacing.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/esfaecalis-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/esfaecalis-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="esfaecalis-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'e\.\s?faecalis') and not(italic[contains(text() ,'E. faecalis')])
 Message: ref  references an organism - 'E. faecalis' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/esfaecalis-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/esfaecalis-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="esfaecalis-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'e\.\s?faecalis') and not(italic[contains(text() ,'E. faecalis')])
 Message: ref  references an organism - 'E. faecalis' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/francisellatularensis-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/francisellatularensis-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="francisellatularensis-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'francisella\s?tularensis') and not(italic[contains(text() ,'Francisella tularensis')])
 Message:  contains an organism - 'Francisella tularensis' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/francisellatularensis-ref-article-title-check/francisellatularensis-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/francisellatularensis-ref-article-title-check/francisellatularensis-ref-article-title-check.sch
@@ -790,7 +790,7 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'francisella\s?tularensis') and not(italic[contains(text() ,'Francisella tularensis')])" role="info" id="francisellatularensis-ref-article-title-check">
         <name/> contains an organism - 'Francisella tularensis' - but there is no italic element with that correct capitalisation or spacing.</report>
@@ -798,7 +798,7 @@
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/francisellatularensis-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/francisellatularensis-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="francisellatularensis-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'francisella\s?tularensis') and not(italic[contains(text() ,'Francisella tularensis')])
 Message:  contains an organism - 'Francisella tularensis' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/ftularensis-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/ftularensis-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="ftularensis-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'f\.\s?tularensis') and not(italic[contains(text() ,'F. tularensis')])
 Message:  contains an organism - 'F. tularensis' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/ftularensis-ref-article-title-check/ftularensis-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/ftularensis-ref-article-title-check/ftularensis-ref-article-title-check.sch
@@ -790,7 +790,7 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'f\.\s?tularensis') and not(italic[contains(text() ,'F. tularensis')])" role="info" id="ftularensis-ref-article-title-check">
         <name/> contains an organism - 'F. tularensis' - but there is no italic element with that correct capitalisation or spacing.</report>
@@ -798,7 +798,7 @@
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/ftularensis-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/ftularensis-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="ftularensis-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'f\.\s?tularensis') and not(italic[contains(text() ,'F. tularensis')])
 Message:  contains an organism - 'F. tularensis' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/halobacteriumssalinarum-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/halobacteriumssalinarum-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="halobacteriumssalinarum-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'halobacterium\s?salinarum') and not(italic[contains(text() ,'Halobacterium salinarum')])
 Message: ref  references an organism - 'Halobacterium salinarum' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/halobacteriumssalinarum-ref-article-title-check/halobacteriumssalinarum-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/halobacteriumssalinarum-ref-article-title-check/halobacteriumssalinarum-ref-article-title-check.sch
@@ -790,14 +790,14 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'halobacterium\s?salinarum') and not(italic[contains(text() ,'Halobacterium salinarum')])" role="info" id="halobacteriumssalinarum-ref-article-title-check">ref <value-of select="ancestor::ref/@id"/> references an organism - 'Halobacterium salinarum' - but there is no italic element with that correct capitalisation or spacing.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/halobacteriumssalinarum-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/halobacteriumssalinarum-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="halobacteriumssalinarum-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'halobacterium\s?salinarum') and not(italic[contains(text() ,'Halobacterium salinarum')])
 Message: ref  references an organism - 'Halobacterium salinarum' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/homosapiens-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/homosapiens-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="homosapiens-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'homo\s?sapiens') and not(italic[contains(text() ,'Homo sapiens')])
 Message: ref  references an organism - 'Homo sapiens' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/homosapiens-ref-article-title-check/homosapiens-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/homosapiens-ref-article-title-check/homosapiens-ref-article-title-check.sch
@@ -790,14 +790,14 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'homo\s?sapiens') and not(italic[contains(text() ,'Homo sapiens')])" role="info" id="homosapiens-ref-article-title-check">ref <value-of select="ancestor::ref/@id"/> references an organism - 'Homo sapiens' - but there is no italic element with that correct capitalisation or spacing.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/homosapiens-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/homosapiens-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="homosapiens-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'homo\s?sapiens') and not(italic[contains(text() ,'Homo sapiens')])
 Message: ref  references an organism - 'Homo sapiens' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/hsapiens-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/hsapiens-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="hsapiens-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'h\.\s?sapiens') and not(italic[contains(text() ,'H. sapiens')])
 Message: ref  references an organism - 'H. sapiens' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/hsapiens-ref-article-title-check/hsapiens-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/hsapiens-ref-article-title-check/hsapiens-ref-article-title-check.sch
@@ -790,14 +790,14 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'h\.\s?sapiens') and not(italic[contains(text() ,'H. sapiens')])" role="info" id="hsapiens-ref-article-title-check">ref <value-of select="ancestor::ref/@id"/> references an organism - 'H. sapiens' - but there is no italic element with that correct capitalisation or spacing.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/hsapiens-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/hsapiens-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="hsapiens-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'h\.\s?sapiens') and not(italic[contains(text() ,'H. sapiens')])
 Message: ref  references an organism - 'H. sapiens' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/hssalinarum-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/hssalinarum-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="hssalinarum-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'h\.\s?salinarum') and not(italic[contains(text() ,'H. salinarum')])
 Message: ref  references an organism - 'H. salinarum' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/hssalinarum-ref-article-title-check/hssalinarum-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/hssalinarum-ref-article-title-check/hssalinarum-ref-article-title-check.sch
@@ -790,14 +790,14 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'h\.\s?salinarum') and not(italic[contains(text() ,'H. salinarum')])" role="info" id="hssalinarum-ref-article-title-check">ref <value-of select="ancestor::ref/@id"/> references an organism - 'H. salinarum' - but there is no italic element with that correct capitalisation or spacing.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/hssalinarum-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/hssalinarum-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="hssalinarum-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'h\.\s?salinarum') and not(italic[contains(text() ,'H. salinarum')])
 Message: ref  references an organism - 'H. salinarum' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/mchilensis-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/mchilensis-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="mchilensis-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'m\.\s?chilensis') and not(italic[contains(text() ,'M. chilensis')])
 Message:  contains an organism - 'M. chilensis' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/mchilensis-ref-article-title-check/mchilensis-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/mchilensis-ref-article-title-check/mchilensis-ref-article-title-check.sch
@@ -790,7 +790,7 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'m\.\s?chilensis') and not(italic[contains(text() ,'M. chilensis')])" role="info" id="mchilensis-ref-article-title-check">
         <name/> contains an organism - 'M. chilensis' - but there is no italic element with that correct capitalisation or spacing.</report>
@@ -798,7 +798,7 @@
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/mchilensis-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/mchilensis-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="mchilensis-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'m\.\s?chilensis') and not(italic[contains(text() ,'M. chilensis')])
 Message:  contains an organism - 'M. chilensis' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/medulis-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/medulis-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="medulis-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'m\.\s?edulis') and not(italic[contains(text() ,'M. edulis')])
 Message:  contains an organism - 'M. edulis' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/medulis-ref-article-title-check/medulis-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/medulis-ref-article-title-check/medulis-ref-article-title-check.sch
@@ -790,7 +790,7 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'m\.\s?edulis') and not(italic[contains(text() ,'M. edulis')])" role="info" id="medulis-ref-article-title-check">
         <name/> contains an organism - 'M. edulis' - but there is no italic element with that correct capitalisation or spacing.</report>
@@ -798,7 +798,7 @@
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/medulis-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/medulis-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="medulis-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'m\.\s?edulis') and not(italic[contains(text() ,'M. edulis')])
 Message:  contains an organism - 'M. edulis' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/mmusculus-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/mmusculus-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="mmusculus-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'m\.\s?musculus') and not(italic[contains(text() ,'M. musculus')])
 Message:  contains an organism - 'M. musculus' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/mmusculus-ref-article-title-check/mmusculus-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/mmusculus-ref-article-title-check/mmusculus-ref-article-title-check.sch
@@ -790,7 +790,7 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'m\.\s?musculus') and not(italic[contains(text() ,'M. musculus')])" role="info" id="mmusculus-ref-article-title-check">
         <name/> contains an organism - 'M. musculus' - but there is no italic element with that correct capitalisation or spacing.</report>
@@ -798,7 +798,7 @@
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/mmusculus-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/mmusculus-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="mmusculus-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'m\.\s?musculus') and not(italic[contains(text() ,'M. musculus')])
 Message:  contains an organism - 'M. musculus' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/msthermophila-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/msthermophila-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="msthermophila-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'m\.\s?thermophila') and not(italic[contains(text() ,'M. thermophila')])
 Message: ref  references an organism - 'M. thermophila' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/msthermophila-ref-article-title-check/msthermophila-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/msthermophila-ref-article-title-check/msthermophila-ref-article-title-check.sch
@@ -790,14 +790,14 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'m\.\s?thermophila') and not(italic[contains(text() ,'M. thermophila')])" role="info" id="msthermophila-ref-article-title-check">ref <value-of select="ancestor::ref/@id"/> references an organism - 'M. thermophila' - but there is no italic element with that correct capitalisation or spacing.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/msthermophila-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/msthermophila-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="msthermophila-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'m\.\s?thermophila') and not(italic[contains(text() ,'M. thermophila')])
 Message: ref  references an organism - 'M. thermophila' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/mtrossulus-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/mtrossulus-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="mtrossulus-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'m\.\s?trossulus') and not(italic[contains(text() ,'M. trossulus')])
 Message:  contains an organism - 'M. trossulus' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/mtrossulus-ref-article-title-check/mtrossulus-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/mtrossulus-ref-article-title-check/mtrossulus-ref-article-title-check.sch
@@ -790,7 +790,7 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'m\.\s?trossulus') and not(italic[contains(text() ,'M. trossulus')])" role="info" id="mtrossulus-ref-article-title-check">
         <name/> contains an organism - 'M. trossulus' - but there is no italic element with that correct capitalisation or spacing.</report>
@@ -798,7 +798,7 @@
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/mtrossulus-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/mtrossulus-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="mtrossulus-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'m\.\s?trossulus') and not(italic[contains(text() ,'M. trossulus')])
 Message:  contains an organism - 'M. trossulus' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/musmusculus-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/musmusculus-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="musmusculus-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'mus\s?musculus') and not(italic[contains(text() ,'Mus musculus')])
 Message:  contains an organism - 'Mus musculus' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/musmusculus-ref-article-title-check/musmusculus-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/musmusculus-ref-article-title-check/musmusculus-ref-article-title-check.sch
@@ -790,7 +790,7 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'mus\s?musculus') and not(italic[contains(text() ,'Mus musculus')])" role="info" id="musmusculus-ref-article-title-check">
         <name/> contains an organism - 'Mus musculus' - but there is no italic element with that correct capitalisation or spacing.</report>
@@ -798,7 +798,7 @@
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/musmusculus-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/musmusculus-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="musmusculus-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'mus\s?musculus') and not(italic[contains(text() ,'Mus musculus')])
 Message:  contains an organism - 'Mus musculus' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/myceliophthorasthermophila-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/myceliophthorasthermophila-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="myceliophthorasthermophila-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'myceliophthora\s?thermophila') and not(italic[contains(text() ,'Myceliophthora thermophila')])
 Message: ref  references an organism - 'Myceliophthora thermophila' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/myceliophthorasthermophila-ref-article-title-check/myceliophthorasthermophila-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/myceliophthorasthermophila-ref-article-title-check/myceliophthorasthermophila-ref-article-title-check.sch
@@ -790,14 +790,14 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'myceliophthora\s?thermophila') and not(italic[contains(text() ,'Myceliophthora thermophila')])" role="info" id="myceliophthorasthermophila-ref-article-title-check">ref <value-of select="ancestor::ref/@id"/> references an organism - 'Myceliophthora thermophila' - but there is no italic element with that correct capitalisation or spacing.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/myceliophthorasthermophila-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/myceliophthorasthermophila-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="myceliophthorasthermophila-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'myceliophthora\s?thermophila') and not(italic[contains(text() ,'Myceliophthora thermophila')])
 Message: ref  references an organism - 'Myceliophthora thermophila' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/mytiluschilensis-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/mytiluschilensis-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="mytiluschilensis-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'mytilus\s?chilensis') and not(italic[contains(text() ,'Mytilus chilensis')])
 Message:  contains an organism - 'Mytilus chilensis' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/mytiluschilensis-ref-article-title-check/mytiluschilensis-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/mytiluschilensis-ref-article-title-check/mytiluschilensis-ref-article-title-check.sch
@@ -790,7 +790,7 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'mytilus\s?chilensis') and not(italic[contains(text() ,'Mytilus chilensis')])" role="info" id="mytiluschilensis-ref-article-title-check">
         <name/> contains an organism - 'Mytilus chilensis' - but there is no italic element with that correct capitalisation or spacing.</report>
@@ -798,7 +798,7 @@
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/mytiluschilensis-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/mytiluschilensis-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="mytiluschilensis-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'mytilus\s?chilensis') and not(italic[contains(text() ,'Mytilus chilensis')])
 Message:  contains an organism - 'Mytilus chilensis' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/mytilusedulis-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/mytilusedulis-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="mytilusedulis-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'mytilus\s?edulis') and not(italic[contains(text() ,'Mytilus edulis')])
 Message:  contains an organism - 'Mytilus edulis' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/mytilusedulis-ref-article-title-check/mytilusedulis-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/mytilusedulis-ref-article-title-check/mytilusedulis-ref-article-title-check.sch
@@ -790,7 +790,7 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'mytilus\s?edulis') and not(italic[contains(text() ,'Mytilus edulis')])" role="info" id="mytilusedulis-ref-article-title-check">
         <name/> contains an organism - 'Mytilus edulis' - but there is no italic element with that correct capitalisation or spacing.</report>
@@ -798,7 +798,7 @@
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/mytilusedulis-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/mytilusedulis-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="mytilusedulis-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'mytilus\s?edulis') and not(italic[contains(text() ,'Mytilus edulis')])
 Message:  contains an organism - 'Mytilus edulis' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/mytilustrossulus-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/mytilustrossulus-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="mytilustrossulus-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'mytilus\s?trossulus') and not(italic[contains(text() ,'Mytilus trossulus')])
 Message:  contains an organism - 'Mytilus trossulus' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/mytilustrossulus-ref-article-title-check/mytilustrossulus-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/mytilustrossulus-ref-article-title-check/mytilustrossulus-ref-article-title-check.sch
@@ -790,7 +790,7 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'mytilus\s?trossulus') and not(italic[contains(text() ,'Mytilus trossulus')])" role="info" id="mytilustrossulus-ref-article-title-check">
         <name/> contains an organism - 'Mytilus trossulus' - but there is no italic element with that correct capitalisation or spacing.</report>
@@ -798,7 +798,7 @@
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/mytilustrossulus-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/mytilustrossulus-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="mytilustrossulus-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'mytilus\s?trossulus') and not(italic[contains(text() ,'Mytilus trossulus')])
 Message:  contains an organism - 'Mytilus trossulus' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/nematostellasvectensis-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/nematostellasvectensis-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="nematostellasvectensis-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'nematostella\s?vectensis') and not(italic[contains(text() ,'Nematostella vectensis')])
 Message: ref  references an organism - 'Nematostella vectensis' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/nematostellasvectensis-ref-article-title-check/nematostellasvectensis-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/nematostellasvectensis-ref-article-title-check/nematostellasvectensis-ref-article-title-check.sch
@@ -790,14 +790,14 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'nematostella\s?vectensis') and not(italic[contains(text() ,'Nematostella vectensis')])" role="info" id="nematostellasvectensis-ref-article-title-check">ref <value-of select="ancestor::ref/@id"/> references an organism - 'Nematostella vectensis' - but there is no italic element with that correct capitalisation or spacing.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/nematostellasvectensis-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/nematostellasvectensis-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="nematostellasvectensis-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'nematostella\s?vectensis') and not(italic[contains(text() ,'Nematostella vectensis')])
 Message: ref  references an organism - 'Nematostella vectensis' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/neurosporascrassa-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/neurosporascrassa-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="neurosporascrassa-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'neurospora\s?crassa') and not(italic[contains(text() ,'Neurospora crassa')])
 Message: ref  references an organism - 'Neurospora crassa' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/neurosporascrassa-ref-article-title-check/neurosporascrassa-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/neurosporascrassa-ref-article-title-check/neurosporascrassa-ref-article-title-check.sch
@@ -790,14 +790,14 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'neurospora\s?crassa') and not(italic[contains(text() ,'Neurospora crassa')])" role="info" id="neurosporascrassa-ref-article-title-check">ref <value-of select="ancestor::ref/@id"/> references an organism - 'Neurospora crassa' - but there is no italic element with that correct capitalisation or spacing.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/neurosporascrassa-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/neurosporascrassa-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="neurosporascrassa-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'neurospora\s?crassa') and not(italic[contains(text() ,'Neurospora crassa')])
 Message: ref  references an organism - 'Neurospora crassa' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/nicotianasattenuata-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/nicotianasattenuata-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="nicotianasattenuata-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'nicotiana\s?attenuata') and not(italic[contains(text() ,'Nicotiana attenuata')])
 Message: ref  references an organism - 'Nicotiana attenuata' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/nicotianasattenuata-ref-article-title-check/nicotianasattenuata-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/nicotianasattenuata-ref-article-title-check/nicotianasattenuata-ref-article-title-check.sch
@@ -790,14 +790,14 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'nicotiana\s?attenuata') and not(italic[contains(text() ,'Nicotiana attenuata')])" role="info" id="nicotianasattenuata-ref-article-title-check">ref <value-of select="ancestor::ref/@id"/> references an organism - 'Nicotiana attenuata' - but there is no italic element with that correct capitalisation or spacing.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/nicotianasattenuata-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/nicotianasattenuata-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="nicotianasattenuata-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'nicotiana\s?attenuata') and not(italic[contains(text() ,'Nicotiana attenuata')])
 Message: ref  references an organism - 'Nicotiana attenuata' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/nsattenuata-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/nsattenuata-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="nsattenuata-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'n\.\s?attenuata') and not(italic[contains(text() ,'N. attenuata')])
 Message: ref  references an organism - 'N. attenuata' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/nsattenuata-ref-article-title-check/nsattenuata-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/nsattenuata-ref-article-title-check/nsattenuata-ref-article-title-check.sch
@@ -790,14 +790,14 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'n\.\s?attenuata') and not(italic[contains(text() ,'N. attenuata')])" role="info" id="nsattenuata-ref-article-title-check">ref <value-of select="ancestor::ref/@id"/> references an organism - 'N. attenuata' - but there is no italic element with that correct capitalisation or spacing.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/nsattenuata-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/nsattenuata-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="nsattenuata-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'n\.\s?attenuata') and not(italic[contains(text() ,'N. attenuata')])
 Message: ref  references an organism - 'N. attenuata' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/nscrassa-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/nscrassa-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="nscrassa-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'n\.\s?crassa') and not(italic[contains(text() ,'N. crassa')])
 Message: ref  references an organism - 'N. crassa' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/nscrassa-ref-article-title-check/nscrassa-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/nscrassa-ref-article-title-check/nscrassa-ref-article-title-check.sch
@@ -790,14 +790,14 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'n\.\s?crassa') and not(italic[contains(text() ,'N. crassa')])" role="info" id="nscrassa-ref-article-title-check">ref <value-of select="ancestor::ref/@id"/> references an organism - 'N. crassa' - but there is no italic element with that correct capitalisation or spacing.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/nscrassa-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/nscrassa-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="nscrassa-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'n\.\s?crassa') and not(italic[contains(text() ,'N. crassa')])
 Message: ref  references an organism - 'N. crassa' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/nsvectensis-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/nsvectensis-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="nsvectensis-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'n\.\s?vectensis') and not(italic[contains(text() ,'N. vectensis')])
 Message: ref  references an organism - 'N. vectensis' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/nsvectensis-ref-article-title-check/nsvectensis-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/nsvectensis-ref-article-title-check/nsvectensis-ref-article-title-check.sch
@@ -790,14 +790,14 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'n\.\s?vectensis') and not(italic[contains(text() ,'N. vectensis')])" role="info" id="nsvectensis-ref-article-title-check">ref <value-of select="ancestor::ref/@id"/> references an organism - 'N. vectensis' - but there is no italic element with that correct capitalisation or spacing.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/nsvectensis-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/nsvectensis-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="nsvectensis-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'n\.\s?vectensis') and not(italic[contains(text() ,'N. vectensis')])
 Message: ref  references an organism - 'N. vectensis' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/oncopeltussfasciatus-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/oncopeltussfasciatus-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="oncopeltussfasciatus-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'oncopeltus\s?fasciatus') and not(italic[contains(text() ,'Oncopeltus fasciatus')])
 Message: ref  references an organism - 'Oncopeltus fasciatus' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/oncopeltussfasciatus-ref-article-title-check/oncopeltussfasciatus-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/oncopeltussfasciatus-ref-article-title-check/oncopeltussfasciatus-ref-article-title-check.sch
@@ -790,14 +790,14 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'oncopeltus\s?fasciatus') and not(italic[contains(text() ,'Oncopeltus fasciatus')])" role="info" id="oncopeltussfasciatus-ref-article-title-check">ref <value-of select="ancestor::ref/@id"/> references an organism - 'Oncopeltus fasciatus' - but there is no italic element with that correct capitalisation or spacing.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/oncopeltussfasciatus-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/oncopeltussfasciatus-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="oncopeltussfasciatus-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'oncopeltus\s?fasciatus') and not(italic[contains(text() ,'Oncopeltus fasciatus')])
 Message: ref  references an organism - 'Oncopeltus fasciatus' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/osfasciatus-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/osfasciatus-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="osfasciatus-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'o\.\s?fasciatus') and not(italic[contains(text() ,'O. fasciatus')])
 Message: ref  references an organism - 'O. fasciatus' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/osfasciatus-ref-article-title-check/osfasciatus-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/osfasciatus-ref-article-title-check/osfasciatus-ref-article-title-check.sch
@@ -790,14 +790,14 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'o\.\s?fasciatus') and not(italic[contains(text() ,'O. fasciatus')])" role="info" id="osfasciatus-ref-article-title-check">ref <value-of select="ancestor::ref/@id"/> references an organism - 'O. fasciatus' - but there is no italic element with that correct capitalisation or spacing.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/osfasciatus-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/osfasciatus-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="osfasciatus-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'o\.\s?fasciatus') and not(italic[contains(text() ,'O. fasciatus')])
 Message: ref  references an organism - 'O. fasciatus' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/paeruginosa-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/paeruginosa-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="paeruginosa-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'p\.\s?aeruginosa') and not(italic[contains(text() ,'P. aeruginosa')])
 Message:  contains an organism - 'P. aeruginosa' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/paeruginosa-ref-article-title-check/paeruginosa-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/paeruginosa-ref-article-title-check/paeruginosa-ref-article-title-check.sch
@@ -790,7 +790,7 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'p\.\s?aeruginosa') and not(italic[contains(text() ,'P. aeruginosa')])" role="info" id="paeruginosa-ref-article-title-check">
         <name/> contains an organism - 'P. aeruginosa' - but there is no italic element with that correct capitalisation or spacing.</report>
@@ -798,7 +798,7 @@
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/paeruginosa-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/paeruginosa-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="paeruginosa-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'p\.\s?aeruginosa') and not(italic[contains(text() ,'P. aeruginosa')])
 Message:  contains an organism - 'P. aeruginosa' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/papioscynocephalus-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/papioscynocephalus-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="papioscynocephalus-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'papio\s?cynocephalus') and not(italic[contains(text() ,'Papio cynocephalus')])
 Message: ref  references an organism - 'Papio cynocephalus' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/papioscynocephalus-ref-article-title-check/papioscynocephalus-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/papioscynocephalus-ref-article-title-check/papioscynocephalus-ref-article-title-check.sch
@@ -790,14 +790,14 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'papio\s?cynocephalus') and not(italic[contains(text() ,'Papio cynocephalus')])" role="info" id="papioscynocephalus-ref-article-title-check">ref <value-of select="ancestor::ref/@id"/> references an organism - 'Papio cynocephalus' - but there is no italic element with that correct capitalisation or spacing.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/papioscynocephalus-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/papioscynocephalus-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="papioscynocephalus-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'papio\s?cynocephalus') and not(italic[contains(text() ,'Papio cynocephalus')])
 Message: ref  references an organism - 'Papio cynocephalus' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/pknowlesi-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/pknowlesi-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="pknowlesi-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'p\.\s?knowlesi') and not(italic[contains(text() ,'P. knowlesi')])
 Message:  contains an organism - 'P. knowlesi' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/pknowlesi-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/pknowlesi-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="pknowlesi-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'p\.\s?knowlesi') and not(italic[contains(text() ,'P. knowlesi')])
 Message:  contains an organism - 'P. knowlesi' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/pknowlesi-ref-article-title-check/pknowlesi-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/pknowlesi-ref-article-title-check/pknowlesi-ref-article-title-check.sch
@@ -790,7 +790,7 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'p\.\s?knowlesi') and not(italic[contains(text() ,'P. knowlesi')])" role="info" id="pknowlesi-ref-article-title-check">
         <name/> contains an organism - 'P. knowlesi' - but there is no italic element with that correct capitalisation or spacing.</report>
@@ -798,7 +798,7 @@
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/planceolata-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/planceolata-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="planceolata-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'p\.\s?lanceolata') and not(italic[contains(text() ,'P. lanceolata')])
 Message:  contains an organism - 'P. lanceolata' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/planceolata-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/planceolata-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="planceolata-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'p\.\s?lanceolata') and not(italic[contains(text() ,'P. lanceolata')])
 Message:  contains an organism - 'P. lanceolata' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/planceolata-ref-article-title-check/planceolata-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/planceolata-ref-article-title-check/planceolata-ref-article-title-check.sch
@@ -790,7 +790,7 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'p\.\s?lanceolata') and not(italic[contains(text() ,'P. lanceolata')])" role="info" id="planceolata-ref-article-title-check">
         <name/> contains an organism - 'P. lanceolata' - but there is no italic element with that correct capitalisation or spacing.</report>
@@ -798,7 +798,7 @@
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/plantagolanceolata-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/plantagolanceolata-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="plantagolanceolata-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'plantago\s?lanceolata') and not(italic[contains(text() ,'Plantago lanceolata')])
 Message:  contains an organism - 'Plantago lanceolata' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/plantagolanceolata-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/plantagolanceolata-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="plantagolanceolata-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'plantago\s?lanceolata') and not(italic[contains(text() ,'Plantago lanceolata')])
 Message:  contains an organism - 'Plantago lanceolata' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/plantagolanceolata-ref-article-title-check/plantagolanceolata-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/plantagolanceolata-ref-article-title-check/plantagolanceolata-ref-article-title-check.sch
@@ -790,7 +790,7 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'plantago\s?lanceolata') and not(italic[contains(text() ,'Plantago lanceolata')])" role="info" id="plantagolanceolata-ref-article-title-check">
         <name/> contains an organism - 'Plantago lanceolata' - but there is no italic element with that correct capitalisation or spacing.</report>
@@ -798,7 +798,7 @@
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/plasmodiumknowlesi-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/plasmodiumknowlesi-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="plasmodiumknowlesi-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'plasmodium\s?knowlesi') and not(italic[contains(text() ,'Plasmodium knowlesi')])
 Message:  contains an organism - 'Plasmodium knowlesi' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/plasmodiumknowlesi-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/plasmodiumknowlesi-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="plasmodiumknowlesi-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'plasmodium\s?knowlesi') and not(italic[contains(text() ,'Plasmodium knowlesi')])
 Message:  contains an organism - 'Plasmodium knowlesi' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/plasmodiumknowlesi-ref-article-title-check/plasmodiumknowlesi-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/plasmodiumknowlesi-ref-article-title-check/plasmodiumknowlesi-ref-article-title-check.sch
@@ -790,7 +790,7 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'plasmodium\s?knowlesi') and not(italic[contains(text() ,'Plasmodium knowlesi')])" role="info" id="plasmodiumknowlesi-ref-article-title-check">
         <name/> contains an organism - 'Plasmodium knowlesi' - but there is no italic element with that correct capitalisation or spacing.</report>
@@ -798,7 +798,7 @@
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/plasmodiumsfalciparum-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/plasmodiumsfalciparum-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="plasmodiumsfalciparum-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'plasmodium\s?falciparum') and not(italic[contains(text() ,'Plasmodium falciparum')])
 Message: ref  references an organism - 'Plasmodium falciparum' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/plasmodiumsfalciparum-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/plasmodiumsfalciparum-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="plasmodiumsfalciparum-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'plasmodium\s?falciparum') and not(italic[contains(text() ,'Plasmodium falciparum')])
 Message: ref  references an organism - 'Plasmodium falciparum' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/plasmodiumsfalciparum-ref-article-title-check/plasmodiumsfalciparum-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/plasmodiumsfalciparum-ref-article-title-check/plasmodiumsfalciparum-ref-article-title-check.sch
@@ -790,14 +790,14 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'plasmodium\s?falciparum') and not(italic[contains(text() ,'Plasmodium falciparum')])" role="info" id="plasmodiumsfalciparum-ref-article-title-check">ref <value-of select="ancestor::ref/@id"/> references an organism - 'Plasmodium falciparum' - but there is no italic element with that correct capitalisation or spacing.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/platynereissdumerilii-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/platynereissdumerilii-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="platynereissdumerilii-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'platynereis\s?dumerilii') and not(italic[contains(text() ,'Platynereis dumerilii')])
 Message: ref  references an organism - 'Platynereis dumerilii' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/platynereissdumerilii-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/platynereissdumerilii-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="platynereissdumerilii-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'platynereis\s?dumerilii') and not(italic[contains(text() ,'Platynereis dumerilii')])
 Message: ref  references an organism - 'Platynereis dumerilii' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/platynereissdumerilii-ref-article-title-check/platynereissdumerilii-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/platynereissdumerilii-ref-article-title-check/platynereissdumerilii-ref-article-title-check.sch
@@ -790,14 +790,14 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'platynereis\s?dumerilii') and not(italic[contains(text() ,'Platynereis dumerilii')])" role="info" id="platynereissdumerilii-ref-article-title-check">ref <value-of select="ancestor::ref/@id"/> references an organism - 'Platynereis dumerilii' - but there is no italic element with that correct capitalisation or spacing.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/podosphaeraplantaginis-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/podosphaeraplantaginis-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="podosphaeraplantaginis-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'podosphaera\s?plantaginis') and not(italic[contains(text() ,'Podosphaera plantaginis')])
 Message:  contains an organism - 'Podosphaera plantaginis' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/podosphaeraplantaginis-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/podosphaeraplantaginis-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="podosphaeraplantaginis-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'podosphaera\s?plantaginis') and not(italic[contains(text() ,'Podosphaera plantaginis')])
 Message:  contains an organism - 'Podosphaera plantaginis' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/podosphaeraplantaginis-ref-article-title-check/podosphaeraplantaginis-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/podosphaeraplantaginis-ref-article-title-check/podosphaeraplantaginis-ref-article-title-check.sch
@@ -790,7 +790,7 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'podosphaera\s?plantaginis') and not(italic[contains(text() ,'Podosphaera plantaginis')])" role="info" id="podosphaeraplantaginis-ref-article-title-check">
         <name/> contains an organism - 'Podosphaera plantaginis' - but there is no italic element with that correct capitalisation or spacing.</report>
@@ -798,7 +798,7 @@
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/pplantaginis-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/pplantaginis-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="pplantaginis-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'p\.\s?plantaginis') and not(italic[contains(text() ,'P. plantaginis')])
 Message:  contains an organism - 'P. plantaginis' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/pplantaginis-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/pplantaginis-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="pplantaginis-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'p\.\s?plantaginis') and not(italic[contains(text() ,'P. plantaginis')])
 Message:  contains an organism - 'P. plantaginis' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/pplantaginis-ref-article-title-check/pplantaginis-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/pplantaginis-ref-article-title-check/pplantaginis-ref-article-title-check.sch
@@ -790,7 +790,7 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'p\.\s?plantaginis') and not(italic[contains(text() ,'P. plantaginis')])" role="info" id="pplantaginis-ref-article-title-check">
         <name/> contains an organism - 'P. plantaginis' - but there is no italic element with that correct capitalisation or spacing.</report>
@@ -798,7 +798,7 @@
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/pscynocephalus-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/pscynocephalus-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="pscynocephalus-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'p\.\s?cynocephalus') and not(italic[contains(text() ,'P. cynocephalus')])
 Message: ref  references an organism - 'P. cynocephalus' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/pscynocephalus-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/pscynocephalus-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="pscynocephalus-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'p\.\s?cynocephalus') and not(italic[contains(text() ,'P. cynocephalus')])
 Message: ref  references an organism - 'P. cynocephalus' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/pscynocephalus-ref-article-title-check/pscynocephalus-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/pscynocephalus-ref-article-title-check/pscynocephalus-ref-article-title-check.sch
@@ -790,14 +790,14 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'p\.\s?cynocephalus') and not(italic[contains(text() ,'P. cynocephalus')])" role="info" id="pscynocephalus-ref-article-title-check">ref <value-of select="ancestor::ref/@id"/> references an organism - 'P. cynocephalus' - but there is no italic element with that correct capitalisation or spacing.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/psdumerilii-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/psdumerilii-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="psdumerilii-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'p\.\s?dumerilii') and not(italic[contains(text() ,'P. dumerilii')])
 Message: ref  references an organism - 'P. dumerilii' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/psdumerilii-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/psdumerilii-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="psdumerilii-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'p\.\s?dumerilii') and not(italic[contains(text() ,'P. dumerilii')])
 Message: ref  references an organism - 'P. dumerilii' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/psdumerilii-ref-article-title-check/psdumerilii-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/psdumerilii-ref-article-title-check/psdumerilii-ref-article-title-check.sch
@@ -790,14 +790,14 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'p\.\s?dumerilii') and not(italic[contains(text() ,'P. dumerilii')])" role="info" id="psdumerilii-ref-article-title-check">ref <value-of select="ancestor::ref/@id"/> references an organism - 'P. dumerilii' - but there is no italic element with that correct capitalisation or spacing.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/pseudomonasaeruginosa-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/pseudomonasaeruginosa-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="pseudomonasaeruginosa-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'pseudomonas\s?aeruginosa') and not(italic[contains(text() ,'Pseudomonas aeruginosa')])
 Message:  contains an organism - 'Pseudomonas aeruginosa' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/pseudomonasaeruginosa-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/pseudomonasaeruginosa-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="pseudomonasaeruginosa-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'pseudomonas\s?aeruginosa') and not(italic[contains(text() ,'Pseudomonas aeruginosa')])
 Message:  contains an organism - 'Pseudomonas aeruginosa' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/pseudomonasaeruginosa-ref-article-title-check/pseudomonasaeruginosa-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/pseudomonasaeruginosa-ref-article-title-check/pseudomonasaeruginosa-ref-article-title-check.sch
@@ -790,7 +790,7 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'pseudomonas\s?aeruginosa') and not(italic[contains(text() ,'Pseudomonas aeruginosa')])" role="info" id="pseudomonasaeruginosa-ref-article-title-check">
         <name/> contains an organism - 'Pseudomonas aeruginosa' - but there is no italic element with that correct capitalisation or spacing.</report>
@@ -798,7 +798,7 @@
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/psfalciparum-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/psfalciparum-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="psfalciparum-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'p\.\s?falciparum') and not(italic[contains(text() ,'P. falciparum')])
 Message: ref  references an organism - 'P. falciparum' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/psfalciparum-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/psfalciparum-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="psfalciparum-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'p\.\s?falciparum') and not(italic[contains(text() ,'P. falciparum')])
 Message: ref  references an organism - 'P. falciparum' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/psfalciparum-ref-article-title-check/psfalciparum-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/psfalciparum-ref-article-title-check/psfalciparum-ref-article-title-check.sch
@@ -790,14 +790,14 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'p\.\s?falciparum') and not(italic[contains(text() ,'P. falciparum')])" role="info" id="psfalciparum-ref-article-title-check">ref <value-of select="ancestor::ref/@id"/> references an organism - 'P. falciparum' - but there is no italic element with that correct capitalisation or spacing.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/saccharomycesscerevisiae-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/saccharomycesscerevisiae-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="saccharomycesscerevisiae-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'saccharomyces\s?cerevisiae') and not(italic[contains(text() ,'Saccharomyces cerevisiae')])
 Message: ref  references an organism - 'Saccharomyces cerevisiae' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/saccharomycesscerevisiae-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/saccharomycesscerevisiae-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="saccharomycesscerevisiae-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'saccharomyces\s?cerevisiae') and not(italic[contains(text() ,'Saccharomyces cerevisiae')])
 Message: ref  references an organism - 'Saccharomyces cerevisiae' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/saccharomycesscerevisiae-ref-article-title-check/saccharomycesscerevisiae-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/saccharomycesscerevisiae-ref-article-title-check/saccharomycesscerevisiae-ref-article-title-check.sch
@@ -790,14 +790,14 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'saccharomyces\s?cerevisiae') and not(italic[contains(text() ,'Saccharomyces cerevisiae')])" role="info" id="saccharomycesscerevisiae-ref-article-title-check">ref <value-of select="ancestor::ref/@id"/> references an organism - 'Saccharomyces cerevisiae' - but there is no italic element with that correct capitalisation or spacing.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/salmonellasenterica-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/salmonellasenterica-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="salmonellasenterica-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'salmonella\s?enterica') and not(italic[contains(text() ,'Salmonella enterica')])
 Message: ref  references an organism - 'Salmonella enterica' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/salmonellasenterica-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/salmonellasenterica-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="salmonellasenterica-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'salmonella\s?enterica') and not(italic[contains(text() ,'Salmonella enterica')])
 Message: ref  references an organism - 'Salmonella enterica' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/salmonellasenterica-ref-article-title-check/salmonellasenterica-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/salmonellasenterica-ref-article-title-check/salmonellasenterica-ref-article-title-check.sch
@@ -790,14 +790,14 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'salmonella\s?enterica') and not(italic[contains(text() ,'Salmonella enterica')])" role="info" id="salmonellasenterica-ref-article-title-check">ref <value-of select="ancestor::ref/@id"/> references an organism - 'Salmonella enterica' - but there is no italic element with that correct capitalisation or spacing.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/salpingoecasrosetta-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/salpingoecasrosetta-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="salpingoecasrosetta-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'salpingoeca\s?rosetta') and not(italic[contains(text() ,'Salpingoeca rosetta')])
 Message: ref  references an organism - 'Salpingoeca rosetta' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/salpingoecasrosetta-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/salpingoecasrosetta-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="salpingoecasrosetta-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'salpingoeca\s?rosetta') and not(italic[contains(text() ,'Salpingoeca rosetta')])
 Message: ref  references an organism - 'Salpingoeca rosetta' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/salpingoecasrosetta-ref-article-title-check/salpingoecasrosetta-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/salpingoecasrosetta-ref-article-title-check/salpingoecasrosetta-ref-article-title-check.sch
@@ -790,14 +790,14 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'salpingoeca\s?rosetta') and not(italic[contains(text() ,'Salpingoeca rosetta')])" role="info" id="salpingoecasrosetta-ref-article-title-check">ref <value-of select="ancestor::ref/@id"/> references an organism - 'Salpingoeca rosetta' - but there is no italic element with that correct capitalisation or spacing.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/schizosaccharomycesspombe-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/schizosaccharomycesspombe-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="schizosaccharomycesspombe-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'schizosaccharomyces\s?pombe') and not(italic[contains(text() ,'Schizosaccharomyces pombe')])
 Message: ref  references an organism - 'Schizosaccharomyces pombe' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/schizosaccharomycesspombe-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/schizosaccharomycesspombe-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="schizosaccharomycesspombe-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'schizosaccharomyces\s?pombe') and not(italic[contains(text() ,'Schizosaccharomyces pombe')])
 Message: ref  references an organism - 'Schizosaccharomyces pombe' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/schizosaccharomycesspombe-ref-article-title-check/schizosaccharomycesspombe-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/schizosaccharomycesspombe-ref-article-title-check/schizosaccharomycesspombe-ref-article-title-check.sch
@@ -790,14 +790,14 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'schizosaccharomyces\s?pombe') and not(italic[contains(text() ,'Schizosaccharomyces pombe')])" role="info" id="schizosaccharomycesspombe-ref-article-title-check">ref <value-of select="ancestor::ref/@id"/> references an organism - 'Schizosaccharomyces pombe' - but there is no italic element with that correct capitalisation or spacing.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/schmidteasmediterranea-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/schmidteasmediterranea-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="schmidteasmediterranea-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'schmidtea\s?mediterranea') and not(italic[contains(text() ,'Schmidtea mediterranea')])
 Message: ref  references an organism - 'Schmidtea mediterranea' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/schmidteasmediterranea-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/schmidteasmediterranea-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="schmidteasmediterranea-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'schmidtea\s?mediterranea') and not(italic[contains(text() ,'Schmidtea mediterranea')])
 Message: ref  references an organism - 'Schmidtea mediterranea' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/schmidteasmediterranea-ref-article-title-check/schmidteasmediterranea-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/schmidteasmediterranea-ref-article-title-check/schmidteasmediterranea-ref-article-title-check.sch
@@ -790,14 +790,14 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'schmidtea\s?mediterranea') and not(italic[contains(text() ,'Schmidtea mediterranea')])" role="info" id="schmidteasmediterranea-ref-article-title-check">ref <value-of select="ancestor::ref/@id"/> references an organism - 'Schmidtea mediterranea' - but there is no italic element with that correct capitalisation or spacing.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/ssaureus-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/ssaureus-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="ssaureus-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'s\.\s?aureus') and not(italic[contains(text() ,'S. aureus')])
 Message: ref  references an organism - 'S. aureus' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/ssaureus-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/ssaureus-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="ssaureus-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'s\.\s?aureus') and not(italic[contains(text() ,'S. aureus')])
 Message: ref  references an organism - 'S. aureus' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/ssaureus-ref-article-title-check/ssaureus-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/ssaureus-ref-article-title-check/ssaureus-ref-article-title-check.sch
@@ -790,14 +790,14 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'s\.\s?aureus') and not(italic[contains(text() ,'S. aureus')])" role="info" id="ssaureus-ref-article-title-check">ref <value-of select="ancestor::ref/@id"/> references an organism - 'S. aureus' - but there is no italic element with that correct capitalisation or spacing.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/sscerevisiae-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/sscerevisiae-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="sscerevisiae-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'s\.\s?cerevisiae') and not(italic[contains(text() ,'S. cerevisiae')])
 Message: ref  references an organism - 'S. cerevisiae' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/sscerevisiae-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/sscerevisiae-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="sscerevisiae-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'s\.\s?cerevisiae') and not(italic[contains(text() ,'S. cerevisiae')])
 Message: ref  references an organism - 'S. cerevisiae' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/sscerevisiae-ref-article-title-check/sscerevisiae-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/sscerevisiae-ref-article-title-check/sscerevisiae-ref-article-title-check.sch
@@ -790,14 +790,14 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'s\.\s?cerevisiae') and not(italic[contains(text() ,'S. cerevisiae')])" role="info" id="sscerevisiae-ref-article-title-check">ref <value-of select="ancestor::ref/@id"/> references an organism - 'S. cerevisiae' - but there is no italic element with that correct capitalisation or spacing.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/ssenterica-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/ssenterica-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="ssenterica-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'s\.\s?enterica') and not(italic[contains(text() ,'S. enterica')])
 Message: ref  references an organism - 'S. enterica' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/ssenterica-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/ssenterica-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="ssenterica-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'s\.\s?enterica') and not(italic[contains(text() ,'S. enterica')])
 Message: ref  references an organism - 'S. enterica' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/ssenterica-ref-article-title-check/ssenterica-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/ssenterica-ref-article-title-check/ssenterica-ref-article-title-check.sch
@@ -790,14 +790,14 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'s\.\s?enterica') and not(italic[contains(text() ,'S. enterica')])" role="info" id="ssenterica-ref-article-title-check">ref <value-of select="ancestor::ref/@id"/> references an organism - 'S. enterica' - but there is no italic element with that correct capitalisation or spacing.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/ssmediterranea-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/ssmediterranea-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="ssmediterranea-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'s\.\s?mediterranea') and not(italic[contains(text() ,'S. mediterranea')])
 Message: ref  references an organism - 'S. mediterranea' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/ssmediterranea-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/ssmediterranea-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="ssmediterranea-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'s\.\s?mediterranea') and not(italic[contains(text() ,'S. mediterranea')])
 Message: ref  references an organism - 'S. mediterranea' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/ssmediterranea-ref-article-title-check/ssmediterranea-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/ssmediterranea-ref-article-title-check/ssmediterranea-ref-article-title-check.sch
@@ -790,14 +790,14 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'s\.\s?mediterranea') and not(italic[contains(text() ,'S. mediterranea')])" role="info" id="ssmediterranea-ref-article-title-check">ref <value-of select="ancestor::ref/@id"/> references an organism - 'S. mediterranea' - but there is no italic element with that correct capitalisation or spacing.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/sspombe-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/sspombe-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="sspombe-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'s\.\s?pombe') and not(italic[contains(text() ,'S. pombe')])
 Message: ref  references an organism - 'S. pombe' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/sspombe-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/sspombe-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="sspombe-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'s\.\s?pombe') and not(italic[contains(text() ,'S. pombe')])
 Message: ref  references an organism - 'S. pombe' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/sspombe-ref-article-title-check/sspombe-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/sspombe-ref-article-title-check/sspombe-ref-article-title-check.sch
@@ -790,14 +790,14 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'s\.\s?pombe') and not(italic[contains(text() ,'S. pombe')])" role="info" id="sspombe-ref-article-title-check">ref <value-of select="ancestor::ref/@id"/> references an organism - 'S. pombe' - but there is no italic element with that correct capitalisation or spacing.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/sspyogenes-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/sspyogenes-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="sspyogenes-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'s\.\s?pyogenes') and not(italic[contains(text() ,'S. pyogenes')])
 Message: ref  references an organism - 'S. pyogenes' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/sspyogenes-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/sspyogenes-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="sspyogenes-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'s\.\s?pyogenes') and not(italic[contains(text() ,'S. pyogenes')])
 Message: ref  references an organism - 'S. pyogenes' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/sspyogenes-ref-article-title-check/sspyogenes-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/sspyogenes-ref-article-title-check/sspyogenes-ref-article-title-check.sch
@@ -790,14 +790,14 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'s\.\s?pyogenes') and not(italic[contains(text() ,'S. pyogenes')])" role="info" id="sspyogenes-ref-article-title-check">ref <value-of select="ancestor::ref/@id"/> references an organism - 'S. pyogenes' - but there is no italic element with that correct capitalisation or spacing.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/ssrosetta-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/ssrosetta-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="ssrosetta-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'s\.\s?rosetta') and not(italic[contains(text() ,'S. rosetta')])
 Message: ref  references an organism - 'S. rosetta' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/ssrosetta-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/ssrosetta-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="ssrosetta-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'s\.\s?rosetta') and not(italic[contains(text() ,'S. rosetta')])
 Message: ref  references an organism - 'S. rosetta' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/ssrosetta-ref-article-title-check/ssrosetta-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/ssrosetta-ref-article-title-check/ssrosetta-ref-article-title-check.sch
@@ -790,14 +790,14 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'s\.\s?rosetta') and not(italic[contains(text() ,'S. rosetta')])" role="info" id="ssrosetta-ref-article-title-check">ref <value-of select="ancestor::ref/@id"/> references an organism - 'S. rosetta' - but there is no italic element with that correct capitalisation or spacing.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/sssolfataricus-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/sssolfataricus-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="sssolfataricus-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'s\.\s?solfataricus') and not(italic[contains(text() ,'S. solfataricus')])
 Message: ref  references an organism - 'S. solfataricus' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/sssolfataricus-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/sssolfataricus-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="sssolfataricus-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'s\.\s?solfataricus') and not(italic[contains(text() ,'S. solfataricus')])
 Message: ref  references an organism - 'S. solfataricus' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/sssolfataricus-ref-article-title-check/sssolfataricus-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/sssolfataricus-ref-article-title-check/sssolfataricus-ref-article-title-check.sch
@@ -790,14 +790,14 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'s\.\s?solfataricus') and not(italic[contains(text() ,'S. solfataricus')])" role="info" id="sssolfataricus-ref-article-title-check">ref <value-of select="ancestor::ref/@id"/> references an organism - 'S. solfataricus' - but there is no italic element with that correct capitalisation or spacing.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/staphylococcussaureus-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/staphylococcussaureus-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="staphylococcussaureus-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'staphylococcus\s?aureus') and not(italic[contains(text() ,'Staphylococcus aureus')])
 Message: ref  references an organism - 'Staphylococcus aureus' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/staphylococcussaureus-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/staphylococcussaureus-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="staphylococcussaureus-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'staphylococcus\s?aureus') and not(italic[contains(text() ,'Staphylococcus aureus')])
 Message: ref  references an organism - 'Staphylococcus aureus' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/staphylococcussaureus-ref-article-title-check/staphylococcussaureus-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/staphylococcussaureus-ref-article-title-check/staphylococcussaureus-ref-article-title-check.sch
@@ -790,14 +790,14 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'staphylococcus\s?aureus') and not(italic[contains(text() ,'Staphylococcus aureus')])" role="info" id="staphylococcussaureus-ref-article-title-check">ref <value-of select="ancestor::ref/@id"/> references an organism - 'Staphylococcus aureus' - but there is no italic element with that correct capitalisation or spacing.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/streptococcusspyogenes-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/streptococcusspyogenes-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="streptococcusspyogenes-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'streptococcus\s?pyogenes') and not(italic[contains(text() ,'Streptococcus pyogenes')])
 Message: ref  references an organism - 'Streptococcus pyogenes' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/streptococcusspyogenes-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/streptococcusspyogenes-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="streptococcusspyogenes-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'streptococcus\s?pyogenes') and not(italic[contains(text() ,'Streptococcus pyogenes')])
 Message: ref  references an organism - 'Streptococcus pyogenes' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/streptococcusspyogenes-ref-article-title-check/streptococcusspyogenes-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/streptococcusspyogenes-ref-article-title-check/streptococcusspyogenes-ref-article-title-check.sch
@@ -790,14 +790,14 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'streptococcus\s?pyogenes') and not(italic[contains(text() ,'Streptococcus pyogenes')])" role="info" id="streptococcusspyogenes-ref-article-title-check">ref <value-of select="ancestor::ref/@id"/> references an organism - 'Streptococcus pyogenes' - but there is no italic element with that correct capitalisation or spacing.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/sulfolobusssolfataricus-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/sulfolobusssolfataricus-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="sulfolobusssolfataricus-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'sulfolobus\s?solfataricus') and not(italic[contains(text() ,'Sulfolobus solfataricus')])
 Message: ref  references an organism - 'Sulfolobus solfataricus' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/sulfolobusssolfataricus-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/sulfolobusssolfataricus-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="sulfolobusssolfataricus-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'sulfolobus\s?solfataricus') and not(italic[contains(text() ,'Sulfolobus solfataricus')])
 Message: ref  references an organism - 'Sulfolobus solfataricus' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/sulfolobusssolfataricus-ref-article-title-check/sulfolobusssolfataricus-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/sulfolobusssolfataricus-ref-article-title-check/sulfolobusssolfataricus-ref-article-title-check.sch
@@ -790,14 +790,14 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'sulfolobus\s?solfataricus') and not(italic[contains(text() ,'Sulfolobus solfataricus')])" role="info" id="sulfolobusssolfataricus-ref-article-title-check">ref <value-of select="ancestor::ref/@id"/> references an organism - 'Sulfolobus solfataricus' - but there is no italic element with that correct capitalisation or spacing.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/tbrucei-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/tbrucei-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="tbrucei-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'t\.\s?brucei') and not(italic[contains(text() ,'T. brucei')])
 Message:  contains an organism - 'T. brucei' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">

--- a/test/tests/gen/org-ref-article-book-title/tbrucei-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/tbrucei-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="tbrucei-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'t\.\s?brucei') and not(italic[contains(text() ,'T. brucei')])
 Message:  contains an organism - 'T. brucei' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">

--- a/test/tests/gen/org-ref-article-book-title/tbrucei-ref-article-title-check/tbrucei-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/tbrucei-ref-article-title-check/tbrucei-ref-article-title-check.sch
@@ -790,7 +790,7 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'t\.\s?brucei') and not(italic[contains(text() ,'T. brucei')])" role="info" id="tbrucei-ref-article-title-check">
         <name/> contains an organism - 'T. brucei' - but there is no italic element with that correct capitalisation or spacing.</report>
@@ -798,7 +798,7 @@
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/tetrahymenasthermophila-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/tetrahymenasthermophila-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="tetrahymenasthermophila-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'tetrahymena\s?thermophila') and not(italic[contains(text() ,'Tetrahymena thermophila')])
 Message: ref  references an organism - 'Tetrahymena thermophila' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/tetrahymenasthermophila-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/tetrahymenasthermophila-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="tetrahymenasthermophila-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'tetrahymena\s?thermophila') and not(italic[contains(text() ,'Tetrahymena thermophila')])
 Message: ref  references an organism - 'Tetrahymena thermophila' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/tetrahymenasthermophila-ref-article-title-check/tetrahymenasthermophila-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/tetrahymenasthermophila-ref-article-title-check/tetrahymenasthermophila-ref-article-title-check.sch
@@ -790,14 +790,14 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'tetrahymena\s?thermophila') and not(italic[contains(text() ,'Tetrahymena thermophila')])" role="info" id="tetrahymenasthermophila-ref-article-title-check">ref <value-of select="ancestor::ref/@id"/> references an organism - 'Tetrahymena thermophila' - but there is no italic element with that correct capitalisation or spacing.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/trypanosomabrucei-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/trypanosomabrucei-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="trypanosomabrucei-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'trypanosoma\s?brucei') and not(italic[contains(text() ,'Trypanosoma brucei')])
 Message:  contains an organism - 'Trypanosoma brucei' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">

--- a/test/tests/gen/org-ref-article-book-title/trypanosomabrucei-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/trypanosomabrucei-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="trypanosomabrucei-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'trypanosoma\s?brucei') and not(italic[contains(text() ,'Trypanosoma brucei')])
 Message:  contains an organism - 'Trypanosoma brucei' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">

--- a/test/tests/gen/org-ref-article-book-title/trypanosomabrucei-ref-article-title-check/trypanosomabrucei-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/trypanosomabrucei-ref-article-title-check/trypanosomabrucei-ref-article-title-check.sch
@@ -790,7 +790,7 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'trypanosoma\s?brucei') and not(italic[contains(text() ,'Trypanosoma brucei')])" role="info" id="trypanosomabrucei-ref-article-title-check">
         <name/> contains an organism - 'Trypanosoma brucei' - but there is no italic element with that correct capitalisation or spacing.</report>
@@ -798,7 +798,7 @@
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/tsthermophila-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/tsthermophila-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="tsthermophila-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'t\.\s?thermophila') and not(italic[contains(text() ,'T. thermophila')])
 Message: ref  references an organism - 'T. thermophila' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/tsthermophila-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/tsthermophila-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="tsthermophila-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'t\.\s?thermophila') and not(italic[contains(text() ,'T. thermophila')])
 Message: ref  references an organism - 'T. thermophila' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/tsthermophila-ref-article-title-check/tsthermophila-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/tsthermophila-ref-article-title-check/tsthermophila-ref-article-title-check.sch
@@ -790,14 +790,14 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'t\.\s?thermophila') and not(italic[contains(text() ,'T. thermophila')])" role="info" id="tsthermophila-ref-article-title-check">ref <value-of select="ancestor::ref/@id"/> references an organism - 'T. thermophila' - but there is no italic element with that correct capitalisation or spacing.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/umaydis-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/umaydis-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="umaydis-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'u\.\s?maydis') and not(italic[contains(text() ,'U. maydis')])
 Message:  contains an organism - 'U. maydis' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/umaydis-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/umaydis-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="umaydis-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'u\.\s?maydis') and not(italic[contains(text() ,'U. maydis')])
 Message:  contains an organism - 'U. maydis' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/umaydis-ref-article-title-check/umaydis-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/umaydis-ref-article-title-check/umaydis-ref-article-title-check.sch
@@ -790,7 +790,7 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'u\.\s?maydis') and not(italic[contains(text() ,'U. maydis')])" role="info" id="umaydis-ref-article-title-check">
         <name/> contains an organism - 'U. maydis' - but there is no italic element with that correct capitalisation or spacing.</report>
@@ -798,7 +798,7 @@
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/ustilagomaydis-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/ustilagomaydis-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="ustilagomaydis-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'ustilago\s?maydis') and not(italic[contains(text() ,'Ustilago maydis')])
 Message:  contains an organism - 'Ustilago maydis' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/ustilagomaydis-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/ustilagomaydis-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="ustilagomaydis-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'ustilago\s?maydis') and not(italic[contains(text() ,'Ustilago maydis')])
 Message:  contains an organism - 'Ustilago maydis' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/ustilagomaydis-ref-article-title-check/ustilagomaydis-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/ustilagomaydis-ref-article-title-check/ustilagomaydis-ref-article-title-check.sch
@@ -790,7 +790,7 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'ustilago\s?maydis') and not(italic[contains(text() ,'Ustilago maydis')])" role="info" id="ustilagomaydis-ref-article-title-check">
         <name/> contains an organism - 'Ustilago maydis' - but there is no italic element with that correct capitalisation or spacing.</report>
@@ -798,7 +798,7 @@
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/vibrioscholerae-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/vibrioscholerae-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="vibrioscholerae-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'vibrio\s?cholerae') and not(italic[contains(text() ,'Vibrio cholerae')])
 Message: ref  references an organism - 'Vibrio cholerae' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/vibrioscholerae-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/vibrioscholerae-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="vibrioscholerae-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'vibrio\s?cholerae') and not(italic[contains(text() ,'Vibrio cholerae')])
 Message: ref  references an organism - 'Vibrio cholerae' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/vibrioscholerae-ref-article-title-check/vibrioscholerae-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/vibrioscholerae-ref-article-title-check/vibrioscholerae-ref-article-title-check.sch
@@ -790,14 +790,14 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'vibrio\s?cholerae') and not(italic[contains(text() ,'Vibrio cholerae')])" role="info" id="vibrioscholerae-ref-article-title-check">ref <value-of select="ancestor::ref/@id"/> references an organism - 'Vibrio cholerae' - but there is no italic element with that correct capitalisation or spacing.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/vscholerae-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/vscholerae-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="vscholerae-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'v\.\s?cholerae') and not(italic[contains(text() ,'V. cholerae')])
 Message: ref  references an organism - 'V. cholerae' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/vscholerae-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/vscholerae-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="vscholerae-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'v\.\s?cholerae') and not(italic[contains(text() ,'V. cholerae')])
 Message: ref  references an organism - 'V. cholerae' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/vscholerae-ref-article-title-check/vscholerae-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/vscholerae-ref-article-title-check/vscholerae-ref-article-title-check.sch
@@ -790,14 +790,14 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'v\.\s?cholerae') and not(italic[contains(text() ,'V. cholerae')])" role="info" id="vscholerae-ref-article-title-check">ref <value-of select="ancestor::ref/@id"/> references an organism - 'V. cholerae' - but there is no italic element with that correct capitalisation or spacing.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/xenopus-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/xenopus-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="xenopus-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'xenopus') and not(italic[contains(text() ,'Xenopus')])
 Message: ref  references an organism - 'Xenopus' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/xenopus-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/xenopus-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="xenopus-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'xenopus') and not(italic[contains(text() ,'Xenopus')])
 Message: ref  references an organism - 'Xenopus' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/xenopus-ref-article-title-check/xenopus-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/xenopus-ref-article-title-check/xenopus-ref-article-title-check.sch
@@ -790,14 +790,14 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'xenopus') and not(italic[contains(text() ,'Xenopus')])" role="info" id="xenopus-ref-article-title-check">ref <value-of select="ancestor::ref/@id"/> references an organism - 'Xenopus' - but there is no italic element with that correct capitalisation or spacing.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/xenopuslaevis-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/xenopuslaevis-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="xenopuslaevis-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'xenopus\s?laevis') and not(italic[contains(text() ,'Xenopus laevis')])
 Message:  contains an organism - 'Xenopus laevis' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/xenopuslaevis-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/xenopuslaevis-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="xenopuslaevis-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'xenopus\s?laevis') and not(italic[contains(text() ,'Xenopus laevis')])
 Message:  contains an organism - 'Xenopus laevis' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/xenopuslaevis-ref-article-title-check/xenopuslaevis-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/xenopuslaevis-ref-article-title-check/xenopuslaevis-ref-article-title-check.sch
@@ -790,7 +790,7 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'xenopus\s?laevis') and not(italic[contains(text() ,'Xenopus laevis')])" role="info" id="xenopuslaevis-ref-article-title-check">
         <name/> contains an organism - 'Xenopus laevis' - but there is no italic element with that correct capitalisation or spacing.</report>
@@ -798,7 +798,7 @@
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/xenopustropicalis-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/xenopustropicalis-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="xenopustropicalis-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'xenopus\s?tropicalis') and not(italic[contains(text() ,'Xenopus tropicalis')])
 Message:  contains an organism - 'Xenopus tropicalis' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/xenopustropicalis-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/xenopustropicalis-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="xenopustropicalis-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'xenopus\s?tropicalis') and not(italic[contains(text() ,'Xenopus tropicalis')])
 Message:  contains an organism - 'Xenopus tropicalis' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/xenopustropicalis-ref-article-title-check/xenopustropicalis-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/xenopustropicalis-ref-article-title-check/xenopustropicalis-ref-article-title-check.sch
@@ -790,7 +790,7 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'xenopus\s?tropicalis') and not(italic[contains(text() ,'Xenopus tropicalis')])" role="info" id="xenopustropicalis-ref-article-title-check">
         <name/> contains an organism - 'Xenopus tropicalis' - but there is no italic element with that correct capitalisation or spacing.</report>
@@ -798,7 +798,7 @@
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/xlaevis-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/xlaevis-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="xlaevis-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'x\.\s?laevis') and not(italic[contains(text() ,'X. laevis')])
 Message:  contains an organism - 'X. laevis' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/xlaevis-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/xlaevis-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="xlaevis-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'x\.\s?laevis') and not(italic[contains(text() ,'X. laevis')])
 Message:  contains an organism - 'X. laevis' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/xlaevis-ref-article-title-check/xlaevis-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/xlaevis-ref-article-title-check/xlaevis-ref-article-title-check.sch
@@ -790,7 +790,7 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'x\.\s?laevis') and not(italic[contains(text() ,'X. laevis')])" role="info" id="xlaevis-ref-article-title-check">
         <name/> contains an organism - 'X. laevis' - but there is no italic element with that correct capitalisation or spacing.</report>
@@ -798,7 +798,7 @@
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/org-ref-article-book-title/xtropicalis-ref-article-title-check/fail.xml
+++ b/test/tests/gen/org-ref-article-book-title/xtropicalis-ref-article-title-check/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="xtropicalis-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'x\.\s?tropicalis') and not(italic[contains(text() ,'X. tropicalis')])
 Message:  contains an organism - 'X. tropicalis' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/xtropicalis-ref-article-title-check/pass.xml
+++ b/test/tests/gen/org-ref-article-book-title/xtropicalis-ref-article-title-check/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="xtropicalis-ref-article-title-check.sch"?>
-<!--Context: element-citation[@publication-type='journal']/article-title
+<!--Context: element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title
 Test: report    matches($lc,'x\.\s?tropicalis') and not(italic[contains(text() ,'X. tropicalis')])
 Message:  contains an organism - 'X. tropicalis' - but there is no italic element with that correct capitalisation or spacing. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/gen/org-ref-article-book-title/xtropicalis-ref-article-title-check/xtropicalis-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/xtropicalis-ref-article-title-check/xtropicalis-ref-article-title-check.sch
@@ -790,7 +790,7 @@
     
   </xsl:function>
   <pattern id="org-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">
       <let name="lc" value="lower-case(.)"/>
       <report test="matches($lc,'x\.\s?tropicalis') and not(italic[contains(text() ,'X. tropicalis')])" role="info" id="xtropicalis-ref-article-title-check">
         <name/> contains an organism - 'X. tropicalis' - but there is no italic element with that correct capitalisation or spacing.</report>
@@ -798,7 +798,7 @@
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/sec-tests/sec-test-5/fail.xml
+++ b/test/tests/gen/sec-tests/sec-test-5/fail.xml
@@ -1,0 +1,104 @@
+<?oxygen SCHSchema="sec-test-5.sch"?>
+<!--Context: sec
+Test: report    count(ancestor::sec) ge 5
+Message: Level  sections are not allowed. Please either make this a level 5 heading, or capture the title as a bolded paragraph in its parent section. -->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <sec id="s1-1">
+      <title>Test 1</title>
+      <p>In this study, we reveal that two variants of COQ-2, derived from alternative splicing of
+        mutually exclusive exons, are the key for the choice to synthesize RQ or UQ. We find that
+        one of the mutually exclusive exons is only found in the genomes of animals that synthesize
+        RQ and that its inclusion remodels the core of the COQ-2 enzyme. We show that the removal
+        of&#x00A0;this exon abolishes almost all RQ biosynthesis in <italic>C. elegans</italic>.
+        Finally, we find that inclusion of this RQ-specific exon expression is increased in the
+        stages of the parasite&#x00A0;life cycle where they encounter hypoxic conditions and
+        increase RQ production, while the alternative exon is increased in normoxic life stages. We
+        thus conclude that alternative splicing of COQ-2 is the key mechanism that causes the switch
+        from UQ to RQ synthesis in the parasite life&#x00A0;cycle.</p>
+      <sec id="s1-1-1">
+        <title>Test 2</title>
+        <p>In this study, we reveal that two variants of COQ-2, derived from alternative splicing of
+          mutually exclusive exons, are the key for the choice to synthesize RQ or UQ. We find that
+          one of the mutually exclusive exons is only found in the genomes of animals that
+          synthesize RQ and that its inclusion remodels the core of the COQ-2 enzyme. We show that
+          the removal of&#x00A0;this exon abolishes almost all RQ biosynthesis in <italic>C.
+            elegans</italic>. Finally, we find that inclusion of this RQ-specific exon expression is
+          increased in the stages of the parasite&#x00A0;life cycle where they encounter hypoxic
+          conditions and increase RQ production, while the alternative exon is increased in normoxic
+          life stages. We thus conclude that alternative splicing of COQ-2 is the key mechanism that
+          causes the switch from UQ to RQ synthesis in the parasite life&#x00A0;cycle.</p>
+        <sec id="s1-1-1-1">
+          <title>Test 3</title>
+          <p>In this study, we reveal that two variants of COQ-2, derived from alternative splicing
+            of mutually exclusive exons, are the key for the choice to synthesize RQ or UQ. We find
+            that one of the mutually exclusive exons is only found in the genomes of animals that
+            synthesize RQ and that its inclusion remodels the core of the COQ-2 enzyme. We show that
+            the removal of&#x00A0;this exon abolishes almost all RQ biosynthesis in <italic>C.
+              elegans</italic>. Finally, we find that inclusion of this RQ-specific exon expression
+            is increased in the stages of the parasite&#x00A0;life cycle where they encounter
+            hypoxic conditions and increase RQ production, while the alternative exon is increased
+            in normoxic life stages. We thus conclude that alternative splicing of COQ-2 is the key
+            mechanism that causes the switch from UQ to RQ synthesis in the parasite
+            life&#x00A0;cycle.</p>
+          <sec id="s1-1-1-1-1">
+            <title>Test 4</title>
+            <p>In this study, we reveal that two variants of COQ-2, derived from alternative
+              splicing of mutually exclusive exons, are the key for the choice to synthesize RQ or
+              UQ. We find that one of the mutually exclusive exons is only found in the genomes of
+              animals that synthesize RQ and that its inclusion remodels the core of the COQ-2
+              enzyme. We show that the removal of&#x00A0;this exon abolishes almost all RQ
+              biosynthesis in <italic>C. elegans</italic>. Finally, we find that inclusion of this
+              RQ-specific exon expression is increased in the stages of the parasite&#x00A0;life
+              cycle where they encounter hypoxic conditions and increase RQ production, while the
+              alternative exon is increased in normoxic life stages. We thus conclude that
+              alternative splicing of COQ-2 is the key mechanism that causes the switch from UQ to
+              RQ synthesis in the parasite life&#x00A0;cycle.</p>
+            <sec id="s1-1-1-1-1-1">
+              <title>Test 5</title>
+              <p>In this study, we reveal that two variants of COQ-2, derived from alternative
+                splicing of mutually exclusive exons, are the key for the choice to synthesize RQ or
+                UQ. We find that one of the mutually exclusive exons is only found in the genomes of
+                animals that synthesize RQ and that its inclusion remodels the core of the COQ-2
+                enzyme. We show that the removal of&#x00A0;this exon abolishes almost all RQ
+                biosynthesis in <italic>C. elegans</italic>. Finally, we find that inclusion of this
+                RQ-specific exon expression is increased in the stages of the parasite&#x00A0;life
+                cycle where they encounter hypoxic conditions and increase RQ production, while the
+                alternative exon is increased in normoxic life stages. We thus conclude that
+                alternative splicing of COQ-2 is the key mechanism that causes the switch from UQ to
+                RQ synthesis in the parasite life&#x00A0;cycle.</p>
+              <sec id="s1-1-1-1-1-1-1">
+                <title>Test 6</title>
+                <p>In this study, we reveal that two variants of COQ-2, derived from alternative
+                  splicing of mutually exclusive exons, are the key for the choice to synthesize RQ
+                  or UQ. We find that one of the mutually exclusive exons is only found in the
+                  genomes of animals that synthesize RQ and that its inclusion remodels the core of
+                  the COQ-2 enzyme. We show that the removal of&#x00A0;this exon abolishes almost
+                  all RQ biosynthesis in <italic>C. elegans</italic>. Finally, we find that
+                  inclusion of this RQ-specific exon expression is increased in the stages of the
+                  parasite&#x00A0;life cycle where they encounter hypoxic conditions and increase RQ
+                  production, while the alternative exon is increased in normoxic life stages. We
+                  thus conclude that alternative splicing of COQ-2 is the key mechanism that causes
+                  the switch from UQ to RQ synthesis in the parasite life&#x00A0;cycle.</p>
+                <sec id="s1-1-1-1-1-1-1-1">
+                  <title>Test 7</title>
+                  <p>In this study, we reveal that two variants of COQ-2, derived from alternative
+                    splicing of mutually exclusive exons, are the key for the choice to synthesize
+                    RQ or UQ. We find that one of the mutually exclusive exons is only found in the
+                    genomes of animals that synthesize RQ and that its inclusion remodels the core
+                    of the COQ-2 enzyme. We show that the removal of&#x00A0;this exon abolishes
+                    almost all RQ biosynthesis in <italic>C. elegans</italic>. Finally, we find that
+                    inclusion of this RQ-specific exon expression is increased in the stages of the
+                    parasite&#x00A0;life cycle where they encounter hypoxic conditions and increase
+                    RQ production, while the alternative exon is increased in normoxic life stages.
+                    We thus conclude that alternative splicing of COQ-2 is the key mechanism that
+                    causes the switch from UQ to RQ synthesis in the parasite life&#x00A0;cycle.</p>
+                </sec>
+              </sec>
+            </sec>
+          </sec>
+        </sec>
+      </sec>
+    </sec>
+  </article>
+</root>

--- a/test/tests/gen/sec-tests/sec-test-5/pass.xml
+++ b/test/tests/gen/sec-tests/sec-test-5/pass.xml
@@ -1,0 +1,77 @@
+<?oxygen SCHSchema="sec-test-5.sch"?>
+<!--Context: sec
+Test: report    count(ancestor::sec) ge 5
+Message: Level  sections are not allowed. Please either make this a level 5 heading, or capture the title as a bolded paragraph in its parent section. -->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML"
+  xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <sec id="s1-1">
+      <title>Test 1</title>
+      <p>In this study, we reveal that two variants of COQ-2, derived from alternative splicing of
+        mutually exclusive exons, are the key for the choice to synthesize RQ or UQ. We find that
+        one of the mutually exclusive exons is only found in the genomes of animals that synthesize
+        RQ and that its inclusion remodels the core of the COQ-2 enzyme. We show that the removal
+        of&#x00A0;this exon abolishes almost all RQ biosynthesis in <italic>C. elegans</italic>.
+        Finally, we find that inclusion of this RQ-specific exon expression is increased in the
+        stages of the parasite&#x00A0;life cycle where they encounter hypoxic conditions and
+        increase RQ production, while the alternative exon is increased in normoxic life stages. We
+        thus conclude that alternative splicing of COQ-2 is the key mechanism that causes the switch
+        from UQ to RQ synthesis in the parasite life&#x00A0;cycle.</p>
+      <sec id="s1-1-1">
+        <title>Test 2</title>
+        <p>In this study, we reveal that two variants of COQ-2, derived from alternative splicing of
+          mutually exclusive exons, are the key for the choice to synthesize RQ or UQ. We find that
+          one of the mutually exclusive exons is only found in the genomes of animals that
+          synthesize RQ and that its inclusion remodels the core of the COQ-2 enzyme. We show that
+          the removal of&#x00A0;this exon abolishes almost all RQ biosynthesis in <italic>C.
+            elegans</italic>. Finally, we find that inclusion of this RQ-specific exon expression is
+          increased in the stages of the parasite&#x00A0;life cycle where they encounter hypoxic
+          conditions and increase RQ production, while the alternative exon is increased in normoxic
+          life stages. We thus conclude that alternative splicing of COQ-2 is the key mechanism that
+          causes the switch from UQ to RQ synthesis in the parasite life&#x00A0;cycle.</p>
+        <sec id="s1-1-1-1">
+          <title>Test 3</title>
+          <p>In this study, we reveal that two variants of COQ-2, derived from alternative splicing
+            of mutually exclusive exons, are the key for the choice to synthesize RQ or UQ. We find
+            that one of the mutually exclusive exons is only found in the genomes of animals that
+            synthesize RQ and that its inclusion remodels the core of the COQ-2 enzyme. We show that
+            the removal of&#x00A0;this exon abolishes almost all RQ biosynthesis in <italic>C.
+              elegans</italic>. Finally, we find that inclusion of this RQ-specific exon expression
+            is increased in the stages of the parasite&#x00A0;life cycle where they encounter
+            hypoxic conditions and increase RQ production, while the alternative exon is increased
+            in normoxic life stages. We thus conclude that alternative splicing of COQ-2 is the key
+            mechanism that causes the switch from UQ to RQ synthesis in the parasite
+            life&#x00A0;cycle.</p>
+          <sec id="s1-1-1-1-1">
+            <title>Test 4</title>
+            <p>In this study, we reveal that two variants of COQ-2, derived from alternative
+              splicing of mutually exclusive exons, are the key for the choice to synthesize RQ or
+              UQ. We find that one of the mutually exclusive exons is only found in the genomes of
+              animals that synthesize RQ and that its inclusion remodels the core of the COQ-2
+              enzyme. We show that the removal of&#x00A0;this exon abolishes almost all RQ
+              biosynthesis in <italic>C. elegans</italic>. Finally, we find that inclusion of this
+              RQ-specific exon expression is increased in the stages of the parasite&#x00A0;life
+              cycle where they encounter hypoxic conditions and increase RQ production, while the
+              alternative exon is increased in normoxic life stages. We thus conclude that
+              alternative splicing of COQ-2 is the key mechanism that causes the switch from UQ to
+              RQ synthesis in the parasite life&#x00A0;cycle.</p>
+            <sec id="s1-1-1-1-1-1">
+              <title>Test 5</title>
+              <p>In this study, we reveal that two variants of COQ-2, derived from alternative
+                splicing of mutually exclusive exons, are the key for the choice to synthesize RQ or
+                UQ. We find that one of the mutually exclusive exons is only found in the genomes of
+                animals that synthesize RQ and that its inclusion remodels the core of the COQ-2
+                enzyme. We show that the removal of&#x00A0;this exon abolishes almost all RQ
+                biosynthesis in <italic>C. elegans</italic>. Finally, we find that inclusion of this
+                RQ-specific exon expression is increased in the stages of the parasite&#x00A0;life
+                cycle where they encounter hypoxic conditions and increase RQ production, while the
+                alternative exon is increased in normoxic life stages. We thus conclude that
+                alternative splicing of COQ-2 is the key mechanism that causes the switch from UQ to
+                RQ synthesis in the parasite life&#x00A0;cycle.</p>
+            </sec>
+          </sec>
+        </sec>
+      </sec>
+    </sec>
+  </article>
+</root>

--- a/test/tests/gen/sec-tests/sec-test-5/sec-test-5.sch
+++ b/test/tests/gen/sec-tests/sec-test-5/sec-test-5.sch
@@ -1,0 +1,803 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna','hiv','aids','covid-19','covid')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="contains($token1,'-')">
+            <xsl:value-of select="string-join(for $x in tokenize($s,'\s') return e:titleCaseToken($x),' ')"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:ref-cite-list">
+    <xsl:param name="ref-list" as="node()"/>
+    <xsl:element name="list">
+      <xsl:for-each select="$ref-list/ref[element-citation[year]]">
+        <xsl:variable name="cite" select="e:citation-format1(./element-citation[1]/year[1])"/>
+        <xsl:element name="item">
+          <xsl:attribute name="id">
+            <xsl:value-of select="./@id"/>
+          </xsl:attribute>
+          <xsl:attribute name="no-suffix">
+            <xsl:value-of select="replace($cite,'[A-Za-z]$','')"/>
+          </xsl:attribute>
+          <xsl:value-of select="$cite"/>
+        </xsl:element>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:non-distinct-citations">
+    <xsl:param name="cite-list" as="node()"/>
+    <xsl:element name="list">
+    <xsl:for-each select="$cite-list//*:item">
+      <xsl:variable name="cite" select="./string()"/>
+      <xsl:choose>
+        <xsl:when test="./preceding::*:item/string() = $cite">
+          <xsl:element name="item">
+            <xsl:attribute name="id">
+              <xsl:value-of select="./@id"/>
+            </xsl:attribute>
+            <xsl:value-of select="$cite"/>
+          </xsl:element>
+        </xsl:when>
+        <xsl:when test="not(matches($cite,'[A-Za-z]$')) and (./preceding::*:item/@no-suffix/string() = $cite)">
+          <xsl:element name="item">
+            <xsl:attribute name="id">
+              <xsl:value-of select="./@id"/>
+            </xsl:attribute>
+          <xsl:value-of select="$cite"/>
+          </xsl:element>
+        </xsl:when>
+        <xsl:when test="not(matches($cite,'[A-Za-z]$')) and ./following::*:item/@no-suffix/string() = $cite">
+          <xsl:element name="item">
+            <xsl:attribute name="id">
+              <xsl:value-of select="./@id"/>
+            </xsl:attribute>
+          <xsl:value-of select="$cite"/>
+          </xsl:element>
+        </xsl:when>
+        <xsl:otherwise/>
+      </xsl:choose>
+    </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|e\.\s?faecalis|h\.\s?sapiens|homo\s?sapiens|c\.\s?trachomatis|chlamydia\s?trachomatis|enterococcus\s?faecalis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?lanceolata|plantago\s?lanceolata|m\.\s?trossulus|mytilus\s?trossulus|m\.\s?edulis|mytilus\s?edulis|m\.\s?chilensis|mytilus\s?chilensis|u\.\s?maydis|ustilago\s?maydis|p\.\s?knowlesi|plasmodium\s?knowlesi|p\.\s?aeruginosa|pseudomonas\s?aeruginosa|t\.\s?brucei|trypanosoma\s?brucei|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <let name="sec-title-regex" value="string-join(     for $x in tokenize($org-regex,'\|')     return concat('^',$x,'$')     ,'|')"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?brucei')">
+        <xsl:value-of select="'T. brucei'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'trypanosoma\s?brucei')">
+        <xsl:value-of select="'Trypanosoma brucei'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="matches($s,'[Gg]ithub')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Gg]itlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Cc]ode[Pp]lex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Ss]ource[Ff]orge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Bb]it[Bb]ucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="matches($s,'[Aa]ssembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (number(replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','')) gt number($object-no))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:line-count" as="xs:integer">
+    <xsl:param name="arg" as="xs:string?"/>
+    
+    <xsl:sequence select="count(tokenize($arg,'(\r\n?|\n\r?)'))"/>
+    
+  </xsl:function>
+  <pattern id="sec-specific">
+    <rule context="sec" id="sec-tests">
+      <let name="child-count" value="count(p) + count(sec) + count(fig) + count(fig-group) + count(media) + count(table-wrap) + count(boxed-text) + count(list) + count(fn-group) + count(supplementary-material) + count(related-object)"/>
+      <report test="count(ancestor::sec) ge 5" role="error" id="sec-test-5">Level <value-of select="count(ancestor::sec) + 1"/> sections are not allowed. Please either make this a level 5 heading, or capture the title as a bolded paragraph in its parent section.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::sec" role="error" id="sec-tests-xspec-assert">sec must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/xspec/schematron.sch
+++ b/test/xspec/schematron.sch
@@ -3244,6 +3244,8 @@
     <assert test="title" role="error" id="sec-test-1">sec must have a title</assert>
       
       <assert test="$child-count gt 0" role="error" id="sec-test-2">sec appears to contain no content. This cannot be correct.</assert>
+      
+      <report test="count(ancestor::sec) ge 5" role="error" id="sec-test-5">Level <value-of select="count(ancestor::sec) + 1"/> sections are not allowed. Please either make this a level 5 heading, or capture the title as a bolded paragraph in its parent section.</report>
     </rule>
   </pattern>
   <pattern id="res-data-sec-pattern">
@@ -5651,7 +5653,7 @@
   </pattern>
   
   <pattern id="org-ref-article-book-title-pattern">
-    <rule context="element-citation[@publication-type='journal']/article-title" id="org-ref-article-book-title">	
+    <rule context="element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title" id="org-ref-article-book-title">	
       <let name="lc" value="lower-case(.)"/>
       
       <report test="matches($lc,'b\.\s?subtilis') and not(italic[contains(text() ,'B. subtilis')])" role="info" id="bssubtilis-ref-article-title-check">ref <value-of select="ancestor::ref/@id"/> references an organism - 'B. subtilis' - but there is no italic element with that correct capitalisation or spacing.</report>
@@ -7953,7 +7955,7 @@
       <assert test="descendant::xref[@ref-type='table']" role="error" id="table-xref-conformance-xspec-assert">xref[@ref-type='table'] must be present.</assert>
       <assert test="descendant::xref[@ref-type='supplementary-material']" role="error" id="supp-file-xref-conformance-xspec-assert">xref[@ref-type='supplementary-material'] must be present.</assert>
       <assert test="descendant::xref[@ref-type='disp-formula']" role="error" id="equation-xref-conformance-xspec-assert">xref[@ref-type='disp-formula'] must be present.</assert>
-      <assert test="descendant::element-citation[@publication-type='journal']/article-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation[@publication-type='journal']/article-title must be present.</assert>
+      <assert test="descendant::element-citation/article-title or descendant::element-citation/chapter-title or descendant::element-citation/source or descendant::element-citation/data-title" role="error" id="org-ref-article-book-title-xspec-assert">element-citation/article-title|element-citation/chapter-title|element-citation/source|element-citation/data-title must be present.</assert>
       <assert test="descendant::article//article-meta/title-group/article-title  or descendant:: article/body//sec/title  or descendant:: article//article-meta//kwd" role="error" id="org-title-kwd-xspec-assert">article//article-meta/title-group/article-title | article/body//sec/title | article//article-meta//kwd must be present.</assert>
       <assert test="descendant::p or descendant::td or descendant::th or descendant::title or descendant::xref or descendant::bold or descendant::italic or descendant::sub or descendant::sc or descendant::named-content or descendant::monospace or descendant::code or descendant::underline or descendant::fn or descendant::institution or descendant::ext-link" role="error" id="unallowed-symbol-tests-xspec-assert">p|td|th|title|xref|bold|italic|sub|sc|named-content|monospace|code|underline|fn|institution|ext-link must be present.</assert>
       <assert test="descendant::sup" role="error" id="unallowed-symbol-tests-sup-xspec-assert">sup must be present.</assert>

--- a/test/xspec/schematron.xspec
+++ b/test/xspec/schematron.xspec
@@ -6227,6 +6227,16 @@
         <x:expect-assert id="sec-test-2" role="error"/>
         <x:expect-not-assert id="sec-tests-xspec-assert" role="error"/>
       </x:scenario>
+      <x:scenario label="sec-test-5-pass">
+        <x:context href="../tests/gen/sec-tests/sec-test-5/pass.xml"/>
+        <x:expect-not-report id="sec-test-5" role="error"/>
+        <x:expect-not-assert id="sec-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="sec-test-5-fail">
+        <x:context href="../tests/gen/sec-tests/sec-test-5/fail.xml"/>
+        <x:expect-report id="sec-test-5" role="error"/>
+        <x:expect-not-assert id="sec-tests-xspec-assert" role="error"/>
+      </x:scenario>
     </x:scenario>
     <x:scenario label="res-data-sec">
       <x:scenario label="sec-test-3-pass">


### PR DESCRIPTION
- Disallow level 6+ sections.
- Extend `org-ref-article-book-title` to other reference elements.