### PR TITLE
perf: mathbackground-tests improvement

### DIFF
--- a/src/final-JATS-schematron.sch
+++ b/src/final-JATS-schematron.sch
@@ -3137,7 +3137,7 @@
       
       <assert test="$child-count gt 0" role="error" id="sec-test-2">[sec-test-2] sec appears to contain no content. This cannot be correct.</assert>
       
-      <report test="count(ancestor::sec) ge 5" role="error" id="sec-test-5">[sec-test-5] Level <value-of select="count(ancestor::sec) + 1"/> sections are not allowed. Please either make this a level 5 heading, or capture the title as a bolded paragraph in its parent section.</report>
+      <report test="count(ancestor::sec) ge 5" role="error" id="sec-test-5">[sec-test-5] Level <value-of select="count(ancestor::sec) + 1"/> sections are not allowed. Please either make this a level 5 heading, or capture the title as a bolded paragraph in its parent section. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/article-structure#sec-test-5</report>
     </rule>
   </pattern>
   <pattern id="res-data-sec-pattern">
@@ -6668,15 +6668,15 @@
     </rule>
   </pattern>
   <pattern id="mathbackground-tests-pattern">
-    <rule context="mml:*" id="mathbackground-tests">
+    <rule context="mml:*[@mathbackground]" id="mathbackground-tests">
       
       
       
       
       
-      <report test="@mathbackground and not(ancestor::table-wrap)" role="error" id="final-mathbackground-test-1">[final-mathbackground-test-1] math (<value-of select="name()"/> element) containing '<value-of select="."/>' has '<value-of select="@mathbackground"/>' colour background formatting. This likely means that there's a mistake in the content which will not render correctly online. If it's not a mistake, and the background colour is deliberate, then this will need to removed.</report>
+      <report test="not(ancestor::table-wrap)" role="error" id="final-mathbackground-test-1">[final-mathbackground-test-1] math (<value-of select="name()"/> element) containing '<value-of select="."/>' has '<value-of select="@mathbackground"/>' colour background formatting. This likely means that there's a mistake in the content which will not render correctly online. If it's not a mistake, and the background colour is deliberate, then this will need to removed.</report>
       
-      <report test="@mathbackground and ancestor::table-wrap" role="error" id="final-mathbackground-test-2">[final-mathbackground-test-2] math (<value-of select="name()"/> element) containing '<value-of select="."/>' has '<value-of select="@mathbackground"/>' colour background formatting. This likely means that there's a mistake in the content which will not render correctly online. If it's not a mistake, and the background colour is deliberate, then either the background colour will need to added to the table cell (rather than the maths), or it needs to be removed.</report>
+      <report test="ancestor::table-wrap" role="error" id="final-mathbackground-test-2">[final-mathbackground-test-2] math (<value-of select="name()"/> element) containing '<value-of select="."/>' has '<value-of select="@mathbackground"/>' colour background formatting. This likely means that there's a mistake in the content which will not render correctly online. If it's not a mistake, and the background colour is deliberate, then either the background colour will need to added to the table cell (rather than the maths), or it needs to be removed.</report>
       
     </rule>
   </pattern>

--- a/src/final-package-JATS-schematron.sch
+++ b/src/final-package-JATS-schematron.sch
@@ -3238,7 +3238,7 @@
       
       <assert test="$child-count gt 0" role="error" id="sec-test-2">sec appears to contain no content. This cannot be correct.</assert>
       
-      <report test="count(ancestor::sec) ge 5" role="error" id="sec-test-5">Level <value-of select="count(ancestor::sec) + 1"/> sections are not allowed. Please either make this a level 5 heading, or capture the title as a bolded paragraph in its parent section.</report>
+      <report test="count(ancestor::sec) ge 5" role="error" id="sec-test-5">Level <value-of select="count(ancestor::sec) + 1"/> sections are not allowed. Please either make this a level 5 heading, or capture the title as a bolded paragraph in its parent section. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/article-structure#sec-test-5</report>
     </rule>
   </pattern>
   <pattern id="res-data-sec-pattern">
@@ -6995,15 +6995,15 @@
     </rule>
   </pattern>
   <pattern id="mathbackground-tests-pattern">
-    <rule context="mml:*" id="mathbackground-tests">
+    <rule context="mml:*[@mathbackground]" id="mathbackground-tests">
       
       
       
       
       
-      <report test="@mathbackground and not(ancestor::table-wrap)" role="error" id="final-mathbackground-test-1">math (<value-of select="name()"/> element) containing '<value-of select="."/>' has '<value-of select="@mathbackground"/>' colour background formatting. This likely means that there's a mistake in the content which will not render correctly online. If it's not a mistake, and the background colour is deliberate, then this will need to removed.</report>
+      <report test="not(ancestor::table-wrap)" role="error" id="final-mathbackground-test-1">math (<value-of select="name()"/> element) containing '<value-of select="."/>' has '<value-of select="@mathbackground"/>' colour background formatting. This likely means that there's a mistake in the content which will not render correctly online. If it's not a mistake, and the background colour is deliberate, then this will need to removed.</report>
       
-      <report test="@mathbackground and ancestor::table-wrap" role="error" id="final-mathbackground-test-2">math (<value-of select="name()"/> element) containing '<value-of select="."/>' has '<value-of select="@mathbackground"/>' colour background formatting. This likely means that there's a mistake in the content which will not render correctly online. If it's not a mistake, and the background colour is deliberate, then either the background colour will need to added to the table cell (rather than the maths), or it needs to be removed.</report>
+      <report test="ancestor::table-wrap" role="error" id="final-mathbackground-test-2">math (<value-of select="name()"/> element) containing '<value-of select="."/>' has '<value-of select="@mathbackground"/>' colour background formatting. This likely means that there's a mistake in the content which will not render correctly online. If it's not a mistake, and the background colour is deliberate, then either the background colour will need to added to the table cell (rather than the maths), or it needs to be removed.</report>
       
     </rule>
   </pattern>

--- a/src/pre-JATS-schematron.sch
+++ b/src/pre-JATS-schematron.sch
@@ -3135,7 +3135,7 @@
       
       <assert test="$child-count gt 0" role="error" id="sec-test-2">[sec-test-2] sec appears to contain no content. This cannot be correct.</assert>
       
-      <report test="count(ancestor::sec) ge 5" role="error" id="sec-test-5">[sec-test-5] Level <value-of select="count(ancestor::sec) + 1"/> sections are not allowed. Please either make this a level 5 heading, or capture the title as a bolded paragraph in its parent section.</report>
+      <report test="count(ancestor::sec) ge 5" role="error" id="sec-test-5">[sec-test-5] Level <value-of select="count(ancestor::sec) + 1"/> sections are not allowed. Please either make this a level 5 heading, or capture the title as a bolded paragraph in its parent section. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/article-structure#sec-test-5</report>
     </rule>
   </pattern>
   <pattern id="res-data-sec-pattern">
@@ -6666,11 +6666,11 @@
     </rule>
   </pattern>
   <pattern id="mathbackground-tests-pattern">
-    <rule context="mml:*" id="mathbackground-tests">
+    <rule context="mml:*[@mathbackground]" id="mathbackground-tests">
       
-      <report test="@mathbackground and not(ancestor::table-wrap)" role="warning" id="pre-mathbackground-test-1">[pre-mathbackground-test-1] math (<value-of select="name()"/> element) containing '<value-of select="."/>' has '<value-of select="@mathbackground"/>' colour background formatting. This likely means that there's a mistake in the content which will not render correctly online. Please check this carefully against the original manuscript. If it's not a mistake, and the background colour is deliberate, then please add the following author query -&gt; 'Where possible, we prefer that colours are not used in text in the interests of accessibility and because they will not display in downstream HTML (for example in PMC). eLife does not support background colours for text, however we do support the following colours for text itself - 'red', 'blue' and 'purple'. Please confirm how you would like the colour(s) captured here given this information, and note that our preference would be to use more common forms of emphasis (such as bold, italic or underline) if possible to still convey the same meaning.'.</report>
+      <report test="not(ancestor::table-wrap)" role="warning" id="pre-mathbackground-test-1">[pre-mathbackground-test-1] math (<value-of select="name()"/> element) containing '<value-of select="."/>' has '<value-of select="@mathbackground"/>' colour background formatting. This likely means that there's a mistake in the content which will not render correctly online. Please check this carefully against the original manuscript. If it's not a mistake, and the background colour is deliberate, then please add the following author query -&gt; 'Where possible, we prefer that colours are not used in text in the interests of accessibility and because they will not display in downstream HTML (for example in PMC). eLife does not support background colours for text, however we do support the following colours for text itself - 'red', 'blue' and 'purple'. Please confirm how you would like the colour(s) captured here given this information, and note that our preference would be to use more common forms of emphasis (such as bold, italic or underline) if possible to still convey the same meaning.'.</report>
       
-      <report test="@mathbackground and ancestor::table-wrap" role="warning" id="pre-mathbackground-test-2">[pre-mathbackground-test-2] math (<value-of select="name()"/> element) containing '<value-of select="."/>' has '<value-of select="@mathbackground"/>' colour background formatting. This likely means that there's a mistake in the content which will not render correctly online. Please check this carefully against the original manuscript. If it's not a mistake, and the background colour is deliberate, then please ensure that the background colour is captured for the table cell (rather than the maths).</report>
+      <report test="ancestor::table-wrap" role="warning" id="pre-mathbackground-test-2">[pre-mathbackground-test-2] math (<value-of select="name()"/> element) containing '<value-of select="."/>' has '<value-of select="@mathbackground"/>' colour background formatting. This likely means that there's a mistake in the content which will not render correctly online. Please check this carefully against the original manuscript. If it's not a mistake, and the background colour is deliberate, then please ensure that the background colour is captured for the table cell (rather than the maths).</report>
       
       
       

--- a/src/schematron.sch
+++ b/src/schematron.sch
@@ -4447,7 +4447,7 @@
       
       <report test="count(ancestor::sec) ge 5"
         role="error"
-        id="sec-test-5">Level <value-of select="count(ancestor::sec) + 1"/> sections are not allowed. Please either make this a level 5 heading, or capture the title as a bolded paragraph in its parent section.</report>
+        id="sec-test-5">Level <value-of select="count(ancestor::sec) + 1"/> sections are not allowed. Please either make this a level 5 heading, or capture the title as a bolded paragraph in its parent section. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/article-structure#sec-test-5</report>
     </rule>
     
     <rule context="article[@article-type='research-article']//sec[not(@sec-type) and not(descendant::xref[@ref-type='bibr']) and not(matches(.,'[Gg]ithub|[Gg]itlab|[Cc]ode[Pp]lex|[Ss]ource[Ff]orge|[Bb]it[Bb]ucket'))]"
@@ -9628,22 +9628,22 @@
       
     </rule>
     
-    <rule context="mml:*" 
+    <rule context="mml:*[@mathbackground]" 
       id="mathbackground-tests">
       
-      <report test="@mathbackground and not(ancestor::table-wrap)"
+      <report test="not(ancestor::table-wrap)"
         role="warning"
         id="pre-mathbackground-test-1">math (<value-of select="name()"/> element) containing '<value-of select="."/>' has '<value-of select="@mathbackground"/>' colour background formatting. This likely means that there's a mistake in the content which will not render correctly online. Please check this carefully against the original manuscript. If it's not a mistake, and the background colour is deliberate, then please add the following author query -> 'Where possible, we prefer that colours are not used in text in the interests of accessibility and because they will not display in downstream HTML (for example in PMC). eLife does not support background colours for text, however we do support the following colours for text itself - 'red', 'blue' and 'purple'. Please confirm how you would like the colour(s) captured here given this information, and note that our preference would be to use more common forms of emphasis (such as bold, italic or underline) if possible to still convey the same meaning.'.</report>
       
-      <report test="@mathbackground and ancestor::table-wrap"
+      <report test="ancestor::table-wrap"
         role="warning"
         id="pre-mathbackground-test-2">math (<value-of select="name()"/> element) containing '<value-of select="."/>' has '<value-of select="@mathbackground"/>' colour background formatting. This likely means that there's a mistake in the content which will not render correctly online. Please check this carefully against the original manuscript. If it's not a mistake, and the background colour is deliberate, then please ensure that the background colour is captured for the table cell (rather than the maths).</report>
       
-      <report test="@mathbackground and not(ancestor::table-wrap)"
+      <report test="not(ancestor::table-wrap)"
         role="error"
         id="final-mathbackground-test-1">math (<value-of select="name()"/> element) containing '<value-of select="."/>' has '<value-of select="@mathbackground"/>' colour background formatting. This likely means that there's a mistake in the content which will not render correctly online. If it's not a mistake, and the background colour is deliberate, then this will need to removed.</report>
       
-      <report test="@mathbackground and ancestor::table-wrap"
+      <report test="ancestor::table-wrap"
         role="error"
         id="final-mathbackground-test-2">math (<value-of select="name()"/> element) containing '<value-of select="."/>' has '<value-of select="@mathbackground"/>' colour background formatting. This likely means that there's a mistake in the content which will not render correctly online. If it's not a mistake, and the background colour is deliberate, then either the background colour will need to added to the table cell (rather than the maths), or it needs to be removed.</report>
       

--- a/test/tests/gen/mathbackground-tests/final-mathbackground-test-1/fail.xml
+++ b/test/tests/gen/mathbackground-tests/final-mathbackground-test-1/fail.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="final-mathbackground-test-1.sch"?>
-<!--Context: mml:*
-Test: report    @mathbackground and not(ancestor::table-wrap)
+<!--Context: mml:*[@mathbackground]
+Test: report    not(ancestor::table-wrap)
 Message: math ( element) containing '' has '' colour background formatting. This likely means that there's a mistake in the content which will not render correctly online. If it's not a mistake, and the background colour is deliberate, then this will need to removed. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>

--- a/test/tests/gen/mathbackground-tests/final-mathbackground-test-1/final-mathbackground-test-1.sch
+++ b/test/tests/gen/mathbackground-tests/final-mathbackground-test-1/final-mathbackground-test-1.sch
@@ -790,13 +790,13 @@
     
   </xsl:function>
   <pattern id="house-style">
-    <rule context="mml:*" id="mathbackground-tests">
-      <report test="@mathbackground and not(ancestor::table-wrap)" role="error" id="final-mathbackground-test-1">math (<value-of select="name()"/> element) containing '<value-of select="."/>' has '<value-of select="@mathbackground"/>' colour background formatting. This likely means that there's a mistake in the content which will not render correctly online. If it's not a mistake, and the background colour is deliberate, then this will need to removed.</report>
+    <rule context="mml:*[@mathbackground]" id="mathbackground-tests">
+      <report test="not(ancestor::table-wrap)" role="error" id="final-mathbackground-test-1">math (<value-of select="name()"/> element) containing '<value-of select="."/>' has '<value-of select="@mathbackground"/>' colour background formatting. This likely means that there's a mistake in the content which will not render correctly online. If it's not a mistake, and the background colour is deliberate, then this will need to removed.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::mml:*" role="error" id="mathbackground-tests-xspec-assert">mml:* must be present.</assert>
+      <assert test="descendant::mml:*[@mathbackground]" role="error" id="mathbackground-tests-xspec-assert">mml:*[@mathbackground] must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/mathbackground-tests/final-mathbackground-test-1/pass.xml
+++ b/test/tests/gen/mathbackground-tests/final-mathbackground-test-1/pass.xml
@@ -1,192 +1,139 @@
 <?oxygen SCHSchema="final-mathbackground-test-1.sch"?>
-<!--Context: mml:*
-Test: report    @mathbackground and not(ancestor::table-wrap)
+<!--Context: mml:*[@mathbackground]
+Test: report    not(ancestor::table-wrap)
 Message: math ( element) containing '' has '' colour background formatting. This likely means that there's a mistake in the content which will not render correctly online. If it's not a mistake, and the background colour is deliberate, then this will need to removed. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>
-    <disp-formula id="equ27">
-      <mml:math id="m27">
-        <mml:mstyle displaystyle="true" scriptlevel="0">
-          <mml:mrow>
-            <mml:mtable columnalign="left left" columnspacing="1em" rowspacing="4pt">
-              <mml:mtr>
-                <mml:mtd>
-                  <mml:mfrac>
-                    <mml:mrow>
-                      <mml:mi>d</mml:mi>
+    <table-wrap>
+      <disp-formula id="equ27">
+        <mml:math id="m27">
+          <mml:mstyle displaystyle="true" scriptlevel="0">
+            <mml:mrow>
+              <mml:mtable columnalign="left left" columnspacing="1em" rowspacing="4pt">
+                <mml:mtr>
+                  <mml:mtd>
+                    <mml:mfrac>
                       <mml:mrow>
-                        <mml:mo>[</mml:mo>
+                        <mml:text mathcolor="red" mathbackground="yellow">\UpDelta</mml:text>
+                        <mml:mi>d</mml:mi>
                         <mml:mrow>
-                          <mml:mi>R</mml:mi>
+                          <mml:mo>[</mml:mo>
                           <mml:mrow>
-                            <mml:mo>(</mml:mo>
+                            <mml:mi>R</mml:mi>
                             <mml:mrow>
-                              <mml:mn>0</mml:mn>
-                              <mml:mo>,</mml:mo>
-                              <mml:mn>0</mml:mn>
+                              <mml:mo>(</mml:mo>
+                              <mml:mrow>
+                                <mml:mn>0</mml:mn>
+                                <mml:mo>,</mml:mo>
+                                <mml:mn>0</mml:mn>
+                              </mml:mrow>
+                              <mml:mo>)</mml:mo>
                             </mml:mrow>
-                            <mml:mo>)</mml:mo>
                           </mml:mrow>
+                          <mml:mo>]</mml:mo>
                         </mml:mrow>
-                        <mml:mo>]</mml:mo>
                       </mml:mrow>
-                    </mml:mrow>
-                    <mml:mrow>
-                      <mml:mi>d</mml:mi>
-                      <mml:mi>t</mml:mi>
-                    </mml:mrow>
-                  </mml:mfrac>
-                </mml:mtd>
-                <mml:mtd>
-                  <mml:mo>=</mml:mo>
-                  <mml:msub>
-                    <mml:mi>k</mml:mi>
-                    <mml:mrow>
-                      <mml:mi>r</mml:mi>
-                      <mml:mi>e</mml:mi>
-                      <mml:mi>p</mml:mi>
-                    </mml:mrow>
-                  </mml:msub>
-                  <mml:mrow>
-                    <mml:mo>[</mml:mo>
-                    <mml:mrow>
-                      <mml:mi>P</mml:mi>
-                      <mml:mn>0</mml:mn>
-                    </mml:mrow>
-                    <mml:mo>]</mml:mo>
-                  </mml:mrow>
-                  <mml:mo>−</mml:mo>
-                  <mml:mrow>
-                    <mml:mo>(</mml:mo>
-                    <mml:mrow>
                       <mml:mrow>
-                        <mml:mstyle mathcolor="blue">
-                          <mml:mrow>
-                            <mml:mi>r</mml:mi>
-                            <mml:mo>⋅</mml:mo>
-                            <mml:mi>u</mml:mi>
-                          </mml:mrow>
-                        </mml:mstyle>
+                        <mml:mi>d</mml:mi>
+                        <mml:mi>t</mml:mi>
                       </mml:mrow>
-                      <mml:mo>+</mml:mo>
-                      <mml:mtext> </mml:mtext>
-                      <mml:mn>5</mml:mn>
-                      <mml:mrow>
-                        <mml:mo>[</mml:mo>
-                        <mml:mrow>
-                          <mml:mi>C</mml:mi>
-                          <mml:msup>
-                            <mml:mi>a</mml:mi>
-                            <mml:mrow>
-                              <mml:mn>2</mml:mn>
-                              <mml:mo>+</mml:mo>
-                            </mml:mrow>
-                          </mml:msup>
-                        </mml:mrow>
-                        <mml:mo>]</mml:mo>
-                      </mml:mrow>
-                      <mml:msub>
-                        <mml:mi>k</mml:mi>
-                        <mml:mrow>
-                          <mml:mn>1</mml:mn>
-                        </mml:mrow>
-                      </mml:msub>
-                      <mml:mo>+</mml:mo>
-                      <mml:mrow>
-                        <mml:mstyle mathcolor="red">
-                          <mml:mn>2</mml:mn>
-                          <mml:mrow>
-                            <mml:mo>[</mml:mo>
-                            <mml:mrow>
-                              <mml:mi>C</mml:mi>
-                              <mml:msup>
-                                <mml:mi>a</mml:mi>
-                                <mml:mrow>
-                                  <mml:mn>2</mml:mn>
-                                  <mml:mo>+</mml:mo>
-                                </mml:mrow>
-                              </mml:msup>
-                            </mml:mrow>
-                            <mml:mo>]</mml:mo>
-                          </mml:mrow>
-                          <mml:msub>
-                            <mml:mi>k</mml:mi>
-                            <mml:mrow>
-                              <mml:mn>2</mml:mn>
-                            </mml:mrow>
-                          </mml:msub>
-                        </mml:mstyle>
-                      </mml:mrow>
-                      <mml:mo>+</mml:mo>
-                      <mml:msup>
-                        <mml:mi>L</mml:mi>
-                        <mml:mrow>
-                          <mml:mo>+</mml:mo>
-                        </mml:mrow>
-                      </mml:msup>
-                    </mml:mrow>
-                    <mml:mo>)</mml:mo>
-                  </mml:mrow>
-                </mml:mtd>
-              </mml:mtr>
-              <mml:mtr>
-                <mml:mtd/>
-                <mml:mtd>
-                  <mml:mrow>
-                    <mml:mo>[</mml:mo>
-                    <mml:mrow>
-                      <mml:mi>R</mml:mi>
-                      <mml:mrow>
-                        <mml:mo>(</mml:mo>
-                        <mml:mrow>
-                          <mml:mn>0</mml:mn>
-                          <mml:mo>,</mml:mo>
-                          <mml:mn>0</mml:mn>
-                        </mml:mrow>
-                        <mml:mo>)</mml:mo>
-                      </mml:mrow>
-                    </mml:mrow>
-                    <mml:mo>]</mml:mo>
-                  </mml:mrow>
-                  <mml:mo>+</mml:mo>
-                  <mml:msub>
-                    <mml:mi>k</mml:mi>
-                    <mml:mrow>
-                      <mml:mo>−</mml:mo>
-                      <mml:mn>1</mml:mn>
-                    </mml:mrow>
-                  </mml:msub>
-                  <mml:mrow>
-                    <mml:mo>[</mml:mo>
-                    <mml:mrow>
-                      <mml:mi>R</mml:mi>
-                      <mml:mrow>
-                        <mml:mo>(</mml:mo>
-                        <mml:mrow>
-                          <mml:mn>1</mml:mn>
-                          <mml:mo>,</mml:mo>
-                          <mml:mn>0</mml:mn>
-                        </mml:mrow>
-                        <mml:mo>)</mml:mo>
-                      </mml:mrow>
-                    </mml:mrow>
-                    <mml:mo>]</mml:mo>
-                  </mml:mrow>
-                </mml:mtd>
-              </mml:mtr>
-              <mml:mtr>
-                <mml:mtd/>
-                <mml:mtd>
-                  <mml:mo>+</mml:mo>
-                  <mml:mtext> </mml:mtext>
-                  <mml:mstyle mathcolor="red">
+                    </mml:mfrac>
+                  </mml:mtd>
+                  <mml:mtd>
+                    <mml:mo>=</mml:mo>
                     <mml:msub>
                       <mml:mi>k</mml:mi>
                       <mml:mrow>
-                        <mml:mo>−</mml:mo>
-                        <mml:mn>2</mml:mn>
+                        <mml:mi>r</mml:mi>
+                        <mml:mi>e</mml:mi>
+                        <mml:mi>p</mml:mi>
                       </mml:mrow>
                     </mml:msub>
+                    <mml:mrow>
+                      <mml:mo>[</mml:mo>
+                      <mml:mrow>
+                        <mml:mi>P</mml:mi>
+                        <mml:mn>0</mml:mn>
+                      </mml:mrow>
+                      <mml:mo>]</mml:mo>
+                    </mml:mrow>
+                    <mml:mo>−</mml:mo>
+                    <mml:mrow>
+                      <mml:mo>(</mml:mo>
+                      <mml:mrow>
+                        <mml:mrow>
+                          <mml:mstyle mathcolor="blue">
+                            <mml:mrow>
+                              <mml:mi>r</mml:mi>
+                              <mml:mo>⋅</mml:mo>
+                              <mml:mi>u</mml:mi>
+                            </mml:mrow>
+                          </mml:mstyle>
+                        </mml:mrow>
+                        <mml:mo>+</mml:mo>
+                        <mml:mtext> </mml:mtext>
+                        <mml:mn>5</mml:mn>
+                        <mml:mrow>
+                          <mml:mo>[</mml:mo>
+                          <mml:mrow>
+                            <mml:mi>C</mml:mi>
+                            <mml:msup>
+                              <mml:mi>a</mml:mi>
+                              <mml:mrow>
+                                <mml:mn>2</mml:mn>
+                                <mml:mo>+</mml:mo>
+                              </mml:mrow>
+                            </mml:msup>
+                          </mml:mrow>
+                          <mml:mo>]</mml:mo>
+                        </mml:mrow>
+                        <mml:msub>
+                          <mml:mi>k</mml:mi>
+                          <mml:mrow>
+                            <mml:mn>1</mml:mn>
+                          </mml:mrow>
+                        </mml:msub>
+                        <mml:mo>+</mml:mo>
+                        <mml:mrow>
+                          <mml:mstyle mathcolor="red">
+                            <mml:mn>2</mml:mn>
+                            <mml:mrow>
+                              <mml:mo>[</mml:mo>
+                              <mml:mrow>
+                                <mml:mi>C</mml:mi>
+                                <mml:msup>
+                                  <mml:mi>a</mml:mi>
+                                  <mml:mrow>
+                                    <mml:mn>2</mml:mn>
+                                    <mml:mo>+</mml:mo>
+                                  </mml:mrow>
+                                </mml:msup>
+                              </mml:mrow>
+                              <mml:mo>]</mml:mo>
+                            </mml:mrow>
+                            <mml:msub>
+                              <mml:mi>k</mml:mi>
+                              <mml:mrow>
+                                <mml:mn>2</mml:mn>
+                              </mml:mrow>
+                            </mml:msub>
+                          </mml:mstyle>
+                        </mml:mrow>
+                        <mml:mo>+</mml:mo>
+                        <mml:msup>
+                          <mml:mi>L</mml:mi>
+                          <mml:mrow>
+                            <mml:mo>+</mml:mo>
+                          </mml:mrow>
+                        </mml:msup>
+                      </mml:mrow>
+                      <mml:mo>)</mml:mo>
+                    </mml:mrow>
+                  </mml:mtd>
+                </mml:mtr>
+                <mml:mtr>
+                  <mml:mtd/>
+                  <mml:mtd>
                     <mml:mrow>
                       <mml:mo>[</mml:mo>
                       <mml:mrow>
@@ -196,20 +143,76 @@ Message: math ( element) containing '' has '' colour background formatting. This
                           <mml:mrow>
                             <mml:mn>0</mml:mn>
                             <mml:mo>,</mml:mo>
-                            <mml:mn>1</mml:mn>
+                            <mml:mn>0</mml:mn>
                           </mml:mrow>
                           <mml:mo>)</mml:mo>
                         </mml:mrow>
                       </mml:mrow>
                       <mml:mo>]</mml:mo>
                     </mml:mrow>
-                  </mml:mstyle>
-                </mml:mtd>
-              </mml:mtr>
-            </mml:mtable>
-          </mml:mrow>
-        </mml:mstyle>
-      </mml:math>
-    </disp-formula>
+                    <mml:mo>+</mml:mo>
+                    <mml:msub>
+                      <mml:mi>k</mml:mi>
+                      <mml:mrow>
+                        <mml:mo>−</mml:mo>
+                        <mml:mn>1</mml:mn>
+                      </mml:mrow>
+                    </mml:msub>
+                    <mml:mrow>
+                      <mml:mo>[</mml:mo>
+                      <mml:mrow>
+                        <mml:mi>R</mml:mi>
+                        <mml:mrow>
+                          <mml:mo>(</mml:mo>
+                          <mml:mrow>
+                            <mml:mn>1</mml:mn>
+                            <mml:mo>,</mml:mo>
+                            <mml:mn>0</mml:mn>
+                          </mml:mrow>
+                          <mml:mo>)</mml:mo>
+                        </mml:mrow>
+                      </mml:mrow>
+                      <mml:mo>]</mml:mo>
+                    </mml:mrow>
+                  </mml:mtd>
+                </mml:mtr>
+                <mml:mtr>
+                  <mml:mtd/>
+                  <mml:mtd>
+                    <mml:mo>+</mml:mo>
+                    <mml:mtext> </mml:mtext>
+                    <mml:mstyle mathcolor="red">
+                      <mml:msub>
+                        <mml:mi>k</mml:mi>
+                        <mml:mrow>
+                          <mml:mo>−</mml:mo>
+                          <mml:mn>2</mml:mn>
+                        </mml:mrow>
+                      </mml:msub>
+                      <mml:mrow>
+                        <mml:mo>[</mml:mo>
+                        <mml:mrow>
+                          <mml:mi>R</mml:mi>
+                          <mml:mrow>
+                            <mml:mo>(</mml:mo>
+                            <mml:mrow>
+                              <mml:mn>0</mml:mn>
+                              <mml:mo>,</mml:mo>
+                              <mml:mn>1</mml:mn>
+                            </mml:mrow>
+                            <mml:mo>)</mml:mo>
+                          </mml:mrow>
+                        </mml:mrow>
+                        <mml:mo>]</mml:mo>
+                      </mml:mrow>
+                    </mml:mstyle>
+                  </mml:mtd>
+                </mml:mtr>
+              </mml:mtable>
+            </mml:mrow>
+          </mml:mstyle>
+        </mml:math>
+      </disp-formula>
+    </table-wrap>
   </article>
 </root>

--- a/test/tests/gen/mathbackground-tests/final-mathbackground-test-2/fail.xml
+++ b/test/tests/gen/mathbackground-tests/final-mathbackground-test-2/fail.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="final-mathbackground-test-2.sch"?>
-<!--Context: mml:*
-Test: report    @mathbackground and ancestor::table-wrap
+<!--Context: mml:*[@mathbackground]
+Test: report    ancestor::table-wrap
 Message: math ( element) containing '' has '' colour background formatting. This likely means that there's a mistake in the content which will not render correctly online. If it's not a mistake, and the background colour is deliberate, then either the background colour will need to added to the table cell (rather than the maths), or it needs to be removed. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>

--- a/test/tests/gen/mathbackground-tests/final-mathbackground-test-2/final-mathbackground-test-2.sch
+++ b/test/tests/gen/mathbackground-tests/final-mathbackground-test-2/final-mathbackground-test-2.sch
@@ -790,13 +790,13 @@
     
   </xsl:function>
   <pattern id="house-style">
-    <rule context="mml:*" id="mathbackground-tests">
-      <report test="@mathbackground and ancestor::table-wrap" role="error" id="final-mathbackground-test-2">math (<value-of select="name()"/> element) containing '<value-of select="."/>' has '<value-of select="@mathbackground"/>' colour background formatting. This likely means that there's a mistake in the content which will not render correctly online. If it's not a mistake, and the background colour is deliberate, then either the background colour will need to added to the table cell (rather than the maths), or it needs to be removed.</report>
+    <rule context="mml:*[@mathbackground]" id="mathbackground-tests">
+      <report test="ancestor::table-wrap" role="error" id="final-mathbackground-test-2">math (<value-of select="name()"/> element) containing '<value-of select="."/>' has '<value-of select="@mathbackground"/>' colour background formatting. This likely means that there's a mistake in the content which will not render correctly online. If it's not a mistake, and the background colour is deliberate, then either the background colour will need to added to the table cell (rather than the maths), or it needs to be removed.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::mml:*" role="error" id="mathbackground-tests-xspec-assert">mml:* must be present.</assert>
+      <assert test="descendant::mml:*[@mathbackground]" role="error" id="mathbackground-tests-xspec-assert">mml:*[@mathbackground] must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/mathbackground-tests/final-mathbackground-test-2/pass.xml
+++ b/test/tests/gen/mathbackground-tests/final-mathbackground-test-2/pass.xml
@@ -1,10 +1,10 @@
 <?oxygen SCHSchema="final-mathbackground-test-2.sch"?>
-<!--Context: mml:*
-Test: report    @mathbackground and ancestor::table-wrap
+<!--Context: mml:*[@mathbackground]
+Test: report    ancestor::table-wrap
 Message: math ( element) containing '' has '' colour background formatting. This likely means that there's a mistake in the content which will not render correctly online. If it's not a mistake, and the background colour is deliberate, then either the background colour will need to added to the table cell (rather than the maths), or it needs to be removed. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>
-    <table-wrap>
+    
       <inline-formula id="equ27">
         <mml:math id="m27">
           <mml:mstyle displaystyle="true" scriptlevel="0">
@@ -14,6 +14,7 @@ Message: math ( element) containing '' has '' colour background formatting. This
                   <mml:mtd>
                     <mml:mfrac>
                       <mml:mrow>
+                        <mml:text mathcolor="red" mathbackground="yellow">\UpDelta</mml:text>
                         <mml:mi>d</mml:mi>
                         <mml:mrow>
                           <mml:mo>[</mml:mo>
@@ -212,6 +213,6 @@ Message: math ( element) containing '' has '' colour background formatting. This
           </mml:mstyle>
         </mml:math>
       </inline-formula>
-    </table-wrap>
+    
   </article>
 </root>

--- a/test/tests/gen/mathbackground-tests/pre-mathbackground-test-1/fail.xml
+++ b/test/tests/gen/mathbackground-tests/pre-mathbackground-test-1/fail.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="pre-mathbackground-test-1.sch"?>
-<!--Context: mml:*
-Test: report    @mathbackground and not(ancestor::table-wrap)
+<!--Context: mml:*[@mathbackground]
+Test: report    not(ancestor::table-wrap)
 Message: math ( element) containing '' has '' colour background formatting. This likely means that there's a mistake in the content which will not render correctly online. Please check this carefully against the original manuscript. If it's not a mistake, and the background colour is deliberate, then please add the following author query -> 'Where possible, we prefer that colours are not used in text in the interests of accessibility and because they will not display in downstream HTML (for example in PMC). eLife does not support background colours for text, however we do support the following colours for text itself - 'red', 'blue' and 'purple'. Please confirm how you would like the colour(s) captured here given this information, and note that our preference would be to use more common forms of emphasis (such as bold, italic or underline) if possible to still convey the same meaning.'. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>

--- a/test/tests/gen/mathbackground-tests/pre-mathbackground-test-1/pass.xml
+++ b/test/tests/gen/mathbackground-tests/pre-mathbackground-test-1/pass.xml
@@ -1,192 +1,139 @@
 <?oxygen SCHSchema="pre-mathbackground-test-1.sch"?>
-<!--Context: mml:*
-Test: report    @mathbackground and not(ancestor::table-wrap)
+<!--Context: mml:*[@mathbackground]
+Test: report    not(ancestor::table-wrap)
 Message: math ( element) containing '' has '' colour background formatting. This likely means that there's a mistake in the content which will not render correctly online. Please check this carefully against the original manuscript. If it's not a mistake, and the background colour is deliberate, then please add the following author query -> 'Where possible, we prefer that colours are not used in text in the interests of accessibility and because they will not display in downstream HTML (for example in PMC). eLife does not support background colours for text, however we do support the following colours for text itself - 'red', 'blue' and 'purple'. Please confirm how you would like the colour(s) captured here given this information, and note that our preference would be to use more common forms of emphasis (such as bold, italic or underline) if possible to still convey the same meaning.'. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>
-    <disp-formula id="equ27">
-      <mml:math id="m27">
-        <mml:mstyle displaystyle="true" scriptlevel="0">
-          <mml:mrow>
-            <mml:mtable columnalign="left left" columnspacing="1em" rowspacing="4pt">
-              <mml:mtr>
-                <mml:mtd>
-                  <mml:mfrac>
-                    <mml:mrow>
-                      <mml:mi>d</mml:mi>
+    <table-wrap>
+      <disp-formula id="equ27">
+        <mml:math id="m27">
+          <mml:mstyle displaystyle="true" scriptlevel="0">
+            <mml:mrow>
+              <mml:mtable columnalign="left left" columnspacing="1em" rowspacing="4pt">
+                <mml:mtr>
+                  <mml:mtd>
+                    <mml:mfrac>
                       <mml:mrow>
-                        <mml:mo>[</mml:mo>
+                        <mml:text mathcolor="red" mathbackground="yellow">\UpDelta</mml:text>
+                        <mml:mi>d</mml:mi>
                         <mml:mrow>
-                          <mml:mi>R</mml:mi>
+                          <mml:mo>[</mml:mo>
                           <mml:mrow>
-                            <mml:mo>(</mml:mo>
+                            <mml:mi>R</mml:mi>
                             <mml:mrow>
-                              <mml:mn>0</mml:mn>
-                              <mml:mo>,</mml:mo>
-                              <mml:mn>0</mml:mn>
+                              <mml:mo>(</mml:mo>
+                              <mml:mrow>
+                                <mml:mn>0</mml:mn>
+                                <mml:mo>,</mml:mo>
+                                <mml:mn>0</mml:mn>
+                              </mml:mrow>
+                              <mml:mo>)</mml:mo>
                             </mml:mrow>
-                            <mml:mo>)</mml:mo>
                           </mml:mrow>
+                          <mml:mo>]</mml:mo>
                         </mml:mrow>
-                        <mml:mo>]</mml:mo>
                       </mml:mrow>
-                    </mml:mrow>
-                    <mml:mrow>
-                      <mml:mi>d</mml:mi>
-                      <mml:mi>t</mml:mi>
-                    </mml:mrow>
-                  </mml:mfrac>
-                </mml:mtd>
-                <mml:mtd>
-                  <mml:mo>=</mml:mo>
-                  <mml:msub>
-                    <mml:mi>k</mml:mi>
-                    <mml:mrow>
-                      <mml:mi>r</mml:mi>
-                      <mml:mi>e</mml:mi>
-                      <mml:mi>p</mml:mi>
-                    </mml:mrow>
-                  </mml:msub>
-                  <mml:mrow>
-                    <mml:mo>[</mml:mo>
-                    <mml:mrow>
-                      <mml:mi>P</mml:mi>
-                      <mml:mn>0</mml:mn>
-                    </mml:mrow>
-                    <mml:mo>]</mml:mo>
-                  </mml:mrow>
-                  <mml:mo>−</mml:mo>
-                  <mml:mrow>
-                    <mml:mo>(</mml:mo>
-                    <mml:mrow>
                       <mml:mrow>
-                        <mml:mstyle mathcolor="blue">
-                          <mml:mrow>
-                            <mml:mi>r</mml:mi>
-                            <mml:mo>⋅</mml:mo>
-                            <mml:mi>u</mml:mi>
-                          </mml:mrow>
-                        </mml:mstyle>
+                        <mml:mi>d</mml:mi>
+                        <mml:mi>t</mml:mi>
                       </mml:mrow>
-                      <mml:mo>+</mml:mo>
-                      <mml:mtext> </mml:mtext>
-                      <mml:mn>5</mml:mn>
-                      <mml:mrow>
-                        <mml:mo>[</mml:mo>
-                        <mml:mrow>
-                          <mml:mi>C</mml:mi>
-                          <mml:msup>
-                            <mml:mi>a</mml:mi>
-                            <mml:mrow>
-                              <mml:mn>2</mml:mn>
-                              <mml:mo>+</mml:mo>
-                            </mml:mrow>
-                          </mml:msup>
-                        </mml:mrow>
-                        <mml:mo>]</mml:mo>
-                      </mml:mrow>
-                      <mml:msub>
-                        <mml:mi>k</mml:mi>
-                        <mml:mrow>
-                          <mml:mn>1</mml:mn>
-                        </mml:mrow>
-                      </mml:msub>
-                      <mml:mo>+</mml:mo>
-                      <mml:mrow>
-                        <mml:mstyle mathcolor="red">
-                          <mml:mn>2</mml:mn>
-                          <mml:mrow>
-                            <mml:mo>[</mml:mo>
-                            <mml:mrow>
-                              <mml:mi>C</mml:mi>
-                              <mml:msup>
-                                <mml:mi>a</mml:mi>
-                                <mml:mrow>
-                                  <mml:mn>2</mml:mn>
-                                  <mml:mo>+</mml:mo>
-                                </mml:mrow>
-                              </mml:msup>
-                            </mml:mrow>
-                            <mml:mo>]</mml:mo>
-                          </mml:mrow>
-                          <mml:msub>
-                            <mml:mi>k</mml:mi>
-                            <mml:mrow>
-                              <mml:mn>2</mml:mn>
-                            </mml:mrow>
-                          </mml:msub>
-                        </mml:mstyle>
-                      </mml:mrow>
-                      <mml:mo>+</mml:mo>
-                      <mml:msup>
-                        <mml:mi>L</mml:mi>
-                        <mml:mrow>
-                          <mml:mo>+</mml:mo>
-                        </mml:mrow>
-                      </mml:msup>
-                    </mml:mrow>
-                    <mml:mo>)</mml:mo>
-                  </mml:mrow>
-                </mml:mtd>
-              </mml:mtr>
-              <mml:mtr>
-                <mml:mtd/>
-                <mml:mtd>
-                  <mml:mrow>
-                    <mml:mo>[</mml:mo>
-                    <mml:mrow>
-                      <mml:mi>R</mml:mi>
-                      <mml:mrow>
-                        <mml:mo>(</mml:mo>
-                        <mml:mrow>
-                          <mml:mn>0</mml:mn>
-                          <mml:mo>,</mml:mo>
-                          <mml:mn>0</mml:mn>
-                        </mml:mrow>
-                        <mml:mo>)</mml:mo>
-                      </mml:mrow>
-                    </mml:mrow>
-                    <mml:mo>]</mml:mo>
-                  </mml:mrow>
-                  <mml:mo>+</mml:mo>
-                  <mml:msub>
-                    <mml:mi>k</mml:mi>
-                    <mml:mrow>
-                      <mml:mo>−</mml:mo>
-                      <mml:mn>1</mml:mn>
-                    </mml:mrow>
-                  </mml:msub>
-                  <mml:mrow>
-                    <mml:mo>[</mml:mo>
-                    <mml:mrow>
-                      <mml:mi>R</mml:mi>
-                      <mml:mrow>
-                        <mml:mo>(</mml:mo>
-                        <mml:mrow>
-                          <mml:mn>1</mml:mn>
-                          <mml:mo>,</mml:mo>
-                          <mml:mn>0</mml:mn>
-                        </mml:mrow>
-                        <mml:mo>)</mml:mo>
-                      </mml:mrow>
-                    </mml:mrow>
-                    <mml:mo>]</mml:mo>
-                  </mml:mrow>
-                </mml:mtd>
-              </mml:mtr>
-              <mml:mtr>
-                <mml:mtd/>
-                <mml:mtd>
-                  <mml:mo>+</mml:mo>
-                  <mml:mtext> </mml:mtext>
-                  <mml:mstyle mathcolor="red">
+                    </mml:mfrac>
+                  </mml:mtd>
+                  <mml:mtd>
+                    <mml:mo>=</mml:mo>
                     <mml:msub>
                       <mml:mi>k</mml:mi>
                       <mml:mrow>
-                        <mml:mo>−</mml:mo>
-                        <mml:mn>2</mml:mn>
+                        <mml:mi>r</mml:mi>
+                        <mml:mi>e</mml:mi>
+                        <mml:mi>p</mml:mi>
                       </mml:mrow>
                     </mml:msub>
+                    <mml:mrow>
+                      <mml:mo>[</mml:mo>
+                      <mml:mrow>
+                        <mml:mi>P</mml:mi>
+                        <mml:mn>0</mml:mn>
+                      </mml:mrow>
+                      <mml:mo>]</mml:mo>
+                    </mml:mrow>
+                    <mml:mo>−</mml:mo>
+                    <mml:mrow>
+                      <mml:mo>(</mml:mo>
+                      <mml:mrow>
+                        <mml:mrow>
+                          <mml:mstyle mathcolor="blue">
+                            <mml:mrow>
+                              <mml:mi>r</mml:mi>
+                              <mml:mo>⋅</mml:mo>
+                              <mml:mi>u</mml:mi>
+                            </mml:mrow>
+                          </mml:mstyle>
+                        </mml:mrow>
+                        <mml:mo>+</mml:mo>
+                        <mml:mtext> </mml:mtext>
+                        <mml:mn>5</mml:mn>
+                        <mml:mrow>
+                          <mml:mo>[</mml:mo>
+                          <mml:mrow>
+                            <mml:mi>C</mml:mi>
+                            <mml:msup>
+                              <mml:mi>a</mml:mi>
+                              <mml:mrow>
+                                <mml:mn>2</mml:mn>
+                                <mml:mo>+</mml:mo>
+                              </mml:mrow>
+                            </mml:msup>
+                          </mml:mrow>
+                          <mml:mo>]</mml:mo>
+                        </mml:mrow>
+                        <mml:msub>
+                          <mml:mi>k</mml:mi>
+                          <mml:mrow>
+                            <mml:mn>1</mml:mn>
+                          </mml:mrow>
+                        </mml:msub>
+                        <mml:mo>+</mml:mo>
+                        <mml:mrow>
+                          <mml:mstyle mathcolor="red">
+                            <mml:mn>2</mml:mn>
+                            <mml:mrow>
+                              <mml:mo>[</mml:mo>
+                              <mml:mrow>
+                                <mml:mi>C</mml:mi>
+                                <mml:msup>
+                                  <mml:mi>a</mml:mi>
+                                  <mml:mrow>
+                                    <mml:mn>2</mml:mn>
+                                    <mml:mo>+</mml:mo>
+                                  </mml:mrow>
+                                </mml:msup>
+                              </mml:mrow>
+                              <mml:mo>]</mml:mo>
+                            </mml:mrow>
+                            <mml:msub>
+                              <mml:mi>k</mml:mi>
+                              <mml:mrow>
+                                <mml:mn>2</mml:mn>
+                              </mml:mrow>
+                            </mml:msub>
+                          </mml:mstyle>
+                        </mml:mrow>
+                        <mml:mo>+</mml:mo>
+                        <mml:msup>
+                          <mml:mi>L</mml:mi>
+                          <mml:mrow>
+                            <mml:mo>+</mml:mo>
+                          </mml:mrow>
+                        </mml:msup>
+                      </mml:mrow>
+                      <mml:mo>)</mml:mo>
+                    </mml:mrow>
+                  </mml:mtd>
+                </mml:mtr>
+                <mml:mtr>
+                  <mml:mtd/>
+                  <mml:mtd>
                     <mml:mrow>
                       <mml:mo>[</mml:mo>
                       <mml:mrow>
@@ -196,20 +143,76 @@ Message: math ( element) containing '' has '' colour background formatting. This
                           <mml:mrow>
                             <mml:mn>0</mml:mn>
                             <mml:mo>,</mml:mo>
-                            <mml:mn>1</mml:mn>
+                            <mml:mn>0</mml:mn>
                           </mml:mrow>
                           <mml:mo>)</mml:mo>
                         </mml:mrow>
                       </mml:mrow>
                       <mml:mo>]</mml:mo>
                     </mml:mrow>
-                  </mml:mstyle>
-                </mml:mtd>
-              </mml:mtr>
-            </mml:mtable>
-          </mml:mrow>
-        </mml:mstyle>
-      </mml:math>
-    </disp-formula>
+                    <mml:mo>+</mml:mo>
+                    <mml:msub>
+                      <mml:mi>k</mml:mi>
+                      <mml:mrow>
+                        <mml:mo>−</mml:mo>
+                        <mml:mn>1</mml:mn>
+                      </mml:mrow>
+                    </mml:msub>
+                    <mml:mrow>
+                      <mml:mo>[</mml:mo>
+                      <mml:mrow>
+                        <mml:mi>R</mml:mi>
+                        <mml:mrow>
+                          <mml:mo>(</mml:mo>
+                          <mml:mrow>
+                            <mml:mn>1</mml:mn>
+                            <mml:mo>,</mml:mo>
+                            <mml:mn>0</mml:mn>
+                          </mml:mrow>
+                          <mml:mo>)</mml:mo>
+                        </mml:mrow>
+                      </mml:mrow>
+                      <mml:mo>]</mml:mo>
+                    </mml:mrow>
+                  </mml:mtd>
+                </mml:mtr>
+                <mml:mtr>
+                  <mml:mtd/>
+                  <mml:mtd>
+                    <mml:mo>+</mml:mo>
+                    <mml:mtext> </mml:mtext>
+                    <mml:mstyle mathcolor="red">
+                      <mml:msub>
+                        <mml:mi>k</mml:mi>
+                        <mml:mrow>
+                          <mml:mo>−</mml:mo>
+                          <mml:mn>2</mml:mn>
+                        </mml:mrow>
+                      </mml:msub>
+                      <mml:mrow>
+                        <mml:mo>[</mml:mo>
+                        <mml:mrow>
+                          <mml:mi>R</mml:mi>
+                          <mml:mrow>
+                            <mml:mo>(</mml:mo>
+                            <mml:mrow>
+                              <mml:mn>0</mml:mn>
+                              <mml:mo>,</mml:mo>
+                              <mml:mn>1</mml:mn>
+                            </mml:mrow>
+                            <mml:mo>)</mml:mo>
+                          </mml:mrow>
+                        </mml:mrow>
+                        <mml:mo>]</mml:mo>
+                      </mml:mrow>
+                    </mml:mstyle>
+                  </mml:mtd>
+                </mml:mtr>
+              </mml:mtable>
+            </mml:mrow>
+          </mml:mstyle>
+        </mml:math>
+      </disp-formula>
+    </table-wrap>
   </article>
 </root>

--- a/test/tests/gen/mathbackground-tests/pre-mathbackground-test-1/pre-mathbackground-test-1.sch
+++ b/test/tests/gen/mathbackground-tests/pre-mathbackground-test-1/pre-mathbackground-test-1.sch
@@ -790,13 +790,13 @@
     
   </xsl:function>
   <pattern id="house-style">
-    <rule context="mml:*" id="mathbackground-tests">
-      <report test="@mathbackground and not(ancestor::table-wrap)" role="warning" id="pre-mathbackground-test-1">math (<value-of select="name()"/> element) containing '<value-of select="."/>' has '<value-of select="@mathbackground"/>' colour background formatting. This likely means that there's a mistake in the content which will not render correctly online. Please check this carefully against the original manuscript. If it's not a mistake, and the background colour is deliberate, then please add the following author query -&gt; 'Where possible, we prefer that colours are not used in text in the interests of accessibility and because they will not display in downstream HTML (for example in PMC). eLife does not support background colours for text, however we do support the following colours for text itself - 'red', 'blue' and 'purple'. Please confirm how you would like the colour(s) captured here given this information, and note that our preference would be to use more common forms of emphasis (such as bold, italic or underline) if possible to still convey the same meaning.'.</report>
+    <rule context="mml:*[@mathbackground]" id="mathbackground-tests">
+      <report test="not(ancestor::table-wrap)" role="warning" id="pre-mathbackground-test-1">math (<value-of select="name()"/> element) containing '<value-of select="."/>' has '<value-of select="@mathbackground"/>' colour background formatting. This likely means that there's a mistake in the content which will not render correctly online. Please check this carefully against the original manuscript. If it's not a mistake, and the background colour is deliberate, then please add the following author query -&gt; 'Where possible, we prefer that colours are not used in text in the interests of accessibility and because they will not display in downstream HTML (for example in PMC). eLife does not support background colours for text, however we do support the following colours for text itself - 'red', 'blue' and 'purple'. Please confirm how you would like the colour(s) captured here given this information, and note that our preference would be to use more common forms of emphasis (such as bold, italic or underline) if possible to still convey the same meaning.'.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::mml:*" role="error" id="mathbackground-tests-xspec-assert">mml:* must be present.</assert>
+      <assert test="descendant::mml:*[@mathbackground]" role="error" id="mathbackground-tests-xspec-assert">mml:*[@mathbackground] must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/mathbackground-tests/pre-mathbackground-test-2/fail.xml
+++ b/test/tests/gen/mathbackground-tests/pre-mathbackground-test-2/fail.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="pre-mathbackground-test-2.sch"?>
-<!--Context: mml:*
-Test: report    @mathbackground and ancestor::table-wrap
+<!--Context: mml:*[@mathbackground]
+Test: report    ancestor::table-wrap
 Message: math ( element) containing '' has '' colour background formatting. This likely means that there's a mistake in the content which will not render correctly online. Please check this carefully against the original manuscript. If it's not a mistake, and the background colour is deliberate, then please ensure that the background colour is captured for the table cell (rather than the maths). -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>

--- a/test/tests/gen/mathbackground-tests/pre-mathbackground-test-2/pass.xml
+++ b/test/tests/gen/mathbackground-tests/pre-mathbackground-test-2/pass.xml
@@ -1,10 +1,10 @@
 <?oxygen SCHSchema="pre-mathbackground-test-2.sch"?>
-<!--Context: mml:*
-Test: report    @mathbackground and ancestor::table-wrap
+<!--Context: mml:*[@mathbackground]
+Test: report    ancestor::table-wrap
 Message: math ( element) containing '' has '' colour background formatting. This likely means that there's a mistake in the content which will not render correctly online. Please check this carefully against the original manuscript. If it's not a mistake, and the background colour is deliberate, then please ensure that the background colour is captured for the table cell (rather than the maths). -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>
-    <table-wrap>
+    
       <inline-formula id="equ27">
         <mml:math id="m27">
           <mml:mstyle displaystyle="true" scriptlevel="0">
@@ -14,6 +14,7 @@ Message: math ( element) containing '' has '' colour background formatting. This
                   <mml:mtd>
                     <mml:mfrac>
                       <mml:mrow>
+                        <mml:text mathcolor="red" mathbackground="yellow">\UpDelta</mml:text>
                         <mml:mi>d</mml:mi>
                         <mml:mrow>
                           <mml:mo>[</mml:mo>
@@ -212,6 +213,6 @@ Message: math ( element) containing '' has '' colour background formatting. This
           </mml:mstyle>
         </mml:math>
       </inline-formula>
-    </table-wrap>
+    
   </article>
 </root>

--- a/test/tests/gen/mathbackground-tests/pre-mathbackground-test-2/pre-mathbackground-test-2.sch
+++ b/test/tests/gen/mathbackground-tests/pre-mathbackground-test-2/pre-mathbackground-test-2.sch
@@ -790,13 +790,13 @@
     
   </xsl:function>
   <pattern id="house-style">
-    <rule context="mml:*" id="mathbackground-tests">
-      <report test="@mathbackground and ancestor::table-wrap" role="warning" id="pre-mathbackground-test-2">math (<value-of select="name()"/> element) containing '<value-of select="."/>' has '<value-of select="@mathbackground"/>' colour background formatting. This likely means that there's a mistake in the content which will not render correctly online. Please check this carefully against the original manuscript. If it's not a mistake, and the background colour is deliberate, then please ensure that the background colour is captured for the table cell (rather than the maths).</report>
+    <rule context="mml:*[@mathbackground]" id="mathbackground-tests">
+      <report test="ancestor::table-wrap" role="warning" id="pre-mathbackground-test-2">math (<value-of select="name()"/> element) containing '<value-of select="."/>' has '<value-of select="@mathbackground"/>' colour background formatting. This likely means that there's a mistake in the content which will not render correctly online. Please check this carefully against the original manuscript. If it's not a mistake, and the background colour is deliberate, then please ensure that the background colour is captured for the table cell (rather than the maths).</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::mml:*" role="error" id="mathbackground-tests-xspec-assert">mml:* must be present.</assert>
+      <assert test="descendant::mml:*[@mathbackground]" role="error" id="mathbackground-tests-xspec-assert">mml:*[@mathbackground] must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/sec-tests/sec-test-5/fail.xml
+++ b/test/tests/gen/sec-tests/sec-test-5/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="sec-test-5.sch"?>
 <!--Context: sec
 Test: report    count(ancestor::sec) ge 5
-Message: Level  sections are not allowed. Please either make this a level 5 heading, or capture the title as a bolded paragraph in its parent section. -->
+Message: Level  sections are not allowed. Please either make this a level 5 heading, or capture the title as a bolded paragraph in its parent section. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/article-structure#sec-test-5 -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>
     <sec id="s1-1">
@@ -10,89 +10,89 @@ Message: Level  sections are not allowed. Please either make this a level 5 head
         mutually exclusive exons, are the key for the choice to synthesize RQ or UQ. We find that
         one of the mutually exclusive exons is only found in the genomes of animals that synthesize
         RQ and that its inclusion remodels the core of the COQ-2 enzyme. We show that the removal
-        of&#x00A0;this exon abolishes almost all RQ biosynthesis in <italic>C. elegans</italic>.
+        of this exon abolishes almost all RQ biosynthesis in <italic>C. elegans</italic>.
         Finally, we find that inclusion of this RQ-specific exon expression is increased in the
-        stages of the parasite&#x00A0;life cycle where they encounter hypoxic conditions and
+        stages of the parasite life cycle where they encounter hypoxic conditions and
         increase RQ production, while the alternative exon is increased in normoxic life stages. We
         thus conclude that alternative splicing of COQ-2 is the key mechanism that causes the switch
-        from UQ to RQ synthesis in the parasite life&#x00A0;cycle.</p>
+        from UQ to RQ synthesis in the parasite life cycle.</p>
       <sec id="s1-1-1">
         <title>Test 2</title>
         <p>In this study, we reveal that two variants of COQ-2, derived from alternative splicing of
           mutually exclusive exons, are the key for the choice to synthesize RQ or UQ. We find that
           one of the mutually exclusive exons is only found in the genomes of animals that
           synthesize RQ and that its inclusion remodels the core of the COQ-2 enzyme. We show that
-          the removal of&#x00A0;this exon abolishes almost all RQ biosynthesis in <italic>C.
+          the removal of this exon abolishes almost all RQ biosynthesis in <italic>C.
             elegans</italic>. Finally, we find that inclusion of this RQ-specific exon expression is
-          increased in the stages of the parasite&#x00A0;life cycle where they encounter hypoxic
+          increased in the stages of the parasite life cycle where they encounter hypoxic
           conditions and increase RQ production, while the alternative exon is increased in normoxic
           life stages. We thus conclude that alternative splicing of COQ-2 is the key mechanism that
-          causes the switch from UQ to RQ synthesis in the parasite life&#x00A0;cycle.</p>
+          causes the switch from UQ to RQ synthesis in the parasite life cycle.</p>
         <sec id="s1-1-1-1">
           <title>Test 3</title>
           <p>In this study, we reveal that two variants of COQ-2, derived from alternative splicing
             of mutually exclusive exons, are the key for the choice to synthesize RQ or UQ. We find
             that one of the mutually exclusive exons is only found in the genomes of animals that
             synthesize RQ and that its inclusion remodels the core of the COQ-2 enzyme. We show that
-            the removal of&#x00A0;this exon abolishes almost all RQ biosynthesis in <italic>C.
+            the removal of this exon abolishes almost all RQ biosynthesis in <italic>C.
               elegans</italic>. Finally, we find that inclusion of this RQ-specific exon expression
-            is increased in the stages of the parasite&#x00A0;life cycle where they encounter
+            is increased in the stages of the parasite life cycle where they encounter
             hypoxic conditions and increase RQ production, while the alternative exon is increased
             in normoxic life stages. We thus conclude that alternative splicing of COQ-2 is the key
             mechanism that causes the switch from UQ to RQ synthesis in the parasite
-            life&#x00A0;cycle.</p>
+            life cycle.</p>
           <sec id="s1-1-1-1-1">
             <title>Test 4</title>
             <p>In this study, we reveal that two variants of COQ-2, derived from alternative
               splicing of mutually exclusive exons, are the key for the choice to synthesize RQ or
               UQ. We find that one of the mutually exclusive exons is only found in the genomes of
               animals that synthesize RQ and that its inclusion remodels the core of the COQ-2
-              enzyme. We show that the removal of&#x00A0;this exon abolishes almost all RQ
+              enzyme. We show that the removal of this exon abolishes almost all RQ
               biosynthesis in <italic>C. elegans</italic>. Finally, we find that inclusion of this
-              RQ-specific exon expression is increased in the stages of the parasite&#x00A0;life
+              RQ-specific exon expression is increased in the stages of the parasite life
               cycle where they encounter hypoxic conditions and increase RQ production, while the
               alternative exon is increased in normoxic life stages. We thus conclude that
               alternative splicing of COQ-2 is the key mechanism that causes the switch from UQ to
-              RQ synthesis in the parasite life&#x00A0;cycle.</p>
+              RQ synthesis in the parasite life cycle.</p>
             <sec id="s1-1-1-1-1-1">
               <title>Test 5</title>
               <p>In this study, we reveal that two variants of COQ-2, derived from alternative
                 splicing of mutually exclusive exons, are the key for the choice to synthesize RQ or
                 UQ. We find that one of the mutually exclusive exons is only found in the genomes of
                 animals that synthesize RQ and that its inclusion remodels the core of the COQ-2
-                enzyme. We show that the removal of&#x00A0;this exon abolishes almost all RQ
+                enzyme. We show that the removal of this exon abolishes almost all RQ
                 biosynthesis in <italic>C. elegans</italic>. Finally, we find that inclusion of this
-                RQ-specific exon expression is increased in the stages of the parasite&#x00A0;life
+                RQ-specific exon expression is increased in the stages of the parasite life
                 cycle where they encounter hypoxic conditions and increase RQ production, while the
                 alternative exon is increased in normoxic life stages. We thus conclude that
                 alternative splicing of COQ-2 is the key mechanism that causes the switch from UQ to
-                RQ synthesis in the parasite life&#x00A0;cycle.</p>
+                RQ synthesis in the parasite life cycle.</p>
               <sec id="s1-1-1-1-1-1-1">
                 <title>Test 6</title>
                 <p>In this study, we reveal that two variants of COQ-2, derived from alternative
                   splicing of mutually exclusive exons, are the key for the choice to synthesize RQ
                   or UQ. We find that one of the mutually exclusive exons is only found in the
                   genomes of animals that synthesize RQ and that its inclusion remodels the core of
-                  the COQ-2 enzyme. We show that the removal of&#x00A0;this exon abolishes almost
+                  the COQ-2 enzyme. We show that the removal of this exon abolishes almost
                   all RQ biosynthesis in <italic>C. elegans</italic>. Finally, we find that
                   inclusion of this RQ-specific exon expression is increased in the stages of the
-                  parasite&#x00A0;life cycle where they encounter hypoxic conditions and increase RQ
+                  parasite life cycle where they encounter hypoxic conditions and increase RQ
                   production, while the alternative exon is increased in normoxic life stages. We
                   thus conclude that alternative splicing of COQ-2 is the key mechanism that causes
-                  the switch from UQ to RQ synthesis in the parasite life&#x00A0;cycle.</p>
+                  the switch from UQ to RQ synthesis in the parasite life cycle.</p>
                 <sec id="s1-1-1-1-1-1-1-1">
                   <title>Test 7</title>
                   <p>In this study, we reveal that two variants of COQ-2, derived from alternative
                     splicing of mutually exclusive exons, are the key for the choice to synthesize
                     RQ or UQ. We find that one of the mutually exclusive exons is only found in the
                     genomes of animals that synthesize RQ and that its inclusion remodels the core
-                    of the COQ-2 enzyme. We show that the removal of&#x00A0;this exon abolishes
+                    of the COQ-2 enzyme. We show that the removal of this exon abolishes
                     almost all RQ biosynthesis in <italic>C. elegans</italic>. Finally, we find that
                     inclusion of this RQ-specific exon expression is increased in the stages of the
-                    parasite&#x00A0;life cycle where they encounter hypoxic conditions and increase
+                    parasite life cycle where they encounter hypoxic conditions and increase
                     RQ production, while the alternative exon is increased in normoxic life stages.
                     We thus conclude that alternative splicing of COQ-2 is the key mechanism that
-                    causes the switch from UQ to RQ synthesis in the parasite life&#x00A0;cycle.</p>
+                    causes the switch from UQ to RQ synthesis in the parasite life cycle.</p>
                 </sec>
               </sec>
             </sec>

--- a/test/tests/gen/sec-tests/sec-test-5/pass.xml
+++ b/test/tests/gen/sec-tests/sec-test-5/pass.xml
@@ -1,9 +1,8 @@
 <?oxygen SCHSchema="sec-test-5.sch"?>
 <!--Context: sec
 Test: report    count(ancestor::sec) ge 5
-Message: Level  sections are not allowed. Please either make this a level 5 heading, or capture the title as a bolded paragraph in its parent section. -->
-<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML"
-  xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+Message: Level  sections are not allowed. Please either make this a level 5 heading, or capture the title as a bolded paragraph in its parent section. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/article-structure#sec-test-5 -->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>
     <sec id="s1-1">
       <title>Test 1</title>
@@ -11,63 +10,63 @@ Message: Level  sections are not allowed. Please either make this a level 5 head
         mutually exclusive exons, are the key for the choice to synthesize RQ or UQ. We find that
         one of the mutually exclusive exons is only found in the genomes of animals that synthesize
         RQ and that its inclusion remodels the core of the COQ-2 enzyme. We show that the removal
-        of&#x00A0;this exon abolishes almost all RQ biosynthesis in <italic>C. elegans</italic>.
+        of this exon abolishes almost all RQ biosynthesis in <italic>C. elegans</italic>.
         Finally, we find that inclusion of this RQ-specific exon expression is increased in the
-        stages of the parasite&#x00A0;life cycle where they encounter hypoxic conditions and
+        stages of the parasite life cycle where they encounter hypoxic conditions and
         increase RQ production, while the alternative exon is increased in normoxic life stages. We
         thus conclude that alternative splicing of COQ-2 is the key mechanism that causes the switch
-        from UQ to RQ synthesis in the parasite life&#x00A0;cycle.</p>
+        from UQ to RQ synthesis in the parasite life cycle.</p>
       <sec id="s1-1-1">
         <title>Test 2</title>
         <p>In this study, we reveal that two variants of COQ-2, derived from alternative splicing of
           mutually exclusive exons, are the key for the choice to synthesize RQ or UQ. We find that
           one of the mutually exclusive exons is only found in the genomes of animals that
           synthesize RQ and that its inclusion remodels the core of the COQ-2 enzyme. We show that
-          the removal of&#x00A0;this exon abolishes almost all RQ biosynthesis in <italic>C.
+          the removal of this exon abolishes almost all RQ biosynthesis in <italic>C.
             elegans</italic>. Finally, we find that inclusion of this RQ-specific exon expression is
-          increased in the stages of the parasite&#x00A0;life cycle where they encounter hypoxic
+          increased in the stages of the parasite life cycle where they encounter hypoxic
           conditions and increase RQ production, while the alternative exon is increased in normoxic
           life stages. We thus conclude that alternative splicing of COQ-2 is the key mechanism that
-          causes the switch from UQ to RQ synthesis in the parasite life&#x00A0;cycle.</p>
+          causes the switch from UQ to RQ synthesis in the parasite life cycle.</p>
         <sec id="s1-1-1-1">
           <title>Test 3</title>
           <p>In this study, we reveal that two variants of COQ-2, derived from alternative splicing
             of mutually exclusive exons, are the key for the choice to synthesize RQ or UQ. We find
             that one of the mutually exclusive exons is only found in the genomes of animals that
             synthesize RQ and that its inclusion remodels the core of the COQ-2 enzyme. We show that
-            the removal of&#x00A0;this exon abolishes almost all RQ biosynthesis in <italic>C.
+            the removal of this exon abolishes almost all RQ biosynthesis in <italic>C.
               elegans</italic>. Finally, we find that inclusion of this RQ-specific exon expression
-            is increased in the stages of the parasite&#x00A0;life cycle where they encounter
+            is increased in the stages of the parasite life cycle where they encounter
             hypoxic conditions and increase RQ production, while the alternative exon is increased
             in normoxic life stages. We thus conclude that alternative splicing of COQ-2 is the key
             mechanism that causes the switch from UQ to RQ synthesis in the parasite
-            life&#x00A0;cycle.</p>
+            life cycle.</p>
           <sec id="s1-1-1-1-1">
             <title>Test 4</title>
             <p>In this study, we reveal that two variants of COQ-2, derived from alternative
               splicing of mutually exclusive exons, are the key for the choice to synthesize RQ or
               UQ. We find that one of the mutually exclusive exons is only found in the genomes of
               animals that synthesize RQ and that its inclusion remodels the core of the COQ-2
-              enzyme. We show that the removal of&#x00A0;this exon abolishes almost all RQ
+              enzyme. We show that the removal of this exon abolishes almost all RQ
               biosynthesis in <italic>C. elegans</italic>. Finally, we find that inclusion of this
-              RQ-specific exon expression is increased in the stages of the parasite&#x00A0;life
+              RQ-specific exon expression is increased in the stages of the parasite life
               cycle where they encounter hypoxic conditions and increase RQ production, while the
               alternative exon is increased in normoxic life stages. We thus conclude that
               alternative splicing of COQ-2 is the key mechanism that causes the switch from UQ to
-              RQ synthesis in the parasite life&#x00A0;cycle.</p>
+              RQ synthesis in the parasite life cycle.</p>
             <sec id="s1-1-1-1-1-1">
               <title>Test 5</title>
               <p>In this study, we reveal that two variants of COQ-2, derived from alternative
                 splicing of mutually exclusive exons, are the key for the choice to synthesize RQ or
                 UQ. We find that one of the mutually exclusive exons is only found in the genomes of
                 animals that synthesize RQ and that its inclusion remodels the core of the COQ-2
-                enzyme. We show that the removal of&#x00A0;this exon abolishes almost all RQ
+                enzyme. We show that the removal of this exon abolishes almost all RQ
                 biosynthesis in <italic>C. elegans</italic>. Finally, we find that inclusion of this
-                RQ-specific exon expression is increased in the stages of the parasite&#x00A0;life
+                RQ-specific exon expression is increased in the stages of the parasite life
                 cycle where they encounter hypoxic conditions and increase RQ production, while the
                 alternative exon is increased in normoxic life stages. We thus conclude that
                 alternative splicing of COQ-2 is the key mechanism that causes the switch from UQ to
-                RQ synthesis in the parasite life&#x00A0;cycle.</p>
+                RQ synthesis in the parasite life cycle.</p>
             </sec>
           </sec>
         </sec>

--- a/test/tests/gen/sec-tests/sec-test-5/sec-test-5.sch
+++ b/test/tests/gen/sec-tests/sec-test-5/sec-test-5.sch
@@ -792,7 +792,7 @@
   <pattern id="sec-specific">
     <rule context="sec" id="sec-tests">
       <let name="child-count" value="count(p) + count(sec) + count(fig) + count(fig-group) + count(media) + count(table-wrap) + count(boxed-text) + count(list) + count(fn-group) + count(supplementary-material) + count(related-object)"/>
-      <report test="count(ancestor::sec) ge 5" role="error" id="sec-test-5">Level <value-of select="count(ancestor::sec) + 1"/> sections are not allowed. Please either make this a level 5 heading, or capture the title as a bolded paragraph in its parent section.</report>
+      <report test="count(ancestor::sec) ge 5" role="error" id="sec-test-5">Level <value-of select="count(ancestor::sec) + 1"/> sections are not allowed. Please either make this a level 5 heading, or capture the title as a bolded paragraph in its parent section. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/article-structure#sec-test-5</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/xspec/schematron.sch
+++ b/test/xspec/schematron.sch
@@ -3245,7 +3245,7 @@
       
       <assert test="$child-count gt 0" role="error" id="sec-test-2">sec appears to contain no content. This cannot be correct.</assert>
       
-      <report test="count(ancestor::sec) ge 5" role="error" id="sec-test-5">Level <value-of select="count(ancestor::sec) + 1"/> sections are not allowed. Please either make this a level 5 heading, or capture the title as a bolded paragraph in its parent section.</report>
+      <report test="count(ancestor::sec) ge 5" role="error" id="sec-test-5">Level <value-of select="count(ancestor::sec) + 1"/> sections are not allowed. Please either make this a level 5 heading, or capture the title as a bolded paragraph in its parent section. More info here - https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/article-structure#sec-test-5</report>
     </rule>
   </pattern>
   <pattern id="res-data-sec-pattern">
@@ -6996,15 +6996,15 @@
     </rule>
   </pattern>
   <pattern id="mathbackground-tests-pattern">
-    <rule context="mml:*" id="mathbackground-tests">
+    <rule context="mml:*[@mathbackground]" id="mathbackground-tests">
       
-      <report test="@mathbackground and not(ancestor::table-wrap)" role="warning" id="pre-mathbackground-test-1">math (<value-of select="name()"/> element) containing '<value-of select="."/>' has '<value-of select="@mathbackground"/>' colour background formatting. This likely means that there's a mistake in the content which will not render correctly online. Please check this carefully against the original manuscript. If it's not a mistake, and the background colour is deliberate, then please add the following author query -&gt; 'Where possible, we prefer that colours are not used in text in the interests of accessibility and because they will not display in downstream HTML (for example in PMC). eLife does not support background colours for text, however we do support the following colours for text itself - 'red', 'blue' and 'purple'. Please confirm how you would like the colour(s) captured here given this information, and note that our preference would be to use more common forms of emphasis (such as bold, italic or underline) if possible to still convey the same meaning.'.</report>
+      <report test="not(ancestor::table-wrap)" role="warning" id="pre-mathbackground-test-1">math (<value-of select="name()"/> element) containing '<value-of select="."/>' has '<value-of select="@mathbackground"/>' colour background formatting. This likely means that there's a mistake in the content which will not render correctly online. Please check this carefully against the original manuscript. If it's not a mistake, and the background colour is deliberate, then please add the following author query -&gt; 'Where possible, we prefer that colours are not used in text in the interests of accessibility and because they will not display in downstream HTML (for example in PMC). eLife does not support background colours for text, however we do support the following colours for text itself - 'red', 'blue' and 'purple'. Please confirm how you would like the colour(s) captured here given this information, and note that our preference would be to use more common forms of emphasis (such as bold, italic or underline) if possible to still convey the same meaning.'.</report>
       
-      <report test="@mathbackground and ancestor::table-wrap" role="warning" id="pre-mathbackground-test-2">math (<value-of select="name()"/> element) containing '<value-of select="."/>' has '<value-of select="@mathbackground"/>' colour background formatting. This likely means that there's a mistake in the content which will not render correctly online. Please check this carefully against the original manuscript. If it's not a mistake, and the background colour is deliberate, then please ensure that the background colour is captured for the table cell (rather than the maths).</report>
+      <report test="ancestor::table-wrap" role="warning" id="pre-mathbackground-test-2">math (<value-of select="name()"/> element) containing '<value-of select="."/>' has '<value-of select="@mathbackground"/>' colour background formatting. This likely means that there's a mistake in the content which will not render correctly online. Please check this carefully against the original manuscript. If it's not a mistake, and the background colour is deliberate, then please ensure that the background colour is captured for the table cell (rather than the maths).</report>
       
-      <report test="@mathbackground and not(ancestor::table-wrap)" role="error" id="final-mathbackground-test-1">math (<value-of select="name()"/> element) containing '<value-of select="."/>' has '<value-of select="@mathbackground"/>' colour background formatting. This likely means that there's a mistake in the content which will not render correctly online. If it's not a mistake, and the background colour is deliberate, then this will need to removed.</report>
+      <report test="not(ancestor::table-wrap)" role="error" id="final-mathbackground-test-1">math (<value-of select="name()"/> element) containing '<value-of select="."/>' has '<value-of select="@mathbackground"/>' colour background formatting. This likely means that there's a mistake in the content which will not render correctly online. If it's not a mistake, and the background colour is deliberate, then this will need to removed.</report>
       
-      <report test="@mathbackground and ancestor::table-wrap" role="error" id="final-mathbackground-test-2">math (<value-of select="name()"/> element) containing '<value-of select="."/>' has '<value-of select="@mathbackground"/>' colour background formatting. This likely means that there's a mistake in the content which will not render correctly online. If it's not a mistake, and the background colour is deliberate, then either the background colour will need to added to the table cell (rather than the maths), or it needs to be removed.</report>
+      <report test="ancestor::table-wrap" role="error" id="final-mathbackground-test-2">math (<value-of select="name()"/> element) containing '<value-of select="."/>' has '<value-of select="@mathbackground"/>' colour background formatting. This likely means that there's a mistake in the content which will not render correctly online. If it's not a mistake, and the background colour is deliberate, then either the background colour will need to added to the table cell (rather than the maths), or it needs to be removed.</report>
       
     </rule>
   </pattern>
@@ -7991,7 +7991,7 @@
       <assert test="descendant::th[@style] or descendant::td[@style]" role="error" id="colour-table-2-xspec-assert">th[@style]|td[@style] must be present.</assert>
       <assert test="descendant::named-content" role="error" id="colour-named-content-xspec-assert">named-content must be present.</assert>
       <assert test="descendant::mml:*[@mathcolor]" role="error" id="math-colour-tests-xspec-assert">mml:*[@mathcolor] must be present.</assert>
-      <assert test="descendant::mml:*" role="error" id="mathbackground-tests-xspec-assert">mml:* must be present.</assert>
+      <assert test="descendant::mml:*[@mathbackground]" role="error" id="mathbackground-tests-xspec-assert">mml:*[@mathbackground] must be present.</assert>
       <assert test="descendant::mml:mtext" role="error" id="mtext-tests-xspec-assert">mml:mtext must be present.</assert>
       <assert test="descendant::article/body//p[not(parent::list-item)]" role="error" id="p-punctuation-xspec-assert">article/body//p[not(parent::list-item)] must be present.</assert>
       <assert test="descendant::italic[not(ancestor::ref)]" role="error" id="italic-house-style-xspec-assert">italic[not(ancestor::ref)] must be present.</assert>


### PR DESCRIPTION
- Only fire `mathbackground-tests` on elements with that attribute, in order to reduce number of tests carried out.
- Add GitHub link for `sec-test-5`.