### PR TITLE
improvement: attribute conformance

### DIFF
--- a/src/final-JATS-schematron.sch
+++ b/src/final-JATS-schematron.sch
@@ -6269,7 +6269,7 @@
     <rule context="element-citation[@publication-type='web']" id="website-tests">
       <let name="link" value="lower-case(ext-link[1])"/>
       
-      <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/references/software-references#github-web-test" test="contains($link,'github')" role="warning" id="github-web-test">[github-web-test] web ref '<value-of select="ancestor::ref/@id"/>' has a link which contains 'github', therefore it should almost certainly be captured as a software ref (unless it's a blog post by GitHub).</report>
+      <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/references/software-references#github-web-test" test="contains($link,'github') and not(contains($link,'github.io'))" role="warning" id="github-web-test">[github-web-test] web ref '<value-of select="ancestor::ref/@id"/>' has a link which contains 'github', therefore it should almost certainly be captured as a software ref (unless it's a blog post by GitHub).</report>
       
       <report test="matches(.,'�')" role="error" id="webreplacement-character-presence">[webreplacement-character-presence] web citation contains the replacement character '�' which is unallowed - <value-of select="."/>
       </report>
@@ -7232,6 +7232,15 @@
       <let name="allowed-elements" value="('abstract', 'ack', 'addr-line', 'aff', 'ali:free_to_read', 'ali:license_ref', 'app', 'app-group', 'article', 'article-categories', 'article-id', 'article-meta', 'article-title', 'attrib', 'author-notes', 'award-group', 'award-id', 'back', 'bio', 'body', 'bold', 'boxed-text', 'break', 'caption', 'chapter-title', 'code', 'collab', 'comment', 'conf-date', 'conf-loc', 'conf-name', 'contrib', 'contrib-group', 'contrib-id', 'copyright-holder', 'copyright-statement', 'copyright-year', 'corresp', 'country', 'custom-meta', 'custom-meta-group', 'data-title', 'date', 'date-in-citation', 'day', 'disp-formula', 'disp-quote', 'edition', 'element-citation', 'elocation-id', 'email', 'ext-link', 'fig', 'fig-group', 'fn', 'fn-group', 'fpage', 'front', 'front-stub', 'funding-group', 'funding-source', 'funding-statement', 'given-names', 'graphic', 'history', 'inline-formula', 'inline-graphic', 'institution', 'institution-id', 'institution-wrap', 'issn', 'issue', 'italic', 'journal-id', 'journal-meta', 'journal-title', 'journal-title-group', 'kwd', 'kwd-group', 'label', 'license', 'license-p', 'list', 'list-item', 'lpage', 'media', 'meta-name', 'meta-value', 'mml:math', 'monospace', 'month', 'name', 'named-content', 'on-behalf-of', 'p', 'patent', 'permissions', 'person-group', 'principal-award-recipient', 'pub-date', 'pub-id', 'publisher', 'publisher-loc', 'publisher-name', 'ref', 'ref-list', 'related-article', 'related-object', 'role', 'sc', 'sec', 'self-uri', 'source', 'strike', 'string-date', 'string-name', 'styled-content', 'sub', 'sub-article', 'subj-group', 'subject', 'suffix', 'sup', 'supplementary-material', 'surname', 'table', 'table-wrap', 'table-wrap-foot', 'tbody', 'td', 'th', 'thead', 'title', 'title-group', 'tr', 'underline', 'version', 'volume', 'xref', 'year')"/>
       
       <assert test="name()=$allowed-elements" role="error" id="element-conformity">[element-conformity] <value-of select="name()"/> element is not allowed.</assert>
+      
+    </rule>
+  </pattern>
+  
+  <pattern id="empty-attribute-test-pattern">
+    <rule context="*[@*/normalize-space(.)='']" id="empty-attribute-test">
+      
+      <report test="." role="error" id="empty-attribute-conformance">[empty-attribute-conformance] <value-of select="name()"/> element has attribute(s) with an empty value. &lt;<value-of select="name()"/>
+        <value-of select="for $att in ./@*[normalize-space(.)=''] return concat(' ',$att/name(),'=&quot;',$att,'&quot;')"/>&gt;</report>
       
     </rule>
   </pattern>

--- a/src/final-package-JATS-schematron.sch
+++ b/src/final-package-JATS-schematron.sch
@@ -6592,7 +6592,7 @@
     <rule context="element-citation[@publication-type='web']" id="website-tests">
       <let name="link" value="lower-case(ext-link[1])"/>
       
-      <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/references/software-references#github-web-test" test="contains($link,'github')" role="warning" id="github-web-test">web ref '<value-of select="ancestor::ref/@id"/>' has a link which contains 'github', therefore it should almost certainly be captured as a software ref (unless it's a blog post by GitHub).</report>
+      <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/references/software-references#github-web-test" test="contains($link,'github') and not(contains($link,'github.io'))" role="warning" id="github-web-test">web ref '<value-of select="ancestor::ref/@id"/>' has a link which contains 'github', therefore it should almost certainly be captured as a software ref (unless it's a blog post by GitHub).</report>
       
       <report test="matches(.,'�')" role="error" id="webreplacement-character-presence">web citation contains the replacement character '�' which is unallowed - <value-of select="."/>
       </report>
@@ -7682,6 +7682,16 @@
       
       <assert test="name()=$allowed-elements" role="error" id="element-conformity">
         <value-of select="name()"/> element is not allowed.</assert>
+      
+    </rule>
+  </pattern>
+  
+  <pattern id="empty-attribute-test-pattern">
+    <rule context="*[@*/normalize-space(.)='']" id="empty-attribute-test">
+      
+      <report test="." role="error" id="empty-attribute-conformance">
+        <value-of select="name()"/> element has attribute(s) with an empty value. &lt;<value-of select="name()"/>
+        <value-of select="for $att in ./@*[normalize-space(.)=''] return concat(' ',$att/name(),'=&quot;',$att,'&quot;')"/>&gt;</report>
       
     </rule>
   </pattern>

--- a/src/pre-JATS-schematron.sch
+++ b/src/pre-JATS-schematron.sch
@@ -6267,7 +6267,7 @@
     <rule context="element-citation[@publication-type='web']" id="website-tests">
       <let name="link" value="lower-case(ext-link[1])"/>
       
-      <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/references/software-references#github-web-test" test="contains($link,'github')" role="warning" id="github-web-test">[github-web-test] web ref '<value-of select="ancestor::ref/@id"/>' has a link which contains 'github', therefore it should almost certainly be captured as a software ref (unless it's a blog post by GitHub).</report>
+      <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/references/software-references#github-web-test" test="contains($link,'github') and not(contains($link,'github.io'))" role="warning" id="github-web-test">[github-web-test] web ref '<value-of select="ancestor::ref/@id"/>' has a link which contains 'github', therefore it should almost certainly be captured as a software ref (unless it's a blog post by GitHub).</report>
       
       <report test="matches(.,'�')" role="error" id="webreplacement-character-presence">[webreplacement-character-presence] web citation contains the replacement character '�' which is unallowed - <value-of select="."/>
       </report>
@@ -7230,6 +7230,15 @@
       <let name="allowed-elements" value="('abstract', 'ack', 'addr-line', 'aff', 'ali:free_to_read', 'ali:license_ref', 'app', 'app-group', 'article', 'article-categories', 'article-id', 'article-meta', 'article-title', 'attrib', 'author-notes', 'award-group', 'award-id', 'back', 'bio', 'body', 'bold', 'boxed-text', 'break', 'caption', 'chapter-title', 'code', 'collab', 'comment', 'conf-date', 'conf-loc', 'conf-name', 'contrib', 'contrib-group', 'contrib-id', 'copyright-holder', 'copyright-statement', 'copyright-year', 'corresp', 'country', 'custom-meta', 'custom-meta-group', 'data-title', 'date', 'date-in-citation', 'day', 'disp-formula', 'disp-quote', 'edition', 'element-citation', 'elocation-id', 'email', 'ext-link', 'fig', 'fig-group', 'fn', 'fn-group', 'fpage', 'front', 'front-stub', 'funding-group', 'funding-source', 'funding-statement', 'given-names', 'graphic', 'history', 'inline-formula', 'inline-graphic', 'institution', 'institution-id', 'institution-wrap', 'issn', 'issue', 'italic', 'journal-id', 'journal-meta', 'journal-title', 'journal-title-group', 'kwd', 'kwd-group', 'label', 'license', 'license-p', 'list', 'list-item', 'lpage', 'media', 'meta-name', 'meta-value', 'mml:math', 'monospace', 'month', 'name', 'named-content', 'on-behalf-of', 'p', 'patent', 'permissions', 'person-group', 'principal-award-recipient', 'pub-date', 'pub-id', 'publisher', 'publisher-loc', 'publisher-name', 'ref', 'ref-list', 'related-article', 'related-object', 'role', 'sc', 'sec', 'self-uri', 'source', 'strike', 'string-date', 'string-name', 'styled-content', 'sub', 'sub-article', 'subj-group', 'subject', 'suffix', 'sup', 'supplementary-material', 'surname', 'table', 'table-wrap', 'table-wrap-foot', 'tbody', 'td', 'th', 'thead', 'title', 'title-group', 'tr', 'underline', 'version', 'volume', 'xref', 'year')"/>
       
       <assert test="name()=$allowed-elements" role="error" id="element-conformity">[element-conformity] <value-of select="name()"/> element is not allowed.</assert>
+      
+    </rule>
+  </pattern>
+  
+  <pattern id="empty-attribute-test-pattern">
+    <rule context="*[@*/normalize-space(.)='']" id="empty-attribute-test">
+      
+      <report test="." role="error" id="empty-attribute-conformance">[empty-attribute-conformance] <value-of select="name()"/> element has attribute(s) with an empty value. &lt;<value-of select="name()"/>
+        <value-of select="for $att in ./@*[normalize-space(.)=''] return concat(' ',$att/name(),'=&quot;',$att,'&quot;')"/>&gt;</report>
       
     </rule>
   </pattern>

--- a/src/schematron.sch
+++ b/src/schematron.sch
@@ -9391,7 +9391,7 @@ tokenize(substring-after($text,' et al'),' ')[2]
       <let name="link" value="lower-case(ext-link[1])"/>
       
       <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/references/software-references#github-web-test" 
-        test="contains($link,'github')" 
+        test="contains($link,'github') and not(contains($link,'github.io'))" 
         role="warning" 
         id="github-web-test">web ref '<value-of select="ancestor::ref/@id"/>' has a link which contains 'github', therefore it should almost certainly be captured as a software ref (unless it's a blog post by GitHub).</report>
       
@@ -11203,6 +11203,17 @@ tokenize(substring-after($text,' et al'),' ')[2]
       <assert test="name()=$allowed-elements" 
         role="error" 
         id="element-conformity"><value-of select="name()"/> element is not allowed.</assert>
+      
+    </rule>
+  </pattern>
+  
+  <pattern id="empty-attribute-pattern">
+    
+    <rule context="*[@*/normalize-space(.)='']" id="empty-attribute-test">
+      
+      <report test="." 
+        role="error" 
+        id="empty-attribute-conformance"><value-of select="name()"/> element has attribute(s) with an empty value. &lt;<value-of select="name()"/><value-of select="for $att in ./@*[normalize-space(.)=''] return concat(' ',$att/name(),'=&quot;',$att,'&quot;')"/>></report>
       
     </rule>
   </pattern>

--- a/test/tests/gen/empty-attribute-test/empty-attribute-conformance/empty-attribute-conformance.sch
+++ b/test/tests/gen/empty-attribute-test/empty-attribute-conformance/empty-attribute-conformance.sch
@@ -789,15 +789,11 @@
     <xsl:sequence select="count(tokenize($arg,'(\r\n?|\n\r?)'))"/>
     
   </xsl:function>
-  <pattern id="house-style">
-    <rule context="element-citation[@publication-type='web']" id="website-tests">
-      <let name="link" value="lower-case(ext-link[1])"/>
-      <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/references/software-references#github-web-test" test="contains($link,'github') and not(contains($link,'github.io'))" role="warning" id="github-web-test">web ref '<value-of select="ancestor::ref/@id"/>' has a link which contains 'github', therefore it should almost certainly be captured as a software ref (unless it's a blog post by GitHub).</report>
-    </rule>
-  </pattern>
-  <pattern id="root-pattern">
-    <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation[@publication-type='web']" role="error" id="website-tests-xspec-assert">element-citation[@publication-type='web'] must be present.</assert>
+  <pattern id="empty-attribute-pattern">
+    <rule context="*[@*/normalize-space(.)='']" id="empty-attribute-test">
+      <report test="." role="error" id="empty-attribute-conformance">
+        <value-of select="name()"/> element has attribute(s) with an empty value. &lt;<value-of select="name()"/>
+        <value-of select="for $att in ./@*[normalize-space(.)=''] return concat(' ',$att/name(),'=&quot;',$att,'&quot;')"/>&gt;</report>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/empty-attribute-test/empty-attribute-conformance/fail.xml
+++ b/test/tests/gen/empty-attribute-test/empty-attribute-conformance/fail.xml
@@ -1,0 +1,8 @@
+<?oxygen SCHSchema="empty-attribute-conformance.sch"?>
+<!--Context: *[@*/normalize-space(.)='']
+Test: report    .
+Message:  element has attribute(s) with an empty value. <> -->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article article-type=""/>
+  <article article-type="        "/>
+</root>

--- a/test/tests/gen/empty-attribute-test/empty-attribute-conformance/pass.xml
+++ b/test/tests/gen/empty-attribute-test/empty-attribute-conformance/pass.xml
@@ -1,0 +1,7 @@
+<?oxygen SCHSchema="empty-attribute-conformance.sch"?>
+<!--Context: *[@*/normalize-space(.)='']
+Test: report    .
+Message:  element has attribute(s) with an empty value. <> -->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article article-type="test"/>
+</root>

--- a/test/tests/gen/website-tests/github-web-test/fail.xml
+++ b/test/tests/gen/website-tests/github-web-test/fail.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="github-web-test.sch"?>
 <!--Context: element-citation[@publication-type='web']
-Test: report    contains($link,'github')
+Test: report    contains($link,'github') and not(contains($link,'github.io'))
 Message: web ref '' has a link which contains 'github', therefore it should almost certainly be captured as a software ref (unless it's a blog post by GitHub). -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>

--- a/test/tests/gen/website-tests/github-web-test/pass.xml
+++ b/test/tests/gen/website-tests/github-web-test/pass.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="github-web-test.sch"?>
 <!--Context: element-citation[@publication-type='web']
-Test: report    contains($link,'github')
+Test: report    contains($link,'github') and not(contains($link,'github.io'))
 Message: web ref '' has a link which contains 'github', therefore it should almost certainly be captured as a software ref (unless it's a blog post by GitHub). -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>

--- a/test/xspec/schematron.sch
+++ b/test/xspec/schematron.sch
@@ -6593,7 +6593,7 @@
     <rule context="element-citation[@publication-type='web']" id="website-tests">
       <let name="link" value="lower-case(ext-link[1])"/>
       
-      <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/references/software-references#github-web-test" test="contains($link,'github')" role="warning" id="github-web-test">web ref '<value-of select="ancestor::ref/@id"/>' has a link which contains 'github', therefore it should almost certainly be captured as a software ref (unless it's a blog post by GitHub).</report>
+      <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/references/software-references#github-web-test" test="contains($link,'github') and not(contains($link,'github.io'))" role="warning" id="github-web-test">web ref '<value-of select="ancestor::ref/@id"/>' has a link which contains 'github', therefore it should almost certainly be captured as a software ref (unless it's a blog post by GitHub).</report>
       
       <report test="matches(.,'�')" role="error" id="webreplacement-character-presence">web citation contains the replacement character '�' which is unallowed - <value-of select="."/>
       </report>
@@ -7702,6 +7702,16 @@
       
       <assert test="name()=$allowed-elements" role="error" id="element-conformity">
         <value-of select="name()"/> element is not allowed.</assert>
+      
+    </rule>
+  </pattern>
+  
+  <pattern id="empty-attribute-test-pattern">
+    <rule context="*[@*/normalize-space(.)='']" id="empty-attribute-test">
+      
+      <report test="." role="error" id="empty-attribute-conformance">
+        <value-of select="name()"/> element has attribute(s) with an empty value. &lt;<value-of select="name()"/>
+        <value-of select="for $att in ./@*[normalize-space(.)=''] return concat(' ',$att/name(),'=&quot;',$att,'&quot;')"/>&gt;</report>
       
     </rule>
   </pattern>

--- a/test/xspec/schematron.xspec
+++ b/test/xspec/schematron.xspec
@@ -17452,5 +17452,17 @@
         <x:expect-not-assert id="element-allowlist-xspec-assert" role="error"/>
       </x:scenario>
     </x:scenario>
+    <x:scenario label="empty-attribute-test">
+      <x:scenario label="empty-attribute-conformance-pass">
+        <x:context href="../tests/gen/empty-attribute-test/empty-attribute-conformance/pass.xml"/>
+        <x:expect-not-report id="empty-attribute-conformance" role="error"/>
+        <x:expect-not-assert id="empty-attribute-test-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="empty-attribute-conformance-fail">
+        <x:context href="../tests/gen/empty-attribute-test/empty-attribute-conformance/fail.xml"/>
+        <x:expect-report id="empty-attribute-conformance" role="error"/>
+        <x:expect-not-assert id="empty-attribute-test-xspec-assert" role="error"/>
+      </x:scenario>
+    </x:scenario>
   </x:scenario>
 </x:description>

--- a/validator/webapp/validator.xqm
+++ b/validator/webapp/validator.xqm
@@ -198,7 +198,7 @@ declare function e:json-escape($string){
 };
 
 declare function e:get-message($node){
-  if ($node[@see]) then (e:json-escape(data($node))||' <a href=\"'||$node/@see||'\">'||$node/@see||'</a>')
+  if ($node[@see]) then e:json-escape((data($node)||' '||$node/@see))
   else e:json-escape(data($node))
 };
 

--- a/xquery/elife.xqm
+++ b/xquery/elife.xqm
@@ -57,7 +57,7 @@ return delete node $x,
             else <assert test="{concat('descendant::',$test)}" role="error" id="{concat($rule/@id,'-xspec-assert')}">{$test} must be present.</assert> 
     
     return 
-    if ($id=('pre-colour-styled-content-check','final-colour-styled-content-check','final-strike-flag','permissions-notification')) then ()
+    if ($id=('pre-colour-styled-content-check','final-colour-styled-content-check','final-strike-flag','permissions-notification','empty-attribute-conformance')) then ()
     else insert node 
         <pattern id="root-pattern">
         <rule context="root" id="root-rule">
@@ -231,7 +231,7 @@ declare function elife:sch2xspec-sch($sch){
          let $r := 
              <pattern id="root-pattern">
                 <rule context="root" id="root-rule">{
-                for $z in $t//sch:rule[not(@id=("missing-ref-cited","strike-tests","colour-styled-content"))]
+                for $z in $t//sch:rule[not(@id=("missing-ref-cited","strike-tests","colour-styled-content","empty-attribute-test"))]
                 let $test := $z/@context/string()
                 return
                 if (matches($test,'\|')) then (


### PR DESCRIPTION
- Don't permit empty attributes - `empty-attribute-conformance`.
- Don't fire `github-web-test` for github.io links.
- Validator posts GitHub links as plain text