### PR TITLE
improvement: diacritic test

### DIFF
--- a/src/final-JATS-schematron.sch
+++ b/src/final-JATS-schematron.sch
@@ -1256,6 +1256,15 @@
 		
 		</rule>
   </pattern>
+  <pattern id="corresp-author-initial-tests-pattern">
+    <rule context="article[@article-type=('research-article','review-article','discussion')]//article-meta[not(descendant::custom-meta[meta-name='Template']/meta-value='3')]/contrib-group[1][count(contrib[@contrib-type='author' and @corresp='yes']) gt 1]/contrib[@contrib-type='author' and @corresp='yes' and name]" id="corresp-author-initial-tests">
+      <let name="name" value="e:get-name(name)"/>
+      <let name="normalized-name" value="e:stripDiacritics($name)"/>
+      
+      <report test="$normalized-name != $name" role="warning" id="corresp-author-initial-test">[corresp-author-initial-test] <value-of select="$name"/> has a name with letters that have diacritics or marks. Please ensure that their initials display correctly in the PDF in the 'For correspondence' section on the first page.</report>
+      
+    </rule>
+  </pattern>
   <pattern id="author-children-tests-pattern">
     <rule context="article-meta//contrib[@contrib-type='author']/*" id="author-children-tests">
 		  <let name="article-type" value="ancestor::article/@article-type"/> 
@@ -5020,7 +5029,7 @@
   <pattern id="digest-tests-pattern">
     <rule context="front//abstract[@abstract-type='executive-summary']/p" id="digest-tests">
      
-     <report test="matches(.,'^\p{Ll}')" role="warning" id="digest-test-1">[digest-test-1] digest paragraph starts with a lowercase letter. Is that correct? Or has a paragraph been incorrect split into two? If the latter is the case, the features team will have to be notified so that they can update the word doc for the digest channel.</report>
+     <report test="matches(.,'^\p{Ll}')" role="warning" id="digest-test-1">[digest-test-1] digest paragraph starts with a lowercase letter. Is that correct? Or has a paragraph been incorrect split into two?</report>
      
    </rule>
   </pattern>

--- a/src/final-package-JATS-schematron.sch
+++ b/src/final-package-JATS-schematron.sch
@@ -1272,6 +1272,16 @@
 		
 		</rule>
   </pattern>
+  <pattern id="corresp-author-initial-tests-pattern">
+    <rule context="article[@article-type=('research-article','review-article','discussion')]//article-meta[not(descendant::custom-meta[meta-name='Template']/meta-value='3')]/contrib-group[1][count(contrib[@contrib-type='author' and @corresp='yes']) gt 1]/contrib[@contrib-type='author' and @corresp='yes' and name]" id="corresp-author-initial-tests">
+      <let name="name" value="e:get-name(name)"/>
+      <let name="normalized-name" value="e:stripDiacritics($name)"/>
+      
+      <report test="$normalized-name != $name" role="warning" id="corresp-author-initial-test">
+        <value-of select="$name"/> has a name with letters that have diacritics or marks. Please ensure that their initials display correctly in the PDF in the 'For correspondence' section on the first page.</report>
+      
+    </rule>
+  </pattern>
   <pattern id="author-children-tests-pattern">
     <rule context="article-meta//contrib[@contrib-type='author']/*" id="author-children-tests">
 		  <let name="article-type" value="ancestor::article/@article-type"/> 
@@ -5135,7 +5145,7 @@
   <pattern id="digest-tests-pattern">
     <rule context="front//abstract[@abstract-type='executive-summary']/p" id="digest-tests">
      
-     <report test="matches(.,'^\p{Ll}')" role="warning" id="digest-test-1">digest paragraph starts with a lowercase letter. Is that correct? Or has a paragraph been incorrect split into two? If the latter is the case, the features team will have to be notified so that they can update the word doc for the digest channel.</report>
+     <report test="matches(.,'^\p{Ll}')" role="warning" id="digest-test-1">digest paragraph starts with a lowercase letter. Is that correct? Or has a paragraph been incorrect split into two?</report>
      
    </rule>
   </pattern>

--- a/src/pre-JATS-schematron.sch
+++ b/src/pre-JATS-schematron.sch
@@ -1256,6 +1256,15 @@
 		
 		</rule>
   </pattern>
+  <pattern id="corresp-author-initial-tests-pattern">
+    <rule context="article[@article-type=('research-article','review-article','discussion')]//article-meta[not(descendant::custom-meta[meta-name='Template']/meta-value='3')]/contrib-group[1][count(contrib[@contrib-type='author' and @corresp='yes']) gt 1]/contrib[@contrib-type='author' and @corresp='yes' and name]" id="corresp-author-initial-tests">
+      <let name="name" value="e:get-name(name)"/>
+      <let name="normalized-name" value="e:stripDiacritics($name)"/>
+      
+      <report test="$normalized-name != $name" role="warning" id="corresp-author-initial-test">[corresp-author-initial-test] <value-of select="$name"/> has a name with letters that have diacritics or marks. Please ensure that their initials display correctly in the PDF in the 'For correspondence' section on the first page.</report>
+      
+    </rule>
+  </pattern>
   <pattern id="author-children-tests-pattern">
     <rule context="article-meta//contrib[@contrib-type='author']/*" id="author-children-tests">
 		  <let name="article-type" value="ancestor::article/@article-type"/> 
@@ -5017,7 +5026,7 @@
   <pattern id="digest-tests-pattern">
     <rule context="front//abstract[@abstract-type='executive-summary']/p" id="digest-tests">
      
-     <report test="matches(.,'^\p{Ll}')" role="warning" id="digest-test-1">[digest-test-1] digest paragraph starts with a lowercase letter. Is that correct? Or has a paragraph been incorrect split into two? If the latter is the case, the features team will have to be notified so that they can update the word doc for the digest channel.</report>
+     <report test="matches(.,'^\p{Ll}')" role="warning" id="digest-test-1">[digest-test-1] digest paragraph starts with a lowercase letter. Is that correct? Or has a paragraph been incorrect split into two?</report>
      
    </rule>
   </pattern>

--- a/src/schematron.sch
+++ b/src/schematron.sch
@@ -1506,6 +1506,17 @@
         id="deceased-test-2"><value-of select="$name"/> has the attribute deceased="yes", but no footnote which contains the text 'Deceased', which is incorrect.</report>
 		
 		</rule>
+    
+    <rule context="article[@article-type=('research-article','review-article','discussion')]//article-meta[not(descendant::custom-meta[meta-name='Template']/meta-value='3')]/contrib-group[1][count(contrib[@contrib-type='author' and @corresp='yes']) gt 1]/contrib[@contrib-type='author' and @corresp='yes' and name]" 
+      id="corresp-author-initial-tests">
+      <let name="name" value="e:get-name(name)"/>
+      <let name="normalized-name" value="e:stripDiacritics($name)"/>
+      
+      <report test="$normalized-name != $name" 
+        role="warning" 
+        id="corresp-author-initial-test"><value-of select="$name"/> has a name with letters that have diacritics or marks. Please ensure that their initials display correctly in the PDF in the 'For correspondence' section on the first page.</report>
+      
+    </rule>
 		
 		<rule context="article-meta//contrib[@contrib-type='author']/*" id="author-children-tests">
 		  <let name="article-type" value="ancestor::article/@article-type"/> 
@@ -7085,7 +7096,7 @@ else self::*/local-name() = $allowed-p-blocks"
      
      <report test="matches(.,'^\p{Ll}')" 
        role="warning" 
-       id="digest-test-1">digest paragraph starts with a lowercase letter. Is that correct? Or has a paragraph been incorrect split into two? If the latter is the case, the features team will have to be notified so that they can update the word doc for the digest channel.</report>
+       id="digest-test-1">digest paragraph starts with a lowercase letter. Is that correct? Or has a paragraph been incorrect split into two?</report>
      
    </rule>
    

--- a/src/schematron.sch
+++ b/src/schematron.sch
@@ -1509,7 +1509,7 @@
     
     <rule context="article[@article-type=('research-article','review-article','discussion')]//article-meta[not(descendant::custom-meta[meta-name='Template']/meta-value='3')]/contrib-group[1][count(contrib[@contrib-type='author' and @corresp='yes']) gt 1]/contrib[@contrib-type='author' and @corresp='yes' and name]" 
       id="corresp-author-initial-tests">
-      <let name="name" value="e:get-name(name)"/>
+      <let name="name" value="e:get-name(name[1])"/>
       <let name="normalized-name" value="e:stripDiacritics($name)"/>
       
       <report test="$normalized-name != $name" 

--- a/test/tests/gen/corresp-author-initial-tests/corresp-author-initial-test/corresp-author-initial-test.sch
+++ b/test/tests/gen/corresp-author-initial-tests/corresp-author-initial-test/corresp-author-initial-test.sch
@@ -789,14 +789,17 @@
     <xsl:sequence select="count(tokenize($arg,'(\r\n?|\n\r?)'))"/>
     
   </xsl:function>
-  <pattern id="features">
-    <rule context="front//abstract[@abstract-type='executive-summary']/p" id="digest-tests">
-      <report test="matches(.,'^\p{Ll}')" role="warning" id="digest-test-1">digest paragraph starts with a lowercase letter. Is that correct? Or has a paragraph been incorrect split into two?</report>
+  <pattern id="article-metadata">
+    <rule context="article[@article-type=('research-article','review-article','discussion')]//article-meta[not(descendant::custom-meta[meta-name='Template']/meta-value='3')]/contrib-group[1][count(contrib[@contrib-type='author' and @corresp='yes']) gt 1]/contrib[@contrib-type='author' and @corresp='yes' and name]" id="corresp-author-initial-tests">
+      <let name="name" value="e:get-name(name)"/>
+      <let name="normalized-name" value="e:stripDiacritics($name)"/>
+      <report test="$normalized-name != $name" role="warning" id="corresp-author-initial-test">
+        <value-of select="$name"/> has a name with letters that have diacritics or marks. Please ensure that their initials display correctly in the PDF in the 'For correspondence' section on the first page.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::front//abstract[@abstract-type='executive-summary']/p" role="error" id="digest-tests-xspec-assert">front//abstract[@abstract-type='executive-summary']/p must be present.</assert>
+      <assert test="descendant::article[@article-type=('research-article','review-article','discussion')]//article-meta[not(descendant::custom-meta[meta-name='Template']/meta-value='3')]/contrib-group[1][count(contrib[@contrib-type='author' and @corresp='yes']) gt 1]/contrib[@contrib-type='author' and @corresp='yes' and name]" role="error" id="corresp-author-initial-tests-xspec-assert">article[@article-type=('research-article','review-article','discussion')]//article-meta[not(descendant::custom-meta[meta-name='Template']/meta-value='3')]/contrib-group[1][count(contrib[@contrib-type='author' and @corresp='yes']) gt 1]/contrib[@contrib-type='author' and @corresp='yes' and name] must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/corresp-author-initial-tests/corresp-author-initial-test/fail.xml
+++ b/test/tests/gen/corresp-author-initial-tests/corresp-author-initial-test/fail.xml
@@ -31,7 +31,7 @@ Message:  has a name with letters that have diacritics or marks. Please ensure t
           </contrib>
           <contrib contrib-type="author" corresp="yes" id="author-189778">
             <name>
-              <surname>Rost</surname>
+              <surname>Röst</surname>
               <given-names>Hannes L</given-names>
             </name>
             <email>hannes.rost@utoronto.ca</email>

--- a/test/tests/gen/corresp-author-initial-tests/corresp-author-initial-test/fail.xml
+++ b/test/tests/gen/corresp-author-initial-tests/corresp-author-initial-test/fail.xml
@@ -1,0 +1,119 @@
+<?oxygen SCHSchema="corresp-author-initial-test.sch"?>
+<!--Context: article[@article-type=('research-article','review-article','discussion')]//article-meta[not(descendant::custom-meta[meta-name='Template']/meta-value='3')]/contrib-group[1][count(contrib[@contrib-type='author' and @corresp='yes']) gt 1]/contrib[@contrib-type='author' and @corresp='yes' and name]
+Test: report    $normalized-name != $name
+Message:  has a name with letters that have diacritics or marks. Please ensure that their initials display correctly in the PDF in the 'For correspondence' section on the first page. -->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML"
+  xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article article-type="research-article">
+    <front>
+      <article-meta>
+        <contrib-group>
+          <contrib contrib-type="author" id="author-189776">
+            <name>
+              <surname>Lai</surname>
+              <given-names>Mi</given-names>
+            </name>
+            <xref ref-type="aff" rid="aff1">1</xref>
+            <xref ref-type="other" rid="fund5"/>
+            <xref ref-type="fn" rid="con1"/>
+            <xref ref-type="fn" rid="conf1"/>
+          </contrib>
+          <contrib contrib-type="author" id="author-189777">
+            <name>
+              <surname>Al Rijjal</surname>
+              <given-names>Dana</given-names>
+            </name>
+            <xref ref-type="aff" rid="aff1">1</xref>
+            <xref ref-type="other" rid="fund6"/>
+            <xref ref-type="other" rid="fund7"/>
+            <xref ref-type="fn" rid="con2"/>
+            <xref ref-type="fn" rid="conf1"/>
+          </contrib>
+          <contrib contrib-type="author" corresp="yes" id="author-189778">
+            <name>
+              <surname>Rost</surname>
+              <given-names>Hannes L</given-names>
+            </name>
+            <email>hannes.rost@utoronto.ca</email>
+            <xref ref-type="aff" rid="aff2">2</xref>
+            <xref ref-type="fn" rid="con3"/>
+            <xref ref-type="fn" rid="conf1"/>
+          </contrib>
+          <contrib contrib-type="author" corresp="yes" id="author-189779">
+            <name>
+              <surname>Dai</surname>
+              <given-names>Feihan F</given-names>
+            </name>
+            <email>f.dai@utoronto.ca</email>
+            <xref ref-type="aff" rid="aff1">1</xref>
+            <xref ref-type="fn" rid="con4"/>
+            <xref ref-type="fn" rid="conf1"/>
+          </contrib>
+          <contrib contrib-type="author" corresp="yes" id="author-189780">
+            <name>
+              <surname>Gunderson</surname>
+              <given-names>Erica P</given-names>
+            </name>
+            <email>Erica.Gunderson@kp.org</email>
+            <xref ref-type="aff" rid="aff3">3</xref>
+            <xref ref-type="other" rid="fund2"/>
+            <xref ref-type="other" rid="fund3"/>
+            <xref ref-type="other" rid="fund4"/>
+            <xref ref-type="fn" rid="con5"/>
+            <xref ref-type="fn" rid="conf2"/>
+          </contrib>
+          <contrib contrib-type="author" corresp="yes" id="author-27489">
+            <name>
+              <surname>Wheeler</surname>
+              <given-names>Michael B</given-names>
+            </name>
+            <contrib-id authenticated="true" contrib-id-type="orcid"
+              >https://orcid.org/0000-0002-7480-7267</contrib-id>
+            <email>michael.wheeler@utoronto.ca</email>
+            <xref ref-type="aff" rid="aff1">1</xref>
+            <xref ref-type="aff" rid="aff4">4</xref>
+            <xref ref-type="other" rid="fund1"/>
+            <xref ref-type="other" rid="fund4"/>
+            <xref ref-type="fn" rid="con6"/>
+            <xref ref-type="fn" rid="conf3"/>
+          </contrib>
+          <aff id="aff1">
+            <label>1</label>
+            <institution>Department of Physiology, Faculty of Medicine, University of
+              Toronto</institution>
+            <addr-line>
+              <named-content content-type="city">Ontario</named-content>
+            </addr-line>
+            <country>Canada</country>
+          </aff>
+          <aff id="aff2">
+            <label>2</label>
+            <institution>Donnelly Centre for Cellular &amp; Biomolecular Research, University of
+              Toronto</institution>
+            <addr-line>
+              <named-content content-type="city">Ontario</named-content>
+            </addr-line>
+            <country>Canada</country>
+          </aff>
+          <aff id="aff3">
+            <label>3</label>
+            <institution>Kaiser Permanente Northern California, Division of Research</institution>
+            <addr-line>
+              <named-content content-type="city">Oakland</named-content>
+            </addr-line>
+            <country>United States</country>
+          </aff>
+          <aff id="aff4">
+            <label>4</label>
+            <institution>Advanced Diagnostics, Metabolism, Toronto General Research
+              Institute</institution>
+            <addr-line>
+              <named-content content-type="city">Ontario</named-content>
+            </addr-line>
+            <country>Canada</country>
+          </aff>
+        </contrib-group>
+      </article-meta>
+    </front>
+  </article>
+</root>

--- a/test/tests/gen/corresp-author-initial-tests/corresp-author-initial-test/pass.xml
+++ b/test/tests/gen/corresp-author-initial-tests/corresp-author-initial-test/pass.xml
@@ -31,7 +31,7 @@ Message:  has a name with letters that have diacritics or marks. Please ensure t
           </contrib>
           <contrib contrib-type="author" corresp="yes" id="author-189778">
             <name>
-              <surname>Röst</surname>
+              <surname>Rost</surname>
               <given-names>Hannes L</given-names>
             </name>
             <email>hannes.rost@utoronto.ca</email>

--- a/test/tests/gen/corresp-author-initial-tests/corresp-author-initial-test/pass.xml
+++ b/test/tests/gen/corresp-author-initial-tests/corresp-author-initial-test/pass.xml
@@ -1,0 +1,119 @@
+<?oxygen SCHSchema="corresp-author-initial-test.sch"?>
+<!--Context: article[@article-type=('research-article','review-article','discussion')]//article-meta[not(descendant::custom-meta[meta-name='Template']/meta-value='3')]/contrib-group[1][count(contrib[@contrib-type='author' and @corresp='yes']) gt 1]/contrib[@contrib-type='author' and @corresp='yes' and name]
+Test: report    $normalized-name != $name
+Message:  has a name with letters that have diacritics or marks. Please ensure that their initials display correctly in the PDF in the 'For correspondence' section on the first page. -->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML"
+  xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article article-type="research-article">
+    <front>
+      <article-meta>
+        <contrib-group>
+          <contrib contrib-type="author" id="author-189776">
+            <name>
+              <surname>Lai</surname>
+              <given-names>Mi</given-names>
+            </name>
+            <xref ref-type="aff" rid="aff1">1</xref>
+            <xref ref-type="other" rid="fund5"/>
+            <xref ref-type="fn" rid="con1"/>
+            <xref ref-type="fn" rid="conf1"/>
+          </contrib>
+          <contrib contrib-type="author" id="author-189777">
+            <name>
+              <surname>Al Rijjal</surname>
+              <given-names>Dana</given-names>
+            </name>
+            <xref ref-type="aff" rid="aff1">1</xref>
+            <xref ref-type="other" rid="fund6"/>
+            <xref ref-type="other" rid="fund7"/>
+            <xref ref-type="fn" rid="con2"/>
+            <xref ref-type="fn" rid="conf1"/>
+          </contrib>
+          <contrib contrib-type="author" corresp="yes" id="author-189778">
+            <name>
+              <surname>Röst</surname>
+              <given-names>Hannes L</given-names>
+            </name>
+            <email>hannes.rost@utoronto.ca</email>
+            <xref ref-type="aff" rid="aff2">2</xref>
+            <xref ref-type="fn" rid="con3"/>
+            <xref ref-type="fn" rid="conf1"/>
+          </contrib>
+          <contrib contrib-type="author" corresp="yes" id="author-189779">
+            <name>
+              <surname>Dai</surname>
+              <given-names>Feihan F</given-names>
+            </name>
+            <email>f.dai@utoronto.ca</email>
+            <xref ref-type="aff" rid="aff1">1</xref>
+            <xref ref-type="fn" rid="con4"/>
+            <xref ref-type="fn" rid="conf1"/>
+          </contrib>
+          <contrib contrib-type="author" corresp="yes" id="author-189780">
+            <name>
+              <surname>Gunderson</surname>
+              <given-names>Erica P</given-names>
+            </name>
+            <email>Erica.Gunderson@kp.org</email>
+            <xref ref-type="aff" rid="aff3">3</xref>
+            <xref ref-type="other" rid="fund2"/>
+            <xref ref-type="other" rid="fund3"/>
+            <xref ref-type="other" rid="fund4"/>
+            <xref ref-type="fn" rid="con5"/>
+            <xref ref-type="fn" rid="conf2"/>
+          </contrib>
+          <contrib contrib-type="author" corresp="yes" id="author-27489">
+            <name>
+              <surname>Wheeler</surname>
+              <given-names>Michael B</given-names>
+            </name>
+            <contrib-id authenticated="true" contrib-id-type="orcid"
+              >https://orcid.org/0000-0002-7480-7267</contrib-id>
+            <email>michael.wheeler@utoronto.ca</email>
+            <xref ref-type="aff" rid="aff1">1</xref>
+            <xref ref-type="aff" rid="aff4">4</xref>
+            <xref ref-type="other" rid="fund1"/>
+            <xref ref-type="other" rid="fund4"/>
+            <xref ref-type="fn" rid="con6"/>
+            <xref ref-type="fn" rid="conf3"/>
+          </contrib>
+          <aff id="aff1">
+            <label>1</label>
+            <institution>Department of Physiology, Faculty of Medicine, University of
+              Toronto</institution>
+            <addr-line>
+              <named-content content-type="city">Ontario</named-content>
+            </addr-line>
+            <country>Canada</country>
+          </aff>
+          <aff id="aff2">
+            <label>2</label>
+            <institution>Donnelly Centre for Cellular &amp; Biomolecular Research, University of
+              Toronto</institution>
+            <addr-line>
+              <named-content content-type="city">Ontario</named-content>
+            </addr-line>
+            <country>Canada</country>
+          </aff>
+          <aff id="aff3">
+            <label>3</label>
+            <institution>Kaiser Permanente Northern California, Division of Research</institution>
+            <addr-line>
+              <named-content content-type="city">Oakland</named-content>
+            </addr-line>
+            <country>United States</country>
+          </aff>
+          <aff id="aff4">
+            <label>4</label>
+            <institution>Advanced Diagnostics, Metabolism, Toronto General Research
+              Institute</institution>
+            <addr-line>
+              <named-content content-type="city">Ontario</named-content>
+            </addr-line>
+            <country>Canada</country>
+          </aff>
+        </contrib-group>
+      </article-meta>
+    </front>
+  </article>
+</root>

--- a/test/tests/gen/digest-tests/digest-test-1/fail.xml
+++ b/test/tests/gen/digest-tests/digest-test-1/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="digest-test-1.sch"?>
 <!--Context: front//abstract[@abstract-type='executive-summary']/p
 Test: report    matches(.,'^\p{Ll}')
-Message: digest paragraph starts with a lowercase letter. Is that correct? Or has a paragraph been incorrect split into two? If the latter is the case, the features team will have to be notified so that they can update the word doc for the digest channel. -->
+Message: digest paragraph starts with a lowercase letter. Is that correct? Or has a paragraph been incorrect split into two? -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>
     <front>

--- a/test/tests/gen/digest-tests/digest-test-1/pass.xml
+++ b/test/tests/gen/digest-tests/digest-test-1/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="digest-test-1.sch"?>
 <!--Context: front//abstract[@abstract-type='executive-summary']/p
 Test: report    matches(.,'^\p{Ll}')
-Message: digest paragraph starts with a lowercase letter. Is that correct? Or has a paragraph been incorrect split into two? If the latter is the case, the features team will have to be notified so that they can update the word doc for the digest channel. -->
+Message: digest paragraph starts with a lowercase letter. Is that correct? Or has a paragraph been incorrect split into two? -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>
     <front>

--- a/test/xspec/schematron.sch
+++ b/test/xspec/schematron.sch
@@ -1266,6 +1266,16 @@
 		
 		</rule>
   </pattern>
+  <pattern id="corresp-author-initial-tests-pattern">
+    <rule context="article[@article-type=('research-article','review-article','discussion')]//article-meta[not(descendant::custom-meta[meta-name='Template']/meta-value='3')]/contrib-group[1][count(contrib[@contrib-type='author' and @corresp='yes']) gt 1]/contrib[@contrib-type='author' and @corresp='yes' and name]" id="corresp-author-initial-tests">
+      <let name="name" value="e:get-name(name)"/>
+      <let name="normalized-name" value="e:stripDiacritics($name)"/>
+      
+      <report test="$normalized-name != $name" role="warning" id="corresp-author-initial-test">
+        <value-of select="$name"/> has a name with letters that have diacritics or marks. Please ensure that their initials display correctly in the PDF in the 'For correspondence' section on the first page.</report>
+      
+    </rule>
+  </pattern>
   <pattern id="author-children-tests-pattern">
     <rule context="article-meta//contrib[@contrib-type='author']/*" id="author-children-tests">
 		  <let name="article-type" value="ancestor::article/@article-type"/> 
@@ -5145,7 +5155,7 @@
   <pattern id="digest-tests-pattern">
     <rule context="front//abstract[@abstract-type='executive-summary']/p" id="digest-tests">
      
-     <report test="matches(.,'^\p{Ll}')" role="warning" id="digest-test-1">digest paragraph starts with a lowercase letter. Is that correct? Or has a paragraph been incorrect split into two? If the latter is the case, the features team will have to be notified so that they can update the word doc for the digest channel.</report>
+     <report test="matches(.,'^\p{Ll}')" role="warning" id="digest-test-1">digest paragraph starts with a lowercase letter. Is that correct? Or has a paragraph been incorrect split into two?</report>
      
    </rule>
   </pattern>
@@ -7680,6 +7690,7 @@
       <assert test="descendant::contrib-group//name/suffix" role="error" id="suffix-tests-xspec-assert">contrib-group//name/suffix must be present.</assert>
       <assert test="descendant::contrib-group//name/*" role="error" id="name-child-tests-xspec-assert">contrib-group//name/* must be present.</assert>
       <assert test="descendant::article-meta//contrib" role="error" id="contrib-tests-xspec-assert">article-meta//contrib must be present.</assert>
+      <assert test="descendant::article[@article-type=('research-article','review-article','discussion')]//article-meta[not(descendant::custom-meta[meta-name='Template']/meta-value='3')]/contrib-group[1][count(contrib[@contrib-type='author' and @corresp='yes']) gt 1]/contrib[@contrib-type='author' and @corresp='yes' and name]" role="error" id="corresp-author-initial-tests-xspec-assert">article[@article-type=('research-article','review-article','discussion')]//article-meta[not(descendant::custom-meta[meta-name='Template']/meta-value='3')]/contrib-group[1][count(contrib[@contrib-type='author' and @corresp='yes']) gt 1]/contrib[@contrib-type='author' and @corresp='yes' and name] must be present.</assert>
       <assert test="descendant::article-meta//contrib[@contrib-type='author']/*" role="error" id="author-children-tests-xspec-assert">article-meta//contrib[@contrib-type='author']/* must be present.</assert>
       <assert test="descendant::contrib-id[@contrib-id-type='orcid']" role="error" id="orcid-tests-xspec-assert">contrib-id[@contrib-id-type='orcid'] must be present.</assert>
       <assert test="descendant::article-meta//email" role="error" id="email-tests-xspec-assert">article-meta//email must be present.</assert>

--- a/test/xspec/schematron.xspec
+++ b/test/xspec/schematron.xspec
@@ -1270,6 +1270,18 @@
         <x:expect-not-assert id="contrib-tests-xspec-assert" role="error"/>
       </x:scenario>
     </x:scenario>
+    <x:scenario label="corresp-author-initial-tests">
+      <x:scenario label="corresp-author-initial-test-pass">
+        <x:context href="../tests/gen/corresp-author-initial-tests/corresp-author-initial-test/pass.xml"/>
+        <x:expect-not-report id="corresp-author-initial-test" role="warning"/>
+        <x:expect-not-assert id="corresp-author-initial-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="corresp-author-initial-test-fail">
+        <x:context href="../tests/gen/corresp-author-initial-tests/corresp-author-initial-test/fail.xml"/>
+        <x:expect-report id="corresp-author-initial-test" role="warning"/>
+        <x:expect-not-assert id="corresp-author-initial-tests-xspec-assert" role="error"/>
+      </x:scenario>
+    </x:scenario>
     <x:scenario label="author-children-tests">
       <x:scenario label="author-children-test-pass">
         <x:context href="../tests/gen/author-children-tests/author-children-test/pass.xml"/>


### PR DESCRIPTION
- Fire warning for any author with diacritics/marks in their name in an article which displays initials in the 'For correspondence' section of the PDF - `corresp-author-initial-test`.
- Fix message text in `digest-test-1`.