### PR TITLE
improvement: new tests and fixes

### DIFF
--- a/src/final-JATS-schematron.sch
+++ b/src/final-JATS-schematron.sch
@@ -1258,7 +1258,7 @@
   </pattern>
   <pattern id="corresp-author-initial-tests-pattern">
     <rule context="article[@article-type=('research-article','review-article','discussion')]//article-meta[not(descendant::custom-meta[meta-name='Template']/meta-value='3')]/contrib-group[1][count(contrib[@contrib-type='author' and @corresp='yes']) gt 1]/contrib[@contrib-type='author' and @corresp='yes' and name]" id="corresp-author-initial-tests">
-      <let name="name" value="e:get-name(name)"/>
+      <let name="name" value="e:get-name(name[1])"/>
       <let name="normalized-name" value="e:stripDiacritics($name)"/>
       
       <report test="$normalized-name != $name" role="warning" id="corresp-author-initial-test">[corresp-author-initial-test] <value-of select="$name"/> has a name with letters that have diacritics or marks. Please ensure that their initials display correctly in the PDF in the 'For correspondence' section on the first page.</report>
@@ -1886,7 +1886,7 @@
         id="broken-uri-test">Broken URI in @xlink:href</assert>-->
       
       <!-- Needs further testing. Presume that we want to ensure a url follows certain URI schemes. -->
-      <assert test="matches(@xlink:href,'^https?:..(www\.)?[-a-zA-Z0-9@:%.,_\+~#=]{2,256}\.[a-z]{2,6}([-a-zA-Z0-9@:%,_\\(\)+.~#?&amp;//=]*)$|^ftp://.|^git://.|^tel:.|^mailto:.')" role="warning" id="url-conformance-test">[url-conformance-test] @xlink:href doesn't look like a URL - '<value-of select="@xlink:href"/>'. Is this correct?</assert>
+      <assert test="matches(@xlink:href,'^https?:..(www\.)?[-a-zA-Z0-9@:%.,_\+~#=!]{2,256}\.[a-z]{2,6}([-a-zA-Z0-9@:%,_\\(\)+.~#?!&amp;//=]*)$|^ftp://.|^git://.|^tel:.|^mailto:.')" role="warning" id="url-conformance-test">[url-conformance-test] @xlink:href doesn't look like a URL - '<value-of select="@xlink:href"/>'. Is this correct?</assert>
       
       <report test="matches(@xlink:href,'^(ftp|sftp)://\S+:\S+@')" role="warning" id="ftp-credentials-flag">[ftp-credentials-flag] @xlink:href contains what looks like a link to an FTP site which contains credentials (username and password) - '<value-of select="@xlink:href"/>'. If the link without credentials works (<value-of select="concat(substring-before(@xlink:href,'://'),'://',substring-after(@xlink:href,'@'))"/>), then please replace it with that and notify the authors that you have done so. If the link without credentials does not work, please query with the authors in order to obtain a link without credentials.</report>
       
@@ -2145,8 +2145,10 @@
       
       <assert test="mml:math" role="error" id="disp-formula-test-2">[disp-formula-test-2] disp-formula must contain an mml:math element.</assert>
       
-      <assert test="parent::p" role="error" id="disp-formula-test-3">[disp-formula-test-3] disp-formula must be a child of p. <value-of select="label"/> is a child of <value-of select="parent::*/local-name()"/>
-      </assert>
+      <assert test="parent::p" role="warning" id="disp-formula-test-3">[disp-formula-test-3] In the vast majority of cases disp-formula should be a child of p. <value-of select="label"/> is a child of <value-of select="parent::*/local-name()"/>. Is that correct?</assert>
+      
+      <report test="parent::p and not(preceding-sibling::*) and (not(preceding-sibling::text()) or normalize-space(preceding-sibling::text()[1])='')" role="error" id="disp-formula-test-4">[disp-formula-test-4] disp-formula cannot be placed as the first child of a p element with no content before it (ie. &gt;p&gt;&gt;disp-formula ...). Either capture it at the end of the previous paragraph or capture it as a child of <value-of select="parent::p/parent::*/local-name()"/>
+      </report>
     </rule>
   </pattern>
   <pattern id="inline-formula-tests-pattern">
@@ -3232,9 +3234,10 @@
     </rule>
   </pattern>
   <pattern id="res-data-sec-pattern">
-    <rule context="article[@article-type='research-article']//sec[not(@sec-type) and not(descendant::xref[@ref-type='bibr']) and not(matches(.,'[Gg]ithub|[Gg]itlab|[Cc]ode[Pp]lex|[Ss]ource[Ff]orge|[Bb]it[Bb]ucket'))]" id="res-data-sec">
+    <rule context="article[@article-type='research-article']//sec[not(@sec-type) and not(matches(.,'[Gg]ithub|[Gg]itlab|[Cc]ode[Pp]lex|[Ss]ource[Ff]orge|[Bb]it[Bb]ucket'))]" id="res-data-sec">
+      <let name="title" value="lower-case(title[1])"/>
       
-      <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#sec-test-3" test="matches(title[1],'[Dd]ata') and (matches(title[1],'[Aa]vailability') or matches(title[1],'[Cc]ode') or matches(title[1],'[Aa]ccessib') or matches(title[1],'[Ss]atement'))" role="warning" id="sec-test-3">[sec-test-3] Section has a title '<value-of select="title[1]"/>'. Is it a duplicate of the data availability section (and therefore should be removed)?</report>
+      <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#sec-test-3" test="contains($title,'data') and (contains($title,'availability') or contains($title,'code') or contains($title,'accessib') or contains($title,'statement'))" role="warning" id="sec-test-3">[sec-test-3] Section has a title '<value-of select="title[1]"/>'. Is it a duplicate of the data availability section (and therefore should be removed)?</report>
       
     </rule>
   </pattern>
@@ -4120,9 +4123,9 @@
         The  &lt;patent&gt; element is required. 
         Reference '<value-of select="ancestor::ref/@id"/>' has no &lt;patent&gt; elements.</assert>
       
-      <assert test="ext-link" role="error" id="err-elem-cit-patent-11-1">[err-elem-cit-patent-11-1]
-        The &lt;ext-link&gt; element is required.
-        Reference '<value-of select="ancestor::ref/@id"/>' has no &lt;ext-link&gt; elements.</assert>
+      
+      
+      <assert test="ext-link" role="error" id="final-err-elem-cit-patent-11-1">[final-err-elem-cit-patent-11-1] The &lt;ext-link&gt; element is required in a patent reference. Reference '<value-of select="ancestor::ref/@id"/>' has no &lt;ext-link&gt; elements.</assert>
       
       <assert test="count(*) = count(person-group| article-title| source| year| patent| ext-link)" role="error" id="err-elem-cit-patent-18">[err-elem-cit-patent-18]
         The only tags that are allowed as children of &lt;element-citation&gt; with the publication-type="patent" are:
@@ -4953,6 +4956,8 @@
       <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#pre-das-elem-cit-3" test="pub-id[1]/@xlink:href = preceding::element-citation[(@publication-type='data') and ancestor::sec[@sec-type='data-availability']]/pub-id[1]/@xlink:href" role="error" id="final-das-elem-cit-3">[final-das-elem-cit-3] The reference in position <value-of select="$pos"/> of the data availability section has a link (<value-of select="pub-id[1]/@xlink:href"/>) which is the same as another dataset reference in that section. Dataset reference links should be distinct.</report>
       
       <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#das-elem-cit-4" test="pub-id[1] = preceding::element-citation[(@publication-type='data') and ancestor::sec[@sec-type='data-availability']]/pub-id[1]" role="warning" id="das-elem-cit-4">[das-elem-cit-4] The reference in position <value-of select="$pos"/> of the data availability section has a pub-id (<value-of select="pub-id[1]"/>) which is the same as another dataset reference in that section. This is very likely incorrect. Dataset reference pub-id should be distinct.</report>
+      
+      <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#das-elem-cit-5" test="pub-id[1] = following::element-citation[ancestor::ref-list]/pub-id[1]" role="warning" id="das-elem-cit-5">[das-elem-cit-5] The reference in position <value-of select="$pos"/> of the data availability section has a pub-id (<value-of select="pub-id[1]"/>) which is the same as in another reference in the reference list. Is the same reference in both the reference list and data availability section?</report>
       
     </rule>
   </pattern>

--- a/src/final-package-JATS-schematron.sch
+++ b/src/final-package-JATS-schematron.sch
@@ -1274,7 +1274,7 @@
   </pattern>
   <pattern id="corresp-author-initial-tests-pattern">
     <rule context="article[@article-type=('research-article','review-article','discussion')]//article-meta[not(descendant::custom-meta[meta-name='Template']/meta-value='3')]/contrib-group[1][count(contrib[@contrib-type='author' and @corresp='yes']) gt 1]/contrib[@contrib-type='author' and @corresp='yes' and name]" id="corresp-author-initial-tests">
-      <let name="name" value="e:get-name(name)"/>
+      <let name="name" value="e:get-name(name[1])"/>
       <let name="normalized-name" value="e:stripDiacritics($name)"/>
       
       <report test="$normalized-name != $name" role="warning" id="corresp-author-initial-test">
@@ -1930,7 +1930,7 @@
         id="broken-uri-test">Broken URI in @xlink:href</assert>-->
       
       <!-- Needs further testing. Presume that we want to ensure a url follows certain URI schemes. -->
-      <assert test="matches(@xlink:href,'^https?:..(www\.)?[-a-zA-Z0-9@:%.,_\+~#=]{2,256}\.[a-z]{2,6}([-a-zA-Z0-9@:%,_\\(\)+.~#?&amp;//=]*)$|^ftp://.|^git://.|^tel:.|^mailto:.')" role="warning" id="url-conformance-test">@xlink:href doesn't look like a URL - '<value-of select="@xlink:href"/>'. Is this correct?</assert>
+      <assert test="matches(@xlink:href,'^https?:..(www\.)?[-a-zA-Z0-9@:%.,_\+~#=!]{2,256}\.[a-z]{2,6}([-a-zA-Z0-9@:%,_\\(\)+.~#?!&amp;//=]*)$|^ftp://.|^git://.|^tel:.|^mailto:.')" role="warning" id="url-conformance-test">@xlink:href doesn't look like a URL - '<value-of select="@xlink:href"/>'. Is this correct?</assert>
       
       <report test="matches(@xlink:href,'^(ftp|sftp)://\S+:\S+@')" role="warning" id="ftp-credentials-flag">@xlink:href contains what looks like a link to an FTP site which contains credentials (username and password) - '<value-of select="@xlink:href"/>'. If the link without credentials works (<value-of select="concat(substring-before(@xlink:href,'://'),'://',substring-after(@xlink:href,'@'))"/>), then please replace it with that and notify the authors that you have done so. If the link without credentials does not work, please query with the authors in order to obtain a link without credentials.</report>
       
@@ -2209,8 +2209,10 @@
       
       <assert test="mml:math" role="error" id="disp-formula-test-2">disp-formula must contain an mml:math element.</assert>
       
-      <assert test="parent::p" role="error" id="disp-formula-test-3">disp-formula must be a child of p. <value-of select="label"/> is a child of <value-of select="parent::*/local-name()"/>
-      </assert>
+      <assert test="parent::p" role="warning" id="disp-formula-test-3">In the vast majority of cases disp-formula should be a child of p. <value-of select="label"/> is a child of <value-of select="parent::*/local-name()"/>. Is that correct?</assert>
+      
+      <report test="parent::p and not(preceding-sibling::*) and (not(preceding-sibling::text()) or normalize-space(preceding-sibling::text()[1])='')" role="error" id="disp-formula-test-4">disp-formula cannot be placed as the first child of a p element with no content before it (ie. &gt;p&gt;&gt;disp-formula ...). Either capture it at the end of the previous paragraph or capture it as a child of <value-of select="parent::p/parent::*/local-name()"/>
+      </report>
     </rule>
   </pattern>
   <pattern id="inline-formula-tests-pattern">
@@ -3341,9 +3343,10 @@
     </rule>
   </pattern>
   <pattern id="res-data-sec-pattern">
-    <rule context="article[@article-type='research-article']//sec[not(@sec-type) and not(descendant::xref[@ref-type='bibr']) and not(matches(.,'[Gg]ithub|[Gg]itlab|[Cc]ode[Pp]lex|[Ss]ource[Ff]orge|[Bb]it[Bb]ucket'))]" id="res-data-sec">
+    <rule context="article[@article-type='research-article']//sec[not(@sec-type) and not(matches(.,'[Gg]ithub|[Gg]itlab|[Cc]ode[Pp]lex|[Ss]ource[Ff]orge|[Bb]it[Bb]ucket'))]" id="res-data-sec">
+      <let name="title" value="lower-case(title[1])"/>
       
-      <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#sec-test-3" test="matches(title[1],'[Dd]ata') and (matches(title[1],'[Aa]vailability') or matches(title[1],'[Cc]ode') or matches(title[1],'[Aa]ccessib') or matches(title[1],'[Ss]atement'))" role="warning" id="sec-test-3">Section has a title '<value-of select="title[1]"/>'. Is it a duplicate of the data availability section (and therefore should be removed)?</report>
+      <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#sec-test-3" test="contains($title,'data') and (contains($title,'availability') or contains($title,'code') or contains($title,'accessib') or contains($title,'statement'))" role="warning" id="sec-test-3">Section has a title '<value-of select="title[1]"/>'. Is it a duplicate of the data availability section (and therefore should be removed)?</report>
       
     </rule>
   </pattern>
@@ -4236,9 +4239,9 @@
         The  &lt;patent&gt; element is required. 
         Reference '<value-of select="ancestor::ref/@id"/>' has no &lt;patent&gt; elements.</assert>
       
-      <assert test="ext-link" role="error" id="err-elem-cit-patent-11-1">[err-elem-cit-patent-11-1]
-        The &lt;ext-link&gt; element is required.
-        Reference '<value-of select="ancestor::ref/@id"/>' has no &lt;ext-link&gt; elements.</assert>
+      
+      
+      <assert test="ext-link" role="error" id="final-err-elem-cit-patent-11-1">The &lt;ext-link&gt; element is required in a patent reference. Reference '<value-of select="ancestor::ref/@id"/>' has no &lt;ext-link&gt; elements.</assert>
       
       <assert test="count(*) = count(person-group| article-title| source| year| patent| ext-link)" role="error" id="err-elem-cit-patent-18">[err-elem-cit-patent-18]
         The only tags that are allowed as children of &lt;element-citation&gt; with the publication-type="patent" are:
@@ -5069,6 +5072,8 @@
       <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#pre-das-elem-cit-3" test="pub-id[1]/@xlink:href = preceding::element-citation[(@publication-type='data') and ancestor::sec[@sec-type='data-availability']]/pub-id[1]/@xlink:href" role="error" id="final-das-elem-cit-3">The reference in position <value-of select="$pos"/> of the data availability section has a link (<value-of select="pub-id[1]/@xlink:href"/>) which is the same as another dataset reference in that section. Dataset reference links should be distinct.</report>
       
       <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#das-elem-cit-4" test="pub-id[1] = preceding::element-citation[(@publication-type='data') and ancestor::sec[@sec-type='data-availability']]/pub-id[1]" role="warning" id="das-elem-cit-4">The reference in position <value-of select="$pos"/> of the data availability section has a pub-id (<value-of select="pub-id[1]"/>) which is the same as another dataset reference in that section. This is very likely incorrect. Dataset reference pub-id should be distinct.</report>
+      
+      <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#das-elem-cit-5" test="pub-id[1] = following::element-citation[ancestor::ref-list]/pub-id[1]" role="warning" id="das-elem-cit-5">The reference in position <value-of select="$pos"/> of the data availability section has a pub-id (<value-of select="pub-id[1]"/>) which is the same as in another reference in the reference list. Is the same reference in both the reference list and data availability section?</report>
       
     </rule>
   </pattern>

--- a/src/pre-JATS-schematron.sch
+++ b/src/pre-JATS-schematron.sch
@@ -1258,7 +1258,7 @@
   </pattern>
   <pattern id="corresp-author-initial-tests-pattern">
     <rule context="article[@article-type=('research-article','review-article','discussion')]//article-meta[not(descendant::custom-meta[meta-name='Template']/meta-value='3')]/contrib-group[1][count(contrib[@contrib-type='author' and @corresp='yes']) gt 1]/contrib[@contrib-type='author' and @corresp='yes' and name]" id="corresp-author-initial-tests">
-      <let name="name" value="e:get-name(name)"/>
+      <let name="name" value="e:get-name(name[1])"/>
       <let name="normalized-name" value="e:stripDiacritics($name)"/>
       
       <report test="$normalized-name != $name" role="warning" id="corresp-author-initial-test">[corresp-author-initial-test] <value-of select="$name"/> has a name with letters that have diacritics or marks. Please ensure that their initials display correctly in the PDF in the 'For correspondence' section on the first page.</report>
@@ -1884,7 +1884,7 @@
         id="broken-uri-test">Broken URI in @xlink:href</assert>-->
       
       <!-- Needs further testing. Presume that we want to ensure a url follows certain URI schemes. -->
-      <assert test="matches(@xlink:href,'^https?:..(www\.)?[-a-zA-Z0-9@:%.,_\+~#=]{2,256}\.[a-z]{2,6}([-a-zA-Z0-9@:%,_\\(\)+.~#?&amp;//=]*)$|^ftp://.|^git://.|^tel:.|^mailto:.')" role="warning" id="url-conformance-test">[url-conformance-test] @xlink:href doesn't look like a URL - '<value-of select="@xlink:href"/>'. Is this correct?</assert>
+      <assert test="matches(@xlink:href,'^https?:..(www\.)?[-a-zA-Z0-9@:%.,_\+~#=!]{2,256}\.[a-z]{2,6}([-a-zA-Z0-9@:%,_\\(\)+.~#?!&amp;//=]*)$|^ftp://.|^git://.|^tel:.|^mailto:.')" role="warning" id="url-conformance-test">[url-conformance-test] @xlink:href doesn't look like a URL - '<value-of select="@xlink:href"/>'. Is this correct?</assert>
       
       <report test="matches(@xlink:href,'^(ftp|sftp)://\S+:\S+@')" role="warning" id="ftp-credentials-flag">[ftp-credentials-flag] @xlink:href contains what looks like a link to an FTP site which contains credentials (username and password) - '<value-of select="@xlink:href"/>'. If the link without credentials works (<value-of select="concat(substring-before(@xlink:href,'://'),'://',substring-after(@xlink:href,'@'))"/>), then please replace it with that and notify the authors that you have done so. If the link without credentials does not work, please query with the authors in order to obtain a link without credentials.</report>
       
@@ -2143,8 +2143,10 @@
       
       <assert test="mml:math" role="error" id="disp-formula-test-2">[disp-formula-test-2] disp-formula must contain an mml:math element.</assert>
       
-      <assert test="parent::p" role="error" id="disp-formula-test-3">[disp-formula-test-3] disp-formula must be a child of p. <value-of select="label"/> is a child of <value-of select="parent::*/local-name()"/>
-      </assert>
+      <assert test="parent::p" role="warning" id="disp-formula-test-3">[disp-formula-test-3] In the vast majority of cases disp-formula should be a child of p. <value-of select="label"/> is a child of <value-of select="parent::*/local-name()"/>. Is that correct?</assert>
+      
+      <report test="parent::p and not(preceding-sibling::*) and (not(preceding-sibling::text()) or normalize-space(preceding-sibling::text()[1])='')" role="error" id="disp-formula-test-4">[disp-formula-test-4] disp-formula cannot be placed as the first child of a p element with no content before it (ie. &gt;p&gt;&gt;disp-formula ...). Either capture it at the end of the previous paragraph or capture it as a child of <value-of select="parent::p/parent::*/local-name()"/>
+      </report>
     </rule>
   </pattern>
   <pattern id="inline-formula-tests-pattern">
@@ -3230,9 +3232,10 @@
     </rule>
   </pattern>
   <pattern id="res-data-sec-pattern">
-    <rule context="article[@article-type='research-article']//sec[not(@sec-type) and not(descendant::xref[@ref-type='bibr']) and not(matches(.,'[Gg]ithub|[Gg]itlab|[Cc]ode[Pp]lex|[Ss]ource[Ff]orge|[Bb]it[Bb]ucket'))]" id="res-data-sec">
+    <rule context="article[@article-type='research-article']//sec[not(@sec-type) and not(matches(.,'[Gg]ithub|[Gg]itlab|[Cc]ode[Pp]lex|[Ss]ource[Ff]orge|[Bb]it[Bb]ucket'))]" id="res-data-sec">
+      <let name="title" value="lower-case(title[1])"/>
       
-      <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#sec-test-3" test="matches(title[1],'[Dd]ata') and (matches(title[1],'[Aa]vailability') or matches(title[1],'[Cc]ode') or matches(title[1],'[Aa]ccessib') or matches(title[1],'[Ss]atement'))" role="warning" id="sec-test-3">[sec-test-3] Section has a title '<value-of select="title[1]"/>'. Is it a duplicate of the data availability section (and therefore should be removed)?</report>
+      <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#sec-test-3" test="contains($title,'data') and (contains($title,'availability') or contains($title,'code') or contains($title,'accessib') or contains($title,'statement'))" role="warning" id="sec-test-3">[sec-test-3] Section has a title '<value-of select="title[1]"/>'. Is it a duplicate of the data availability section (and therefore should be removed)?</report>
       
     </rule>
   </pattern>
@@ -4118,9 +4121,9 @@
         The  &lt;patent&gt; element is required. 
         Reference '<value-of select="ancestor::ref/@id"/>' has no &lt;patent&gt; elements.</assert>
       
-      <assert test="ext-link" role="error" id="err-elem-cit-patent-11-1">[err-elem-cit-patent-11-1]
-        The &lt;ext-link&gt; element is required.
-        Reference '<value-of select="ancestor::ref/@id"/>' has no &lt;ext-link&gt; elements.</assert>
+      <assert test="ext-link" role="warning" id="pre-err-elem-cit-patent-11-1">[pre-err-elem-cit-patent-11-1] The &lt;ext-link&gt; element is required in a patent reference. Reference '<value-of select="ancestor::ref/@id"/>' has no &lt;ext-link&gt; elements. If you are unable to determine this yourself, please add an author query asking for this.</assert>
+      
+      
       
       <assert test="count(*) = count(person-group| article-title| source| year| patent| ext-link)" role="error" id="err-elem-cit-patent-18">[err-elem-cit-patent-18]
         The only tags that are allowed as children of &lt;element-citation&gt; with the publication-type="patent" are:
@@ -4951,6 +4954,8 @@
       
       
       <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#das-elem-cit-4" test="pub-id[1] = preceding::element-citation[(@publication-type='data') and ancestor::sec[@sec-type='data-availability']]/pub-id[1]" role="warning" id="das-elem-cit-4">[das-elem-cit-4] The reference in position <value-of select="$pos"/> of the data availability section has a pub-id (<value-of select="pub-id[1]"/>) which is the same as another dataset reference in that section. This is very likely incorrect. Dataset reference pub-id should be distinct.</report>
+      
+      <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#das-elem-cit-5" test="pub-id[1] = following::element-citation[ancestor::ref-list]/pub-id[1]" role="warning" id="das-elem-cit-5">[das-elem-cit-5] The reference in position <value-of select="$pos"/> of the data availability section has a pub-id (<value-of select="pub-id[1]"/>) which is the same as in another reference in the reference list. Is the same reference in both the reference list and data availability section?</report>
       
     </rule>
   </pattern>

--- a/src/schematron.sch
+++ b/src/schematron.sch
@@ -2488,7 +2488,7 @@ else self::*/local-name() = $allowed-p-blocks"
         id="broken-uri-test">Broken URI in @xlink:href</assert>-->
       
       <!-- Needs further testing. Presume that we want to ensure a url follows certain URI schemes. -->
-      <assert test="matches(@xlink:href,'^https?:..(www\.)?[-a-zA-Z0-9@:%.,_\+~#=]{2,256}\.[a-z]{2,6}([-a-zA-Z0-9@:%,_\\(\)+.~#?&amp;//=]*)$|^ftp://.|^git://.|^tel:.|^mailto:.')" 
+      <assert test="matches(@xlink:href,'^https?:..(www\.)?[-a-zA-Z0-9@:%.,_\+~#=!]{2,256}\.[a-z]{2,6}([-a-zA-Z0-9@:%,_\\(\)+.~#?!&amp;//=]*)$|^ftp://.|^git://.|^tel:.|^mailto:.')" 
         role="warning" 
         id="url-conformance-test">@xlink:href doesn't look like a URL - '<value-of select="@xlink:href"/>'. Is this correct?</assert>
       
@@ -2924,8 +2924,12 @@ else self::*/local-name() = $allowed-p-blocks"
         id="disp-formula-test-2">disp-formula must contain an mml:math element.</assert>
       
       <assert test="parent::p" 
+        role="warning" 
+        id="disp-formula-test-3">In the vast majority of cases disp-formula should be a child of p. <value-of select="label"/> is a child of <value-of select="parent::*/local-name()"/>. Is that correct?</assert>
+      
+      <report test="parent::p and not(preceding-sibling::*) and (not(preceding-sibling::text()) or normalize-space(preceding-sibling::text()[1])='')"
         role="error" 
-        id="disp-formula-test-3">disp-formula must be a child of p. <value-of select="label"/> is a child of <value-of select="parent::*/local-name()"/></assert>
+        id="disp-formula-test-4">disp-formula cannot be placed as the first child of a p element with no content before it (ie. &gt;p>&gt;disp-formula ...). Either capture it at the end of the previous paragraph or capture it as a child of <value-of select="parent::p/parent::*/local-name()"/></report>
     </rule>
     
     <rule context="inline-formula" id="inline-formula-tests">
@@ -4579,10 +4583,11 @@ else self::*/local-name() = $allowed-p-blocks"
         id="sec-test-5">Level <value-of select="count(ancestor::sec) + 1"/> sections are not allowed. Please either make this a level 5 heading, or capture the title as a bolded paragraph in its parent section.</report>
     </rule>
     
-    <rule context="article[@article-type='research-article']//sec[not(@sec-type) and not(descendant::xref[@ref-type='bibr']) and not(matches(.,'[Gg]ithub|[Gg]itlab|[Cc]ode[Pp]lex|[Ss]ource[Ff]orge|[Bb]it[Bb]ucket'))]" id="res-data-sec">
+    <rule context="article[@article-type='research-article']//sec[not(@sec-type) and not(matches(.,'[Gg]ithub|[Gg]itlab|[Cc]ode[Pp]lex|[Ss]ource[Ff]orge|[Bb]it[Bb]ucket'))]" id="res-data-sec">
+      <let name="title" value="lower-case(title[1])"/>
       
       <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#sec-test-3" 
-        test="matches(title[1],'[Dd]ata') and (matches(title[1],'[Aa]vailability') or matches(title[1],'[Cc]ode') or matches(title[1],'[Aa]ccessib') or matches(title[1],'[Ss]atement'))" 
+        test="contains($title,'data') and (contains($title,'availability') or contains($title,'code') or contains($title,'accessib') or contains($title,'statement'))" 
         role="warning" 
         id="sec-test-3">Section has a title '<value-of select="title[1]"/>'. Is it a duplicate of the data availability section (and therefore should be removed)?</report>
       
@@ -5834,10 +5839,12 @@ else self::*/local-name() = $allowed-p-blocks"
         Reference '<value-of select="ancestor::ref/@id"/>' has no &lt;patent&gt; elements.</assert>
       
       <assert test="ext-link" 
+        role="warning" 
+        id="pre-err-elem-cit-patent-11-1">The &lt;ext-link&gt; element is required in a patent reference. Reference '<value-of select="ancestor::ref/@id"/>' has no &lt;ext-link&gt; elements. If you are unable to determine this yourself, please add an author query asking for this.</assert>
+      
+      <assert test="ext-link" 
         role="error" 
-        id="err-elem-cit-patent-11-1">[err-elem-cit-patent-11-1]
-        The &lt;ext-link&gt; element is required.
-        Reference '<value-of select="ancestor::ref/@id"/>' has no &lt;ext-link&gt; elements.</assert>
+        id="final-err-elem-cit-patent-11-1">The &lt;ext-link&gt; element is required in a patent reference. Reference '<value-of select="ancestor::ref/@id"/>' has no &lt;ext-link&gt; elements.</assert>
       
       <assert test="count(*) = count(person-group| article-title| source| year| patent| ext-link)" 
         role="error" 
@@ -6983,6 +6990,11 @@ else self::*/local-name() = $allowed-p-blocks"
         test="pub-id[1] = preceding::element-citation[(@publication-type='data') and ancestor::sec[@sec-type='data-availability']]/pub-id[1]" 
         role="warning" 
         id="das-elem-cit-4">The reference in position <value-of select="$pos"/> of the data availability section has a pub-id (<value-of select="pub-id[1]"/>) which is the same as another dataset reference in that section. This is very likely incorrect. Dataset reference pub-id should be distinct.</report>
+      
+      <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#das-elem-cit-5" 
+        test="pub-id[1] = following::element-citation[ancestor::ref-list]/pub-id[1]" 
+        role="warning" 
+        id="das-elem-cit-5">The reference in position <value-of select="$pos"/> of the data availability section has a pub-id (<value-of select="pub-id[1]"/>) which is the same as in another reference in the reference list. Is the same reference in both the reference list and data availability section?</report>
       
     </rule>
     

--- a/test/tests/gen/corresp-author-initial-tests/corresp-author-initial-test/corresp-author-initial-test.sch
+++ b/test/tests/gen/corresp-author-initial-tests/corresp-author-initial-test/corresp-author-initial-test.sch
@@ -791,7 +791,7 @@
   </xsl:function>
   <pattern id="article-metadata">
     <rule context="article[@article-type=('research-article','review-article','discussion')]//article-meta[not(descendant::custom-meta[meta-name='Template']/meta-value='3')]/contrib-group[1][count(contrib[@contrib-type='author' and @corresp='yes']) gt 1]/contrib[@contrib-type='author' and @corresp='yes' and name]" id="corresp-author-initial-tests">
-      <let name="name" value="e:get-name(name)"/>
+      <let name="name" value="e:get-name(name[1])"/>
       <let name="normalized-name" value="e:stripDiacritics($name)"/>
       <report test="$normalized-name != $name" role="warning" id="corresp-author-initial-test">
         <value-of select="$name"/> has a name with letters that have diacritics or marks. Please ensure that their initials display correctly in the PDF in the 'For correspondence' section on the first page.</report>

--- a/test/tests/gen/corresp-author-initial-tests/corresp-author-initial-test/fail.xml
+++ b/test/tests/gen/corresp-author-initial-tests/corresp-author-initial-test/fail.xml
@@ -2,8 +2,7 @@
 <!--Context: article[@article-type=('research-article','review-article','discussion')]//article-meta[not(descendant::custom-meta[meta-name='Template']/meta-value='3')]/contrib-group[1][count(contrib[@contrib-type='author' and @corresp='yes']) gt 1]/contrib[@contrib-type='author' and @corresp='yes' and name]
 Test: report    $normalized-name != $name
 Message:  has a name with letters that have diacritics or marks. Please ensure that their initials display correctly in the PDF in the 'For correspondence' section on the first page. -->
-<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML"
-  xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article article-type="research-article">
     <front>
       <article-meta>
@@ -67,8 +66,7 @@ Message:  has a name with letters that have diacritics or marks. Please ensure t
               <surname>Wheeler</surname>
               <given-names>Michael B</given-names>
             </name>
-            <contrib-id authenticated="true" contrib-id-type="orcid"
-              >https://orcid.org/0000-0002-7480-7267</contrib-id>
+            <contrib-id authenticated="true" contrib-id-type="orcid">https://orcid.org/0000-0002-7480-7267</contrib-id>
             <email>michael.wheeler@utoronto.ca</email>
             <xref ref-type="aff" rid="aff1">1</xref>
             <xref ref-type="aff" rid="aff4">4</xref>

--- a/test/tests/gen/corresp-author-initial-tests/corresp-author-initial-test/pass.xml
+++ b/test/tests/gen/corresp-author-initial-tests/corresp-author-initial-test/pass.xml
@@ -2,8 +2,7 @@
 <!--Context: article[@article-type=('research-article','review-article','discussion')]//article-meta[not(descendant::custom-meta[meta-name='Template']/meta-value='3')]/contrib-group[1][count(contrib[@contrib-type='author' and @corresp='yes']) gt 1]/contrib[@contrib-type='author' and @corresp='yes' and name]
 Test: report    $normalized-name != $name
 Message:  has a name with letters that have diacritics or marks. Please ensure that their initials display correctly in the PDF in the 'For correspondence' section on the first page. -->
-<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML"
-  xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article article-type="research-article">
     <front>
       <article-meta>
@@ -67,8 +66,7 @@ Message:  has a name with letters that have diacritics or marks. Please ensure t
               <surname>Wheeler</surname>
               <given-names>Michael B</given-names>
             </name>
-            <contrib-id authenticated="true" contrib-id-type="orcid"
-              >https://orcid.org/0000-0002-7480-7267</contrib-id>
+            <contrib-id authenticated="true" contrib-id-type="orcid">https://orcid.org/0000-0002-7480-7267</contrib-id>
             <email>michael.wheeler@utoronto.ca</email>
             <xref ref-type="aff" rid="aff1">1</xref>
             <xref ref-type="aff" rid="aff4">4</xref>

--- a/test/tests/gen/disp-formula-tests/disp-formula-test-3/disp-formula-test-3.sch
+++ b/test/tests/gen/disp-formula-tests/disp-formula-test-3/disp-formula-test-3.sch
@@ -791,8 +791,7 @@
   </xsl:function>
   <pattern id="content-containers">
     <rule context="disp-formula" id="disp-formula-tests">
-      <assert test="parent::p" role="error" id="disp-formula-test-3">disp-formula must be a child of p. <value-of select="label"/> is a child of <value-of select="parent::*/local-name()"/>
-      </assert>
+      <assert test="parent::p" role="warning" id="disp-formula-test-3">In the vast majority of cases disp-formula should be a child of p. <value-of select="label"/> is a child of <value-of select="parent::*/local-name()"/>. Is that correct?</assert>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/disp-formula-tests/disp-formula-test-3/fail.xml
+++ b/test/tests/gen/disp-formula-tests/disp-formula-test-3/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="disp-formula-test-3.sch"?>
 <!--Context: disp-formula
 Test: assert    parent::p
-Message: disp-formula must be a child of p.  is a child of  -->
+Message: In the vast majority of cases disp-formula should be a child of p.  is a child of . Is that correct? -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>
     <front/>

--- a/test/tests/gen/disp-formula-tests/disp-formula-test-3/pass.xml
+++ b/test/tests/gen/disp-formula-tests/disp-formula-test-3/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="disp-formula-test-3.sch"?>
 <!--Context: disp-formula
 Test: assert    parent::p
-Message: disp-formula must be a child of p.  is a child of  -->
+Message: In the vast majority of cases disp-formula should be a child of p.  is a child of . Is that correct? -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>
     <front/>

--- a/test/tests/gen/disp-formula-tests/disp-formula-test-4/disp-formula-test-4.sch
+++ b/test/tests/gen/disp-formula-tests/disp-formula-test-4/disp-formula-test-4.sch
@@ -789,15 +789,15 @@
     <xsl:sequence select="count(tokenize($arg,'(\r\n?|\n\r?)'))"/>
     
   </xsl:function>
-  <pattern id="sec-specific">
-    <rule context="article[@article-type='research-article']//sec[not(@sec-type) and not(matches(.,'[Gg]ithub|[Gg]itlab|[Cc]ode[Pp]lex|[Ss]ource[Ff]orge|[Bb]it[Bb]ucket'))]" id="res-data-sec">
-      <let name="title" value="lower-case(title[1])"/>
-      <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#sec-test-3" test="contains($title,'data') and (contains($title,'availability') or contains($title,'code') or contains($title,'accessib') or contains($title,'statement'))" role="warning" id="sec-test-3">Section has a title '<value-of select="title[1]"/>'. Is it a duplicate of the data availability section (and therefore should be removed)?</report>
+  <pattern id="content-containers">
+    <rule context="disp-formula" id="disp-formula-tests">
+      <report test="parent::p and not(preceding-sibling::*) and (not(preceding-sibling::text()) or normalize-space(preceding-sibling::text()[1])='')" role="error" id="disp-formula-test-4">disp-formula cannot be placed as the first child of a p element with no content before it (ie. &gt;p&gt;&gt;disp-formula ...). Either capture it at the end of the previous paragraph or capture it as a child of <value-of select="parent::p/parent::*/local-name()"/>
+      </report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::article[@article-type='research-article']//sec[not(@sec-type) and not(matches(.,'[Gg]ithub or descendant::[Gg]itlab or descendant::[Cc]ode[Pp]lex or descendant::[Ss]ource[Ff]orge or descendant::[Bb]it[Bb]ucket'))]" role="error" id="res-data-sec-xspec-assert">article[@article-type='research-article']//sec[not(@sec-type) and not(matches(.,'[Gg]ithub|[Gg]itlab|[Cc]ode[Pp]lex|[Ss]ource[Ff]orge|[Bb]it[Bb]ucket'))] must be present.</assert>
+      <assert test="descendant::disp-formula" role="error" id="disp-formula-tests-xspec-assert">disp-formula must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/disp-formula-tests/disp-formula-test-4/fail.xml
+++ b/test/tests/gen/disp-formula-tests/disp-formula-test-4/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="disp-formula-test-4.sch"?>
+<!--Context: disp-formula
+Test: report    parent::p and not(preceding-sibling::*) and (not(preceding-sibling::text()) or normalize-space(preceding-sibling::text()[1])='')
+Message: disp-formula cannot be placed as the first child of a p element with no content before it (ie. >p>>disp-formula ...). Either capture it at the end of the previous paragraph or capture it as a child of  -->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p><disp-formula/> some text</p>
+  </article>
+</root>

--- a/test/tests/gen/disp-formula-tests/disp-formula-test-4/pass.xml
+++ b/test/tests/gen/disp-formula-tests/disp-formula-test-4/pass.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="disp-formula-test-4.sch"?>
+<!--Context: disp-formula
+Test: report    parent::p and not(preceding-sibling::*) and (not(preceding-sibling::text()) or normalize-space(preceding-sibling::text()[1])='')
+Message: disp-formula cannot be placed as the first child of a p element with no content before it (ie. >p>>disp-formula ...). Either capture it at the end of the previous paragraph or capture it as a child of  -->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <p> some text <disp-formula/> some text</p>
+  </article>
+</root>

--- a/test/tests/gen/elem-citation-patent/final-err-elem-cit-patent-11-1/fail.xml
+++ b/test/tests/gen/elem-citation-patent/final-err-elem-cit-patent-11-1/fail.xml
@@ -1,0 +1,29 @@
+<?oxygen SCHSchema="final-err-elem-cit-patent-11-1.sch"?>
+<!--Context: element-citation[@publication-type='patent']
+Test: assert    ext-link
+Message: The <ext-link> element is required in a patent reference. Reference '' has no <ext-link> elements. -->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
+  <article>
+    <ref-list>
+      <ref id="bib1">
+        <element-citation publication-type="patent">
+          <person-group person-group-type="inventor">
+            <name><surname>Patterson</surname><given-names>JB</given-names></name>
+            <name><surname>Lonergan</surname><given-names>DG</given-names></name>
+            <name><surname>Flynn</surname><given-names>GA</given-names></name>
+            <name><surname>Qingpeng</surname><given-names>Z</given-names></name>
+            <name><surname>Pallai</surname><given-names>PV</given-names></name>
+          </person-group>
+          <person-group person-group-type="assignee">
+            <collab>Mankind Corp</collab>
+          </person-group>
+          <year iso-8601-date="2011">2011</year>
+          <article-title>IRE-1alpha inhibitors</article-title>
+          <source>United States patent</source>
+          <patent country="United States">US20100941530</patent>
+          
+        </element-citation>
+      </ref>
+    </ref-list>
+  </article>
+</root>

--- a/test/tests/gen/elem-citation-patent/final-err-elem-cit-patent-11-1/final-err-elem-cit-patent-11-1.sch
+++ b/test/tests/gen/elem-citation-patent/final-err-elem-cit-patent-11-1/final-err-elem-cit-patent-11-1.sch
@@ -789,15 +789,14 @@
     <xsl:sequence select="count(tokenize($arg,'(\r\n?|\n\r?)'))"/>
     
   </xsl:function>
-  <pattern id="sec-specific">
-    <rule context="article[@article-type='research-article']//sec[not(@sec-type) and not(matches(.,'[Gg]ithub|[Gg]itlab|[Cc]ode[Pp]lex|[Ss]ource[Ff]orge|[Bb]it[Bb]ucket'))]" id="res-data-sec">
-      <let name="title" value="lower-case(title[1])"/>
-      <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#sec-test-3" test="contains($title,'data') and (contains($title,'availability') or contains($title,'code') or contains($title,'accessib') or contains($title,'statement'))" role="warning" id="sec-test-3">Section has a title '<value-of select="title[1]"/>'. Is it a duplicate of the data availability section (and therefore should be removed)?</report>
+  <pattern id="element-citation-patent-tests">
+    <rule context="element-citation[@publication-type='patent']" id="elem-citation-patent">
+      <assert test="ext-link" role="error" id="final-err-elem-cit-patent-11-1">The &lt;ext-link&gt; element is required in a patent reference. Reference '<value-of select="ancestor::ref/@id"/>' has no &lt;ext-link&gt; elements.</assert>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::article[@article-type='research-article']//sec[not(@sec-type) and not(matches(.,'[Gg]ithub or descendant::[Gg]itlab or descendant::[Cc]ode[Pp]lex or descendant::[Ss]ource[Ff]orge or descendant::[Bb]it[Bb]ucket'))]" role="error" id="res-data-sec-xspec-assert">article[@article-type='research-article']//sec[not(@sec-type) and not(matches(.,'[Gg]ithub|[Gg]itlab|[Cc]ode[Pp]lex|[Ss]ource[Ff]orge|[Bb]it[Bb]ucket'))] must be present.</assert>
+      <assert test="descendant::element-citation[@publication-type='patent']" role="error" id="elem-citation-patent-xspec-assert">element-citation[@publication-type='patent'] must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/elem-citation-patent/final-err-elem-cit-patent-11-1/pass.xml
+++ b/test/tests/gen/elem-citation-patent/final-err-elem-cit-patent-11-1/pass.xml
@@ -1,9 +1,7 @@
-<?oxygen SCHSchema="err-elem-cit-patent-11-1.sch"?>
+<?oxygen SCHSchema="final-err-elem-cit-patent-11-1.sch"?>
 <!--Context: element-citation[@publication-type='patent']
 Test: assert    ext-link
-Message: [err-elem-cit-patent-11-1]
-        The <ext-link> element is required.
-        Reference '' has no <ext-link> elements. -->
+Message: The <ext-link> element is required in a patent reference. Reference '' has no <ext-link> elements. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <ref-list>
@@ -23,7 +21,7 @@ Message: [err-elem-cit-patent-11-1]
           <article-title>IRE-1alpha inhibitors</article-title>
           <source>United States patent</source>
           <patent country="United States">US20100941530</patent>
-          
+          <ext-link ext-link-type="uri" xlink:href="http://europepmc.org/patents/PAT/US2011065162">http://europepmc.org/patents/PAT/US2011065162</ext-link>
         </element-citation>
       </ref>
     </ref-list>

--- a/test/tests/gen/elem-citation-patent/pre-err-elem-cit-patent-11-1/fail.xml
+++ b/test/tests/gen/elem-citation-patent/pre-err-elem-cit-patent-11-1/fail.xml
@@ -1,9 +1,7 @@
-<?oxygen SCHSchema="err-elem-cit-patent-11-1.sch"?>
+<?oxygen SCHSchema="pre-err-elem-cit-patent-11-1.sch"?>
 <!--Context: element-citation[@publication-type='patent']
 Test: assert    ext-link
-Message: [err-elem-cit-patent-11-1]
-        The <ext-link> element is required.
-        Reference '' has no <ext-link> elements. -->
+Message: The <ext-link> element is required in a patent reference. Reference '' has no <ext-link> elements. If you are unable to determine this yourself, please add an author query asking for this. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <ref-list>
@@ -23,7 +21,7 @@ Message: [err-elem-cit-patent-11-1]
           <article-title>IRE-1alpha inhibitors</article-title>
           <source>United States patent</source>
           <patent country="United States">US20100941530</patent>
-          <ext-link ext-link-type="uri" xlink:href="http://europepmc.org/patents/PAT/US2011065162">http://europepmc.org/patents/PAT/US2011065162</ext-link>
+          
         </element-citation>
       </ref>
     </ref-list>

--- a/test/tests/gen/elem-citation-patent/pre-err-elem-cit-patent-11-1/pass.xml
+++ b/test/tests/gen/elem-citation-patent/pre-err-elem-cit-patent-11-1/pass.xml
@@ -1,0 +1,29 @@
+<?oxygen SCHSchema="pre-err-elem-cit-patent-11-1.sch"?>
+<!--Context: element-citation[@publication-type='patent']
+Test: assert    ext-link
+Message: The <ext-link> element is required in a patent reference. Reference '' has no <ext-link> elements. If you are unable to determine this yourself, please add an author query asking for this. -->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
+  <article>
+    <ref-list>
+      <ref id="bib1">
+        <element-citation publication-type="patent">
+          <person-group person-group-type="inventor">
+            <name><surname>Patterson</surname><given-names>JB</given-names></name>
+            <name><surname>Lonergan</surname><given-names>DG</given-names></name>
+            <name><surname>Flynn</surname><given-names>GA</given-names></name>
+            <name><surname>Qingpeng</surname><given-names>Z</given-names></name>
+            <name><surname>Pallai</surname><given-names>PV</given-names></name>
+          </person-group>
+          <person-group person-group-type="assignee">
+            <collab>Mankind Corp</collab>
+          </person-group>
+          <year iso-8601-date="2011">2011</year>
+          <article-title>IRE-1alpha inhibitors</article-title>
+          <source>United States patent</source>
+          <patent country="United States">US20100941530</patent>
+          <ext-link ext-link-type="uri" xlink:href="http://europepmc.org/patents/PAT/US2011065162">http://europepmc.org/patents/PAT/US2011065162</ext-link>
+        </element-citation>
+      </ref>
+    </ref-list>
+  </article>
+</root>

--- a/test/tests/gen/elem-citation-patent/pre-err-elem-cit-patent-11-1/pre-err-elem-cit-patent-11-1.sch
+++ b/test/tests/gen/elem-citation-patent/pre-err-elem-cit-patent-11-1/pre-err-elem-cit-patent-11-1.sch
@@ -791,9 +791,7 @@
   </xsl:function>
   <pattern id="element-citation-patent-tests">
     <rule context="element-citation[@publication-type='patent']" id="elem-citation-patent">
-      <assert test="ext-link" role="error" id="err-elem-cit-patent-11-1">[err-elem-cit-patent-11-1]
-        The &lt;ext-link&gt; element is required.
-        Reference '<value-of select="ancestor::ref/@id"/>' has no &lt;ext-link&gt; elements.</assert>
+      <assert test="ext-link" role="warning" id="pre-err-elem-cit-patent-11-1">The &lt;ext-link&gt; element is required in a patent reference. Reference '<value-of select="ancestor::ref/@id"/>' has no &lt;ext-link&gt; elements. If you are unable to determine this yourself, please add an author query asking for this.</assert>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/ext-link-tests/url-conformance-test/fail.xml
+++ b/test/tests/gen/ext-link-tests/url-conformance-test/fail.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="url-conformance-test.sch"?>
 <!--Context: ext-link[@ext-link-type='uri']
-Test: assert    matches(@xlink:href,'^https?:..(www\.)?[-a-zA-Z0-9@:%.,_\+~#=]{2,256}\.[a-z]{2,6}([-a-zA-Z0-9@:%,_\\(\)+.~#?&//=]*)$|^ftp://.|^git://.|^tel:.|^mailto:.')
+Test: assert    matches(@xlink:href,'^https?:..(www\.)?[-a-zA-Z0-9@:%.,_\+~#=!]{2,256}\.[a-z]{2,6}([-a-zA-Z0-9@:%,_\\(\)+.~#?!&//=]*)$|^ftp://.|^git://.|^tel:.|^mailto:.')
 Message: @xlink:href doesn't look like a URL - ''. Is this correct? -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>

--- a/test/tests/gen/ext-link-tests/url-conformance-test/pass.xml
+++ b/test/tests/gen/ext-link-tests/url-conformance-test/pass.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="url-conformance-test.sch"?>
 <!--Context: ext-link[@ext-link-type='uri']
-Test: assert    matches(@xlink:href,'^https?:..(www\.)?[-a-zA-Z0-9@:%.,_\+~#=]{2,256}\.[a-z]{2,6}([-a-zA-Z0-9@:%,_\\(\)+.~#?&//=]*)$|^ftp://.|^git://.|^tel:.|^mailto:.')
+Test: assert    matches(@xlink:href,'^https?:..(www\.)?[-a-zA-Z0-9@:%.,_\+~#=!]{2,256}\.[a-z]{2,6}([-a-zA-Z0-9@:%,_\\(\)+.~#?!&//=]*)$|^ftp://.|^git://.|^tel:.|^mailto:.')
 Message: @xlink:href doesn't look like a URL - ''. Is this correct? -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>

--- a/test/tests/gen/ext-link-tests/url-conformance-test/url-conformance-test.sch
+++ b/test/tests/gen/ext-link-tests/url-conformance-test/url-conformance-test.sch
@@ -795,7 +795,7 @@
       <let name="parent" value="parent::*[1]/local-name()"/>
       <let name="form-children" value="string-join(         for $x in child::* return if ($x/local-name()=$formatting-elems) then $x/local-name()         else ()         ,', ')"/>
       <let name="non-form-children" value="string-join(         for $x in child::* return if ($x/local-name()=$formatting-elems) then ()         else ($x/local-name())         ,', ')"/>
-      <assert test="matches(@xlink:href,'^https?:..(www\.)?[-a-zA-Z0-9@:%.,_\+~#=]{2,256}\.[a-z]{2,6}([-a-zA-Z0-9@:%,_\\(\)+.~#?&amp;//=]*)$|^ftp://.|^git://.|^tel:.|^mailto:.')" role="warning" id="url-conformance-test">@xlink:href doesn't look like a URL - '<value-of select="@xlink:href"/>'. Is this correct?</assert>
+      <assert test="matches(@xlink:href,'^https?:..(www\.)?[-a-zA-Z0-9@:%.,_\+~#=!]{2,256}\.[a-z]{2,6}([-a-zA-Z0-9@:%,_\\(\)+.~#?!&amp;//=]*)$|^ftp://.|^git://.|^tel:.|^mailto:.')" role="warning" id="url-conformance-test">@xlink:href doesn't look like a URL - '<value-of select="@xlink:href"/>'. Is this correct?</assert>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/gen-das-tests/das-elem-cit-5/das-elem-cit-5.sch
+++ b/test/tests/gen/gen-das-tests/das-elem-cit-5/das-elem-cit-5.sch
@@ -789,15 +789,15 @@
     <xsl:sequence select="count(tokenize($arg,'(\r\n?|\n\r?)'))"/>
     
   </xsl:function>
-  <pattern id="sec-specific">
-    <rule context="article[@article-type='research-article']//sec[not(@sec-type) and not(matches(.,'[Gg]ithub|[Gg]itlab|[Cc]ode[Pp]lex|[Ss]ource[Ff]orge|[Bb]it[Bb]ucket'))]" id="res-data-sec">
-      <let name="title" value="lower-case(title[1])"/>
-      <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#sec-test-3" test="contains($title,'data') and (contains($title,'availability') or contains($title,'code') or contains($title,'accessib') or contains($title,'statement'))" role="warning" id="sec-test-3">Section has a title '<value-of select="title[1]"/>'. Is it a duplicate of the data availability section (and therefore should be removed)?</report>
+  <pattern id="das-element-citation-tests">
+    <rule context="sec[@sec-type='data-availability']//element-citation[@publication-type='data']" id="gen-das-tests">
+      <let name="pos" value="count(ancestor::sec[@sec-type='data-availability']//element-citation[@publication-type='data']) - count(following::element-citation[@publication-type='data' and ancestor::sec[@sec-type='data-availability']])"/>
+      <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#das-elem-cit-5" test="pub-id[1] = following::element-citation[ancestor::ref-list]/pub-id[1]" role="warning" id="das-elem-cit-5">The reference in position <value-of select="$pos"/> of the data availability section has a pub-id (<value-of select="pub-id[1]"/>) which is the same as in another reference in the reference list. Is the same reference in both the reference list and data availability section?</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::article[@article-type='research-article']//sec[not(@sec-type) and not(matches(.,'[Gg]ithub or descendant::[Gg]itlab or descendant::[Cc]ode[Pp]lex or descendant::[Ss]ource[Ff]orge or descendant::[Bb]it[Bb]ucket'))]" role="error" id="res-data-sec-xspec-assert">article[@article-type='research-article']//sec[not(@sec-type) and not(matches(.,'[Gg]ithub|[Gg]itlab|[Cc]ode[Pp]lex|[Ss]ource[Ff]orge|[Bb]it[Bb]ucket'))] must be present.</assert>
+      <assert test="descendant::sec[@sec-type='data-availability']//element-citation[@publication-type='data']" role="error" id="gen-das-tests-xspec-assert">sec[@sec-type='data-availability']//element-citation[@publication-type='data'] must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/gen-das-tests/das-elem-cit-5/fail.xml
+++ b/test/tests/gen/gen-das-tests/das-elem-cit-5/fail.xml
@@ -1,0 +1,40 @@
+<?oxygen SCHSchema="das-elem-cit-5.sch"?>
+<!--Context: sec[@sec-type='data-availability']//element-citation[@publication-type='data']
+Test: report    pub-id[1] = following::element-citation[ancestor::ref-list]/pub-id[1]
+Message: The reference in position  of the data availability section has a pub-id () which is the same as in another reference in the reference list. Is the same reference in both the reference list and data availability section? -->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <back>
+      <sec sec-type="data-availability" id="s7">
+        <title>Data availability</title>
+        <p/>
+        <p>The following dataset was generated:</p>
+        <p>
+          <element-citation publication-type="data" specific-use="isSupplementedBy" id="dataset1">
+            <person-group person-group-type="author">
+              <name><surname>Roan</surname><given-names>NR</given-names></name>
+            </person-group>
+            <year iso-8601-date="2020">2020</year>
+            <data-title>Phenotypic Analysis of the Unstimulated In Vivo HIV CD4 T Cell Reservoir</data-title>
+            <source>Dryad Digital Repository</source>
+            <pub-id assigning-authority="Dryad" pub-id-type="doi">10.7272/Q6KK991S</pub-id>
+          </element-citation>
+        </p>
+      </sec>
+      <ref-list>
+        <title>References</title>
+        <ref id="bib1">
+          <element-citation publication-type="data" specific-use="isSupplementedBy" id="dataset1">
+            <person-group person-group-type="author">
+              <name><surname>Roan</surname><given-names>NR</given-names></name>
+            </person-group>
+            <year iso-8601-date="2020">2020</year>
+            <data-title>Phenotypic Analysis of the Unstimulated In Vivo HIV CD4 T Cell Reservoir</data-title>
+            <source>Dryad Digital Repository</source>
+            <pub-id assigning-authority="Dryad" pub-id-type="doi">10.7272/Q6KK991S</pub-id>
+          </element-citation>
+        </ref>
+      </ref-list>
+    </back>
+  </article>
+</root>

--- a/test/tests/gen/gen-das-tests/das-elem-cit-5/pass.xml
+++ b/test/tests/gen/gen-das-tests/das-elem-cit-5/pass.xml
@@ -1,0 +1,26 @@
+<?oxygen SCHSchema="das-elem-cit-5.sch"?>
+<!--Context: sec[@sec-type='data-availability']//element-citation[@publication-type='data']
+Test: report    pub-id[1] = following::element-citation[ancestor::ref-list]/pub-id[1]
+Message: The reference in position  of the data availability section has a pub-id () which is the same as in another reference in the reference list. Is the same reference in both the reference list and data availability section? -->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <back>
+      <sec sec-type="data-availability" id="s7">
+        <title>Data availability</title>
+        <p/>
+        <p>The following dataset was generated:</p>
+        <p>
+          <element-citation publication-type="data" specific-use="isSupplementedBy" id="dataset1">
+            <person-group person-group-type="author">
+              <name><surname>Roan</surname><given-names>NR</given-names></name>
+            </person-group>
+            <year iso-8601-date="2020">2020</year>
+            <data-title>Phenotypic Analysis of the Unstimulated In Vivo HIV CD4 T Cell Reservoir</data-title>
+            <source>Dryad Digital Repository</source>
+            <pub-id assigning-authority="Dryad" pub-id-type="doi">10.7272/Q6KK991S</pub-id>
+          </element-citation>
+        </p>
+      </sec>
+    </back>
+  </article>
+</root>

--- a/test/tests/gen/res-data-sec/sec-test-3/fail.xml
+++ b/test/tests/gen/res-data-sec/sec-test-3/fail.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="sec-test-3.sch"?>
-<!--Context: article[@article-type='research-article']//sec[not(@sec-type) and not(descendant::xref[@ref-type='bibr']) and not(matches(.,'[Gg]ithub|[Gg]itlab|[Cc]ode[Pp]lex|[Ss]ource[Ff]orge|[Bb]it[Bb]ucket'))]
-Test: report    matches(title[1],'[Dd]ata') and (matches(title[1],'[Aa]vailability') or matches(title[1],'[Cc]ode') or matches(title[1],'[Aa]ccessib') or matches(title[1],'[Ss]atement'))
+<!--Context: article[@article-type='research-article']//sec[not(@sec-type) and not(matches(.,'[Gg]ithub|[Gg]itlab|[Cc]ode[Pp]lex|[Ss]ource[Ff]orge|[Bb]it[Bb]ucket'))]
+Test: report    contains($title,'data') and (contains($title,'availability') or contains($title,'code') or contains($title,'accessib') or contains($title,'statement'))
 Message: Section has a title ''. Is it a duplicate of the data availability section (and therefore should be removed)? -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article article-type="research-article">

--- a/test/tests/gen/res-data-sec/sec-test-3/pass.xml
+++ b/test/tests/gen/res-data-sec/sec-test-3/pass.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="sec-test-3.sch"?>
-<!--Context: article[@article-type='research-article']//sec[not(@sec-type) and not(descendant::xref[@ref-type='bibr']) and not(matches(.,'[Gg]ithub|[Gg]itlab|[Cc]ode[Pp]lex|[Ss]ource[Ff]orge|[Bb]it[Bb]ucket'))]
-Test: report    matches(title[1],'[Dd]ata') and (matches(title[1],'[Aa]vailability') or matches(title[1],'[Cc]ode') or matches(title[1],'[Aa]ccessib') or matches(title[1],'[Ss]atement'))
+<!--Context: article[@article-type='research-article']//sec[not(@sec-type) and not(matches(.,'[Gg]ithub|[Gg]itlab|[Cc]ode[Pp]lex|[Ss]ource[Ff]orge|[Bb]it[Bb]ucket'))]
+Test: report    contains($title,'data') and (contains($title,'availability') or contains($title,'code') or contains($title,'accessib') or contains($title,'statement'))
 Message: Section has a title ''. Is it a duplicate of the data availability section (and therefore should be removed)? -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article article-type="research-article">

--- a/test/xspec/schematron.sch
+++ b/test/xspec/schematron.sch
@@ -1268,7 +1268,7 @@
   </pattern>
   <pattern id="corresp-author-initial-tests-pattern">
     <rule context="article[@article-type=('research-article','review-article','discussion')]//article-meta[not(descendant::custom-meta[meta-name='Template']/meta-value='3')]/contrib-group[1][count(contrib[@contrib-type='author' and @corresp='yes']) gt 1]/contrib[@contrib-type='author' and @corresp='yes' and name]" id="corresp-author-initial-tests">
-      <let name="name" value="e:get-name(name)"/>
+      <let name="name" value="e:get-name(name[1])"/>
       <let name="normalized-name" value="e:stripDiacritics($name)"/>
       
       <report test="$normalized-name != $name" role="warning" id="corresp-author-initial-test">
@@ -1925,7 +1925,7 @@
         id="broken-uri-test">Broken URI in @xlink:href</assert>-->
       
       <!-- Needs further testing. Presume that we want to ensure a url follows certain URI schemes. -->
-      <assert test="matches(@xlink:href,'^https?:..(www\.)?[-a-zA-Z0-9@:%.,_\+~#=]{2,256}\.[a-z]{2,6}([-a-zA-Z0-9@:%,_\\(\)+.~#?&amp;//=]*)$|^ftp://.|^git://.|^tel:.|^mailto:.')" role="warning" id="url-conformance-test">@xlink:href doesn't look like a URL - '<value-of select="@xlink:href"/>'. Is this correct?</assert>
+      <assert test="matches(@xlink:href,'^https?:..(www\.)?[-a-zA-Z0-9@:%.,_\+~#=!]{2,256}\.[a-z]{2,6}([-a-zA-Z0-9@:%,_\\(\)+.~#?!&amp;//=]*)$|^ftp://.|^git://.|^tel:.|^mailto:.')" role="warning" id="url-conformance-test">@xlink:href doesn't look like a URL - '<value-of select="@xlink:href"/>'. Is this correct?</assert>
       
       <report test="matches(@xlink:href,'^(ftp|sftp)://\S+:\S+@')" role="warning" id="ftp-credentials-flag">@xlink:href contains what looks like a link to an FTP site which contains credentials (username and password) - '<value-of select="@xlink:href"/>'. If the link without credentials works (<value-of select="concat(substring-before(@xlink:href,'://'),'://',substring-after(@xlink:href,'@'))"/>), then please replace it with that and notify the authors that you have done so. If the link without credentials does not work, please query with the authors in order to obtain a link without credentials.</report>
       
@@ -2210,8 +2210,10 @@
       
       <assert test="mml:math" role="error" id="disp-formula-test-2">disp-formula must contain an mml:math element.</assert>
       
-      <assert test="parent::p" role="error" id="disp-formula-test-3">disp-formula must be a child of p. <value-of select="label"/> is a child of <value-of select="parent::*/local-name()"/>
-      </assert>
+      <assert test="parent::p" role="warning" id="disp-formula-test-3">In the vast majority of cases disp-formula should be a child of p. <value-of select="label"/> is a child of <value-of select="parent::*/local-name()"/>. Is that correct?</assert>
+      
+      <report test="parent::p and not(preceding-sibling::*) and (not(preceding-sibling::text()) or normalize-space(preceding-sibling::text()[1])='')" role="error" id="disp-formula-test-4">disp-formula cannot be placed as the first child of a p element with no content before it (ie. &gt;p&gt;&gt;disp-formula ...). Either capture it at the end of the previous paragraph or capture it as a child of <value-of select="parent::p/parent::*/local-name()"/>
+      </report>
     </rule>
   </pattern>
   <pattern id="inline-formula-tests-pattern">
@@ -3349,9 +3351,10 @@
     </rule>
   </pattern>
   <pattern id="res-data-sec-pattern">
-    <rule context="article[@article-type='research-article']//sec[not(@sec-type) and not(descendant::xref[@ref-type='bibr']) and not(matches(.,'[Gg]ithub|[Gg]itlab|[Cc]ode[Pp]lex|[Ss]ource[Ff]orge|[Bb]it[Bb]ucket'))]" id="res-data-sec">
+    <rule context="article[@article-type='research-article']//sec[not(@sec-type) and not(matches(.,'[Gg]ithub|[Gg]itlab|[Cc]ode[Pp]lex|[Ss]ource[Ff]orge|[Bb]it[Bb]ucket'))]" id="res-data-sec">
+      <let name="title" value="lower-case(title[1])"/>
       
-      <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#sec-test-3" test="matches(title[1],'[Dd]ata') and (matches(title[1],'[Aa]vailability') or matches(title[1],'[Cc]ode') or matches(title[1],'[Aa]ccessib') or matches(title[1],'[Ss]atement'))" role="warning" id="sec-test-3">Section has a title '<value-of select="title[1]"/>'. Is it a duplicate of the data availability section (and therefore should be removed)?</report>
+      <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#sec-test-3" test="contains($title,'data') and (contains($title,'availability') or contains($title,'code') or contains($title,'accessib') or contains($title,'statement'))" role="warning" id="sec-test-3">Section has a title '<value-of select="title[1]"/>'. Is it a duplicate of the data availability section (and therefore should be removed)?</report>
       
     </rule>
   </pattern>
@@ -4245,9 +4248,9 @@
         The  &lt;patent&gt; element is required. 
         Reference '<value-of select="ancestor::ref/@id"/>' has no &lt;patent&gt; elements.</assert>
       
-      <assert test="ext-link" role="error" id="err-elem-cit-patent-11-1">[err-elem-cit-patent-11-1]
-        The &lt;ext-link&gt; element is required.
-        Reference '<value-of select="ancestor::ref/@id"/>' has no &lt;ext-link&gt; elements.</assert>
+      <assert test="ext-link" role="warning" id="pre-err-elem-cit-patent-11-1">The &lt;ext-link&gt; element is required in a patent reference. Reference '<value-of select="ancestor::ref/@id"/>' has no &lt;ext-link&gt; elements. If you are unable to determine this yourself, please add an author query asking for this.</assert>
+      
+      <assert test="ext-link" role="error" id="final-err-elem-cit-patent-11-1">The &lt;ext-link&gt; element is required in a patent reference. Reference '<value-of select="ancestor::ref/@id"/>' has no &lt;ext-link&gt; elements.</assert>
       
       <assert test="count(*) = count(person-group| article-title| source| year| patent| ext-link)" role="error" id="err-elem-cit-patent-18">[err-elem-cit-patent-18]
         The only tags that are allowed as children of &lt;element-citation&gt; with the publication-type="patent" are:
@@ -5079,6 +5082,8 @@
       <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#pre-das-elem-cit-3" test="pub-id[1]/@xlink:href = preceding::element-citation[(@publication-type='data') and ancestor::sec[@sec-type='data-availability']]/pub-id[1]/@xlink:href" role="error" id="final-das-elem-cit-3">The reference in position <value-of select="$pos"/> of the data availability section has a link (<value-of select="pub-id[1]/@xlink:href"/>) which is the same as another dataset reference in that section. Dataset reference links should be distinct.</report>
       
       <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#das-elem-cit-4" test="pub-id[1] = preceding::element-citation[(@publication-type='data') and ancestor::sec[@sec-type='data-availability']]/pub-id[1]" role="warning" id="das-elem-cit-4">The reference in position <value-of select="$pos"/> of the data availability section has a pub-id (<value-of select="pub-id[1]"/>) which is the same as another dataset reference in that section. This is very likely incorrect. Dataset reference pub-id should be distinct.</report>
+      
+      <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/data-availability#das-elem-cit-5" test="pub-id[1] = following::element-citation[ancestor::ref-list]/pub-id[1]" role="warning" id="das-elem-cit-5">The reference in position <value-of select="$pos"/> of the data availability section has a pub-id (<value-of select="pub-id[1]"/>) which is the same as in another reference in the reference list. Is the same reference in both the reference list and data availability section?</report>
       
     </rule>
   </pattern>
@@ -7852,7 +7857,7 @@
       <assert test="descendant::supplementary-material/*" role="error" id="supplementary-material-children-xspec-assert">supplementary-material/* must be present.</assert>
       <assert test="descendant::author-notes/*" role="error" id="author-notes-children-xspec-assert">author-notes/* must be present.</assert>
       <assert test="descendant::sec" role="error" id="sec-tests-xspec-assert">sec must be present.</assert>
-      <assert test="descendant::article[@article-type='research-article']//sec[not(@sec-type) and not(descendant::xref[@ref-type='bibr']) and not(matches(.,'[Gg]ithub or descendant::[Gg]itlab or descendant::[Cc]ode[Pp]lex or descendant::[Ss]ource[Ff]orge or descendant::[Bb]it[Bb]ucket'))]" role="error" id="res-data-sec-xspec-assert">article[@article-type='research-article']//sec[not(@sec-type) and not(descendant::xref[@ref-type='bibr']) and not(matches(.,'[Gg]ithub|[Gg]itlab|[Cc]ode[Pp]lex|[Ss]ource[Ff]orge|[Bb]it[Bb]ucket'))] must be present.</assert>
+      <assert test="descendant::article[@article-type='research-article']//sec[not(@sec-type) and not(matches(.,'[Gg]ithub or descendant::[Gg]itlab or descendant::[Cc]ode[Pp]lex or descendant::[Ss]ource[Ff]orge or descendant::[Bb]it[Bb]ucket'))]" role="error" id="res-data-sec-xspec-assert">article[@article-type='research-article']//sec[not(@sec-type) and not(matches(.,'[Gg]ithub|[Gg]itlab|[Cc]ode[Pp]lex|[Ss]ource[Ff]orge|[Bb]it[Bb]ucket'))] must be present.</assert>
       <assert test="descendant::article[@article-type='research-article']//sec[not(descendant::xref[@ref-type='bibr'])]" role="error" id="res-ethics-sec-xspec-assert">article[@article-type='research-article']//sec[not(descendant::xref[@ref-type='bibr'])] must be present.</assert>
       <assert test="descendant::back" role="error" id="back-tests-xspec-assert">back must be present.</assert>
       <assert test="descendant::back/sec[@sec-type='data-availability']" role="error" id="data-content-tests-xspec-assert">back/sec[@sec-type='data-availability'] must be present.</assert>

--- a/test/xspec/schematron.xspec
+++ b/test/xspec/schematron.xspec
@@ -3789,12 +3789,22 @@
       </x:scenario>
       <x:scenario label="disp-formula-test-3-pass">
         <x:context href="../tests/gen/disp-formula-tests/disp-formula-test-3/pass.xml"/>
-        <x:expect-not-assert id="disp-formula-test-3" role="error"/>
+        <x:expect-not-assert id="disp-formula-test-3" role="warning"/>
         <x:expect-not-assert id="disp-formula-tests-xspec-assert" role="error"/>
       </x:scenario>
       <x:scenario label="disp-formula-test-3-fail">
         <x:context href="../tests/gen/disp-formula-tests/disp-formula-test-3/fail.xml"/>
-        <x:expect-assert id="disp-formula-test-3" role="error"/>
+        <x:expect-assert id="disp-formula-test-3" role="warning"/>
+        <x:expect-not-assert id="disp-formula-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="disp-formula-test-4-pass">
+        <x:context href="../tests/gen/disp-formula-tests/disp-formula-test-4/pass.xml"/>
+        <x:expect-not-report id="disp-formula-test-4" role="error"/>
+        <x:expect-not-assert id="disp-formula-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="disp-formula-test-4-fail">
+        <x:context href="../tests/gen/disp-formula-tests/disp-formula-test-4/fail.xml"/>
+        <x:expect-report id="disp-formula-test-4" role="error"/>
         <x:expect-not-assert id="disp-formula-tests-xspec-assert" role="error"/>
       </x:scenario>
     </x:scenario>
@@ -8201,14 +8211,24 @@
         <x:expect-assert id="err-elem-cit-patent-10-1-1" role="error"/>
         <x:expect-not-assert id="elem-citation-patent-xspec-assert" role="error"/>
       </x:scenario>
-      <x:scenario label="err-elem-cit-patent-11-1-pass">
-        <x:context href="../tests/gen/elem-citation-patent/err-elem-cit-patent-11-1/pass.xml"/>
-        <x:expect-not-assert id="err-elem-cit-patent-11-1" role="error"/>
+      <x:scenario label="pre-err-elem-cit-patent-11-1-pass">
+        <x:context href="../tests/gen/elem-citation-patent/pre-err-elem-cit-patent-11-1/pass.xml"/>
+        <x:expect-not-assert id="pre-err-elem-cit-patent-11-1" role="warning"/>
         <x:expect-not-assert id="elem-citation-patent-xspec-assert" role="error"/>
       </x:scenario>
-      <x:scenario label="err-elem-cit-patent-11-1-fail">
-        <x:context href="../tests/gen/elem-citation-patent/err-elem-cit-patent-11-1/fail.xml"/>
-        <x:expect-assert id="err-elem-cit-patent-11-1" role="error"/>
+      <x:scenario label="pre-err-elem-cit-patent-11-1-fail">
+        <x:context href="../tests/gen/elem-citation-patent/pre-err-elem-cit-patent-11-1/fail.xml"/>
+        <x:expect-assert id="pre-err-elem-cit-patent-11-1" role="warning"/>
+        <x:expect-not-assert id="elem-citation-patent-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="final-err-elem-cit-patent-11-1-pass">
+        <x:context href="../tests/gen/elem-citation-patent/final-err-elem-cit-patent-11-1/pass.xml"/>
+        <x:expect-not-assert id="final-err-elem-cit-patent-11-1" role="error"/>
+        <x:expect-not-assert id="elem-citation-patent-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="final-err-elem-cit-patent-11-1-fail">
+        <x:context href="../tests/gen/elem-citation-patent/final-err-elem-cit-patent-11-1/fail.xml"/>
+        <x:expect-assert id="final-err-elem-cit-patent-11-1" role="error"/>
         <x:expect-not-assert id="elem-citation-patent-xspec-assert" role="error"/>
       </x:scenario>
       <x:scenario label="err-elem-cit-patent-18-pass">
@@ -9595,6 +9615,16 @@
       <x:scenario label="das-elem-cit-4-fail">
         <x:context href="../tests/gen/gen-das-tests/das-elem-cit-4/fail.xml"/>
         <x:expect-report id="das-elem-cit-4" role="warning"/>
+        <x:expect-not-assert id="gen-das-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="das-elem-cit-5-pass">
+        <x:context href="../tests/gen/gen-das-tests/das-elem-cit-5/pass.xml"/>
+        <x:expect-not-report id="das-elem-cit-5" role="warning"/>
+        <x:expect-not-assert id="gen-das-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="das-elem-cit-5-fail">
+        <x:context href="../tests/gen/gen-das-tests/das-elem-cit-5/fail.xml"/>
+        <x:expect-report id="das-elem-cit-5" role="warning"/>
         <x:expect-not-assert id="gen-das-tests-xspec-assert" role="error"/>
       </x:scenario>
     </x:scenario>


### PR DESCRIPTION
- Specify first `name` element in variable invocation of `e:get-name` to avoid fatal errors
- Fix for `url-conformance-test`
- Downgrade `disp-formula-test-3` to warning.
- Add error for instances of `<p><disp-formula>` (`disp-formula-test-4`) per elifesciences/issues#6130
- perf and fix for `res-data-sec`.
- Warning for same reference in both DAS and ref list - das-elem-cit-5
- Split `err-elem-cit-patent-11-1` into `pre` and `final` versions