### PR TITLE
improvement: add maths check

### DIFF
--- a/src/final-JATS-schematron.sch
+++ b/src/final-JATS-schematron.sch
@@ -831,8 +831,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">
@@ -2330,6 +2330,8 @@
       <report test="child::mml:msqrt and matches($data,'^±\d+%$|^+\d+%$|^-\d+%$|^\d+%$|^±\d+$|^+\d+$|^-\d+$')" role="warning" id="math-test-17">[math-test-17] mml:math only contains number(s) and square root symbol(s) '<value-of select="."/>', which is likely unnecessary. Should this be captured as normal text instead? Such as <value-of select="concat('√',.)"/>?</report>
       
       <report test="ancestor::abstract" role="warning" id="math-test-18">[math-test-18] abstract contains MathML (<value-of select="."/>). Is this necessary? MathML in abstracts may not render downstream, so if it can be represented using normal text/unicode, then please do so instead.</report>
+      
+      <report test="descendant::mml:mi[(.='') and preceding-sibling::*[1][(local-name() = 'mi') and matches(.,'[A-Za-z]')] and following-sibling::*[1][(local-name() = 'mi') and matches(.,'[A-Za-z]')]]" role="warning" id="math-test-19">[math-test-19] Maths containing '<value-of select="."/>' has what looks like words or terms which need separating with a space. With it's current markup the space will not be preserved on the eLife website. Please add in the space(s) using the latext '\;' in the appropriate place(s), so that the space is preserved in the HTML.</report>
     </rule>
   </pattern>
   <pattern id="disp-formula-child-tests-pattern">
@@ -6898,7 +6900,7 @@
       
       <report test="($italic-count != 0) and ($roman-count gt $italic-count)" role="warning" id="latin-italic-info">[latin-italic-info] Latin terms are not consistenly either roman or italic. There are <value-of select="$roman-count"/> roman terms which is more common, and <value-of select="$italic-count"/> italic term(s). The following terms should be unitalicised: <value-of select="e:print-latin-terms($latin-terms//*:list[@list-type='italic'])"/>.</report>
       
-      <report test="($roman-count != 0) and ($italic-count gt $roman-count)" role="warning" id="latin-roman-info">[latin-roman-info] Latin terms are not consistenly either roman or italic. There are <value-of select="$italic-count"/> italic terms which is more common, and <value-of select="$roman-count"/> roman term(s). The following terms should be unitalicised: <value-of select="e:print-latin-terms($latin-terms//*:list[@list-type='italic'])"/>.</report>
+      <report test="($roman-count != 0) and ($italic-count gt $roman-count)" role="warning" id="latin-roman-info">[latin-roman-info] Latin terms are not consistenly either roman or italic. There are <value-of select="$italic-count"/> italic terms which is more common, and <value-of select="$roman-count"/> roman term(s). The following terms should be italicised: <value-of select="e:print-latin-terms($latin-terms//*:list[@list-type='roman'])"/>.</report>
       
       <report test="($roman-count != 0) and ($italic-count = $roman-count)" role="warning" id="latin-conformance-info">[latin-conformance-info] Latin terms are not consistenly either roman or italic. There are an equal number of italic (<value-of select="$italic-count"/>) and roman (<value-of select="$roman-count"/>) terms. The following terms are italicised: <value-of select="e:print-latin-terms($latin-terms//*:list[@list-type='italic'])"/>. The following terms are unitalicised: <value-of select="e:print-latin-terms($latin-terms//*:list[@list-type='roman'])"/>.</report>
     </rule>

--- a/src/final-JATS-schematron.xsl
+++ b/src/final-JATS-schematron.xsl
@@ -793,8 +793,8 @@
       <xsl:param name="article" as="element()"/>
       <xsl:param name="regex" as="xs:string"/>
     
-      <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-      <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+      <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+      <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
       <xsl:element name="result">
@@ -11626,6 +11626,20 @@
             <svrl:text>[math-test-18] abstract contains MathML (<xsl:text/>
                <xsl:value-of select="."/>
                <xsl:text/>). Is this necessary? MathML in abstracts may not render downstream, so if it can be represented using normal text/unicode, then please do so instead.</svrl:text>
+         </svrl:successful-report>
+      </xsl:if>
+
+		    <!--REPORT warning-->
+      <xsl:if test="descendant::mml:mi[(.='') and preceding-sibling::*[1][(local-name() = 'mi') and matches(.,'[A-Za-z]')] and following-sibling::*[1][(local-name() = 'mi') and matches(.,'[A-Za-z]')]]">
+         <svrl:successful-report xmlns:svrl="http://purl.oclc.org/dsdl/svrl" test="descendant::mml:mi[(.='') and preceding-sibling::*[1][(local-name() = 'mi') and matches(.,'[A-Za-z]')] and following-sibling::*[1][(local-name() = 'mi') and matches(.,'[A-Za-z]')]]">
+            <xsl:attribute name="id">math-test-19</xsl:attribute>
+            <xsl:attribute name="role">warning</xsl:attribute>
+            <xsl:attribute name="location">
+               <xsl:apply-templates select="." mode="schematron-select-full-path"/>
+            </xsl:attribute>
+            <svrl:text>[math-test-19] Maths containing '<xsl:text/>
+               <xsl:value-of select="."/>
+               <xsl:text/>' has what looks like words or terms which need separating with a space. With it's current markup the space will not be preserved on the eLife website. Please add in the space(s) using the latext '\;' in the appropriate place(s), so that the space is preserved in the HTML.</svrl:text>
          </svrl:successful-report>
       </xsl:if>
       <xsl:apply-templates select="*" mode="M138"/>
@@ -33590,8 +33604,8 @@
                <xsl:value-of select="$italic-count"/>
                <xsl:text/> italic terms which is more common, and <xsl:text/>
                <xsl:value-of select="$roman-count"/>
-               <xsl:text/> roman term(s). The following terms should be unitalicised: <xsl:text/>
-               <xsl:value-of select="e:print-latin-terms($latin-terms//*:list[@list-type='italic'])"/>
+               <xsl:text/> roman term(s). The following terms should be italicised: <xsl:text/>
+               <xsl:value-of select="e:print-latin-terms($latin-terms//*:list[@list-type='roman'])"/>
                <xsl:text/>.</svrl:text>
          </svrl:successful-report>
       </xsl:if>

--- a/src/final-package-JATS-schematron.sch
+++ b/src/final-package-JATS-schematron.sch
@@ -831,8 +831,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">
@@ -2398,6 +2398,8 @@
       <report test="child::mml:msqrt and matches($data,'^±\d+%$|^+\d+%$|^-\d+%$|^\d+%$|^±\d+$|^+\d+$|^-\d+$')" role="warning" id="math-test-17">mml:math only contains number(s) and square root symbol(s) '<value-of select="."/>', which is likely unnecessary. Should this be captured as normal text instead? Such as <value-of select="concat('√',.)"/>?</report>
       
       <report test="ancestor::abstract" role="warning" id="math-test-18">abstract contains MathML (<value-of select="."/>). Is this necessary? MathML in abstracts may not render downstream, so if it can be represented using normal text/unicode, then please do so instead.</report>
+      
+      <report test="descendant::mml:mi[(.='') and preceding-sibling::*[1][(local-name() = 'mi') and matches(.,'[A-Za-z]')] and following-sibling::*[1][(local-name() = 'mi') and matches(.,'[A-Za-z]')]]" role="warning" id="math-test-19">Maths containing '<value-of select="."/>' has what looks like words or terms which need separating with a space. With it's current markup the space will not be preserved on the eLife website. Please add in the space(s) using the latext '\;' in the appropriate place(s), so that the space is preserved in the HTML.</report>
     </rule>
   </pattern>
   <pattern id="disp-formula-child-tests-pattern">
@@ -7239,7 +7241,7 @@
       
       <report test="($italic-count != 0) and ($roman-count gt $italic-count)" role="warning" id="latin-italic-info">Latin terms are not consistenly either roman or italic. There are <value-of select="$roman-count"/> roman terms which is more common, and <value-of select="$italic-count"/> italic term(s). The following terms should be unitalicised: <value-of select="e:print-latin-terms($latin-terms//*:list[@list-type='italic'])"/>.</report>
       
-      <report test="($roman-count != 0) and ($italic-count gt $roman-count)" role="warning" id="latin-roman-info">Latin terms are not consistenly either roman or italic. There are <value-of select="$italic-count"/> italic terms which is more common, and <value-of select="$roman-count"/> roman term(s). The following terms should be unitalicised: <value-of select="e:print-latin-terms($latin-terms//*:list[@list-type='italic'])"/>.</report>
+      <report test="($roman-count != 0) and ($italic-count gt $roman-count)" role="warning" id="latin-roman-info">Latin terms are not consistenly either roman or italic. There are <value-of select="$italic-count"/> italic terms which is more common, and <value-of select="$roman-count"/> roman term(s). The following terms should be italicised: <value-of select="e:print-latin-terms($latin-terms//*:list[@list-type='roman'])"/>.</report>
       
       <report test="($roman-count != 0) and ($italic-count = $roman-count)" role="warning" id="latin-conformance-info">Latin terms are not consistenly either roman or italic. There are an equal number of italic (<value-of select="$italic-count"/>) and roman (<value-of select="$roman-count"/>) terms. The following terms are italicised: <value-of select="e:print-latin-terms($latin-terms//*:list[@list-type='italic'])"/>. The following terms are unitalicised: <value-of select="e:print-latin-terms($latin-terms//*:list[@list-type='roman'])"/>.</report>
     </rule>

--- a/src/pre-JATS-schematron.sch
+++ b/src/pre-JATS-schematron.sch
@@ -2273,6 +2273,8 @@
       <report test="child::mml:msqrt and matches($data,'^±\d+%$|^+\d+%$|^-\d+%$|^\d+%$|^±\d+$|^+\d+$|^-\d+$')" role="warning" id="math-test-17">[math-test-17] mml:math only contains number(s) and square root symbol(s) '<value-of select="."/>', which is likely unnecessary. Should this be captured as normal text instead? Such as <value-of select="concat('√',.)"/>?</report>
       
       <report test="ancestor::abstract" role="warning" id="math-test-18">[math-test-18] abstract contains MathML (<value-of select="."/>). Is this necessary? MathML in abstracts may not render downstream, so if it can be represented using normal text/unicode, then please do so instead.</report>
+      
+      <report test="descendant::mml:mi[(.='') and preceding-sibling::*[1][(local-name() = 'mi') and matches(.,'[A-Za-z]')] and following-sibling::*[1][(local-name() = 'mi') and matches(.,'[A-Za-z]')]]" role="warning" id="math-test-19">[math-test-19] Maths containing '<value-of select="."/>' has what looks like words or terms which need separating with a space. With it's current markup the space will not be preserved on the eLife website. Please add in the space(s) using the latext '\;' in the appropriate place(s), so that the space is preserved in the HTML.</report>
     </rule>
   </pattern>
   <pattern id="disp-formula-child-tests-pattern">

--- a/src/pre-JATS-schematron.xsl
+++ b/src/pre-JATS-schematron.xsl
@@ -11553,6 +11553,20 @@
                <xsl:text/>). Is this necessary? MathML in abstracts may not render downstream, so if it can be represented using normal text/unicode, then please do so instead.</svrl:text>
          </svrl:successful-report>
       </xsl:if>
+
+		    <!--REPORT warning-->
+      <xsl:if test="descendant::mml:mi[(.='') and preceding-sibling::*[1][(local-name() = 'mi') and matches(.,'[A-Za-z]')] and following-sibling::*[1][(local-name() = 'mi') and matches(.,'[A-Za-z]')]]">
+         <svrl:successful-report xmlns:svrl="http://purl.oclc.org/dsdl/svrl" test="descendant::mml:mi[(.='') and preceding-sibling::*[1][(local-name() = 'mi') and matches(.,'[A-Za-z]')] and following-sibling::*[1][(local-name() = 'mi') and matches(.,'[A-Za-z]')]]">
+            <xsl:attribute name="id">math-test-19</xsl:attribute>
+            <xsl:attribute name="role">warning</xsl:attribute>
+            <xsl:attribute name="location">
+               <xsl:apply-templates select="." mode="schematron-select-full-path"/>
+            </xsl:attribute>
+            <svrl:text>[math-test-19] Maths containing '<xsl:text/>
+               <xsl:value-of select="."/>
+               <xsl:text/>' has what looks like words or terms which need separating with a space. With it's current markup the space will not be preserved on the eLife website. Please add in the space(s) using the latext '\;' in the appropriate place(s), so that the space is preserved in the HTML.</svrl:text>
+         </svrl:successful-report>
+      </xsl:if>
       <xsl:apply-templates select="*" mode="M136"/>
    </xsl:template>
    <xsl:template match="text()" priority="-1" mode="M136"/>

--- a/test/tests/gen/KRT-check/KRT-presence/KRT-presence.sch
+++ b/test/tests/gen/KRT-check/KRT-presence/KRT-presence.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/KRT-td-checks/PMCID-link-test/PMCID-link-test.sch
+++ b/test/tests/gen/KRT-td-checks/PMCID-link-test/PMCID-link-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/KRT-td-checks/PMID-link-test/PMID-link-test.sch
+++ b/test/tests/gen/KRT-td-checks/PMID-link-test/PMID-link-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/KRT-td-checks/addgene-test/addgene-test.sch
+++ b/test/tests/gen/KRT-td-checks/addgene-test/addgene-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/KRT-td-checks/doi-link-test/doi-link-test.sch
+++ b/test/tests/gen/KRT-td-checks/doi-link-test/doi-link-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/KRT-xref-tests/xref-column-test/xref-column-test.sch
+++ b/test/tests/gen/KRT-xref-tests/xref-column-test/xref-column-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/MSA-checks/head-subj-MSA-test/head-subj-MSA-test.sch
+++ b/test/tests/gen/MSA-checks/head-subj-MSA-test/head-subj-MSA-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/abstract-children-tests/abstract-child-test-1/abstract-child-test-1.sch
+++ b/test/tests/gen/abstract-children-tests/abstract-child-test-1/abstract-child-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/abstract-house-tests/final-res-comm-test/final-res-comm-test.sch
+++ b/test/tests/gen/abstract-house-tests/final-res-comm-test/final-res-comm-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/abstract-house-tests/pre-res-comm-test/pre-res-comm-test.sch
+++ b/test/tests/gen/abstract-house-tests/pre-res-comm-test/pre-res-comm-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/abstract-house-tests/res-art-test/res-art-test.sch
+++ b/test/tests/gen/abstract-house-tests/res-art-test/res-art-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/abstract-house-tests/xref-bibr-presence/xref-bibr-presence.sch
+++ b/test/tests/gen/abstract-house-tests/xref-bibr-presence/xref-bibr-presence.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/abstract-sec-titles/clintrial-conformance-1/clintrial-conformance-1.sch
+++ b/test/tests/gen/abstract-sec-titles/clintrial-conformance-1/clintrial-conformance-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/abstract-sec-titles/clintrial-conformance-2/clintrial-conformance-2.sch
+++ b/test/tests/gen/abstract-sec-titles/clintrial-conformance-2/clintrial-conformance-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/abstract-sec-titles/clintrial-conformance-3/clintrial-conformance-3.sch
+++ b/test/tests/gen/abstract-sec-titles/clintrial-conformance-3/clintrial-conformance-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/abstract-sec-titles/clintrial-conformance-4/clintrial-conformance-4.sch
+++ b/test/tests/gen/abstract-sec-titles/clintrial-conformance-4/clintrial-conformance-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/abstract-sec-titles/clintrial-conformance-5/clintrial-conformance-5.sch
+++ b/test/tests/gen/abstract-sec-titles/clintrial-conformance-5/clintrial-conformance-5.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/abstract-sec-titles/clintrial-conformance-6/clintrial-conformance-6.sch
+++ b/test/tests/gen/abstract-sec-titles/clintrial-conformance-6/clintrial-conformance-6.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/abstract-sec-titles/clintrial-conformance-7/clintrial-conformance-7.sch
+++ b/test/tests/gen/abstract-sec-titles/clintrial-conformance-7/clintrial-conformance-7.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/abstract-sec-titles/clintrial-conformance-8/clintrial-conformance-8.sch
+++ b/test/tests/gen/abstract-sec-titles/clintrial-conformance-8/clintrial-conformance-8.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/abstract-tests/abstract-test-2/abstract-test-2.sch
+++ b/test/tests/gen/abstract-tests/abstract-test-2/abstract-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/abstract-tests/abstract-test-4/abstract-test-4.sch
+++ b/test/tests/gen/abstract-tests/abstract-test-4/abstract-test-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/abstract-tests/abstract-test-5/abstract-test-5.sch
+++ b/test/tests/gen/abstract-tests/abstract-test-5/abstract-test-5.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/abstract-tests/abstract-test-6/abstract-test-6.sch
+++ b/test/tests/gen/abstract-tests/abstract-test-6/abstract-test-6.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/abstract-tests/abstract-test-7/abstract-test-7.sch
+++ b/test/tests/gen/abstract-tests/abstract-test-7/abstract-test-7.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/abstract-word-count/final-abstract-word-count-restriction/final-abstract-word-count-restriction.sch
+++ b/test/tests/gen/abstract-word-count/final-abstract-word-count-restriction/final-abstract-word-count-restriction.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/abstract-word-count/pre-abstract-word-count-restriction/pre-abstract-word-count-restriction.sch
+++ b/test/tests/gen/abstract-word-count/pre-abstract-word-count-restriction/pre-abstract-word-count-restriction.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ack-child-tests/ack-child-test-1/ack-child-test-1.sch
+++ b/test/tests/gen/ack-child-tests/ack-child-test-1/ack-child-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ack-content-tests/ack-full-stop-intial-test/ack-full-stop-intial-test.sch
+++ b/test/tests/gen/ack-content-tests/ack-full-stop-intial-test/ack-full-stop-intial-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ack-tests/ack-test-1/ack-test-1.sch
+++ b/test/tests/gen/ack-tests/ack-test-1/ack-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ack-title-tests/ack-content-test/ack-content-test.sch
+++ b/test/tests/gen/ack-title-tests/ack-content-test/ack-content-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ack-title-tests/ack-title-test/ack-title-test.sch
+++ b/test/tests/gen/ack-title-tests/ack-title-test/ack-title-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/additional-info-tests/additional-info-test-1/additional-info-test-1.sch
+++ b/test/tests/gen/additional-info-tests/additional-info-test-1/additional-info-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/additional-info-tests/additional-info-test-2/additional-info-test-2.sch
+++ b/test/tests/gen/additional-info-tests/additional-info-test-2/additional-info-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/additional-info-tests/additional-info-test-4/additional-info-test-4.sch
+++ b/test/tests/gen/additional-info-tests/additional-info-test-4/additional-info-test-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/additional-info-tests/final-additional-info-test-3/final-additional-info-test-3.sch
+++ b/test/tests/gen/additional-info-tests/final-additional-info-test-3/final-additional-info-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/additional-info-tests/pre-additional-info-test-3/pre-additional-info-test-3.sch
+++ b/test/tests/gen/additional-info-tests/pre-additional-info-test-3/pre-additional-info-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/addr-line-child-tests/addr-line-child-1/addr-line-child-1.sch
+++ b/test/tests/gen/addr-line-child-tests/addr-line-child-1/addr-line-child-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/addr-line-child-tests/addr-line-child-2/addr-line-child-2.sch
+++ b/test/tests/gen/addr-line-child-tests/addr-line-child-2/addr-line-child-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/addr-line-parent-test/addr-line-parent/addr-line-parent.sch
+++ b/test/tests/gen/addr-line-parent-test/addr-line-parent/addr-line-parent.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/aff-child-tests/aff-child-conformity/aff-child-conformity.sch
+++ b/test/tests/gen/aff-child-tests/aff-child-conformity/aff-child-conformity.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/aff-ids/aff-id-test/aff-id-test.sch
+++ b/test/tests/gen/aff-ids/aff-id-test/aff-id-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/aff-label-tests/aff-label-conformance-1/aff-label-conformance-1.sch
+++ b/test/tests/gen/aff-label-tests/aff-label-conformance-1/aff-label-conformance-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/aff-tests/aff-test-1/aff-test-1.sch
+++ b/test/tests/gen/aff-tests/aff-test-1/aff-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/app-fig-ids/app-fig-id-test-1/app-fig-id-test-1.sch
+++ b/test/tests/gen/app-fig-ids/app-fig-id-test-1/app-fig-id-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/app-fig-ids/app-fig-id-test-2/app-fig-id-test-2.sch
+++ b/test/tests/gen/app-fig-ids/app-fig-id-test-2/app-fig-id-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/app-fig-ids/app-fig-id-test-3/app-fig-id-test-3.sch
+++ b/test/tests/gen/app-fig-ids/app-fig-id-test-3/app-fig-id-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/app-fig-sup-ids/app-fig-sup-id-test/app-fig-sup-id-test.sch
+++ b/test/tests/gen/app-fig-sup-ids/app-fig-sup-id-test/app-fig-sup-id-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/app-fig-sup-tests/app-fig-sup-test-1/app-fig-sup-test-1.sch
+++ b/test/tests/gen/app-fig-sup-tests/app-fig-sup-test-1/app-fig-sup-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/app-fig-sup-tests/app-fig-sup-test-2/app-fig-sup-test-2.sch
+++ b/test/tests/gen/app-fig-sup-tests/app-fig-sup-test-2/app-fig-sup-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/app-fig-tests/app-fig-test-1/app-fig-test-1.sch
+++ b/test/tests/gen/app-fig-tests/app-fig-test-1/app-fig-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/app-fig-tests/app-fig-test-2/app-fig-test-2.sch
+++ b/test/tests/gen/app-fig-tests/app-fig-test-2/app-fig-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/app-ids/app-id-test-1/app-id-test-1.sch
+++ b/test/tests/gen/app-ids/app-id-test-1/app-id-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/app-ids/app-id-test-2/app-id-test-2.sch
+++ b/test/tests/gen/app-ids/app-id-test-2/app-id-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/app-table-label-tests/app-table-label-test-1/app-table-label-test-1.sch
+++ b/test/tests/gen/app-table-label-tests/app-table-label-test-1/app-table-label-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/app-table-label-tests/app-table-label-test-2/app-table-label-test-2.sch
+++ b/test/tests/gen/app-table-label-tests/app-table-label-test-2/app-table-label-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/app-table-pos-conformance/final-app-table-report/final-app-table-report.sch
+++ b/test/tests/gen/app-table-pos-conformance/final-app-table-report/final-app-table-report.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/app-table-pos-conformance/pre-app-table-report/pre-app-table-report.sch
+++ b/test/tests/gen/app-table-pos-conformance/pre-app-table-report/pre-app-table-report.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/app-table-wrap-ids/app-table-wrap-id-test-1/app-table-wrap-id-test-1.sch
+++ b/test/tests/gen/app-table-wrap-ids/app-table-wrap-id-test-1/app-table-wrap-id-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/app-table-wrap-ids/app-table-wrap-id-test-2/app-table-wrap-id-test-2.sch
+++ b/test/tests/gen/app-table-wrap-ids/app-table-wrap-id-test-2/app-table-wrap-id-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/app-tests/app-test-1/app-test-1.sch
+++ b/test/tests/gen/app-tests/app-test-1/app-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/app-tests/app-test-2/app-test-2.sch
+++ b/test/tests/gen/app-tests/app-test-2/app-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/app-title-tests/app-title-test/app-title-test.sch
+++ b/test/tests/gen/app-title-tests/app-title-test/app-title-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/app-video-ids/app-video-id-test-1/app-video-id-test-1.sch
+++ b/test/tests/gen/app-video-ids/app-video-id-test-1/app-video-id-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/app-video-ids/app-video-id-test-2/app-video-id-test-2.sch
+++ b/test/tests/gen/app-video-ids/app-video-id-test-2/app-video-id-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/app-video-specific/final-app-video-position-test/final-app-video-position-test.sch
+++ b/test/tests/gen/app-video-specific/final-app-video-position-test/final-app-video-position-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/app-video-specific/pre-app-video-position-test/pre-app-video-position-test.sch
+++ b/test/tests/gen/app-video-specific/pre-app-video-position-test/pre-app-video-position-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/app-video-sup-ids/app-video-sup-id-test-1/app-video-sup-id-test-1.sch
+++ b/test/tests/gen/app-video-sup-ids/app-video-sup-id-test-1/app-video-sup-id-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/app-video-sup-ids/app-video-sup-id-test-2/app-video-sup-id-test-2.sch
+++ b/test/tests/gen/app-video-sup-ids/app-video-sup-id-test-2/app-video-sup-id-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/app-video-sup-ids/app-video-sup-id-test-3/app-video-sup-id-test-3.sch
+++ b/test/tests/gen/app-video-sup-ids/app-video-sup-id-test-3/app-video-sup-id-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ar-fig-tests/ar-fig-test-2/ar-fig-test-2.sch
+++ b/test/tests/gen/ar-fig-tests/ar-fig-test-2/ar-fig-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ar-fig-tests/final-ar-fig-position-test/final-ar-fig-position-test.sch
+++ b/test/tests/gen/ar-fig-tests/final-ar-fig-position-test/final-ar-fig-position-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ar-fig-tests/final-ar-fig-test-3/final-ar-fig-test-3.sch
+++ b/test/tests/gen/ar-fig-tests/final-ar-fig-test-3/final-ar-fig-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ar-fig-tests/pre-ar-fig-position-test/pre-ar-fig-position-test.sch
+++ b/test/tests/gen/ar-fig-tests/pre-ar-fig-position-test/pre-ar-fig-position-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ar-fig-tests/pre-ar-fig-test-3/pre-ar-fig-test-3.sch
+++ b/test/tests/gen/ar-fig-tests/pre-ar-fig-test-3/pre-ar-fig-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ar-fig-title-tests/ar-fig-title-test-1/ar-fig-title-test-1.sch
+++ b/test/tests/gen/ar-fig-title-tests/ar-fig-title-test-1/ar-fig-title-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ar-video-specific/final-ar-video-position-test/final-ar-video-position-test.sch
+++ b/test/tests/gen/ar-video-specific/final-ar-video-position-test/final-ar-video-position-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ar-video-specific/pre-ar-video-position-test/pre-ar-video-position-test.sch
+++ b/test/tests/gen/ar-video-specific/pre-ar-video-position-test/pre-ar-video-position-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/article-tests/dtd-info/dtd-info.sch
+++ b/test/tests/gen/article-tests/dtd-info/dtd-info.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/article-tests/line-count/line-count.sch
+++ b/test/tests/gen/article-tests/line-count/line-count.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/article-tests/test-article-back/test-article-back.sch
+++ b/test/tests/gen/article-tests/test-article-back/test-article-back.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/article-tests/test-article-body/test-article-body.sch
+++ b/test/tests/gen/article-tests/test-article-body/test-article-body.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/article-tests/test-article-front/test-article-front.sch
+++ b/test/tests/gen/article-tests/test-article-front/test-article-front.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/article-tests/test-article-type/test-article-type.sch
+++ b/test/tests/gen/article-tests/test-article-type/test-article-type.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/article-title-tests/article-type-title-test-1/article-type-title-test-1.sch
+++ b/test/tests/gen/article-title-tests/article-type-title-test-1/article-type-title-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/article-title-tests/article-type-title-test-2/article-type-title-test-2.sch
+++ b/test/tests/gen/article-title-tests/article-type-title-test-2/article-type-title-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/article-title-tests/sc-title-test-1/sc-title-test-1.sch
+++ b/test/tests/gen/article-title-tests/sc-title-test-1/sc-title-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/article-title-tests/sc-title-test-2/sc-title-test-2.sch
+++ b/test/tests/gen/article-title-tests/sc-title-test-2/sc-title-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/auth-cont-fn-tests/auth-cont-fn-test-1/auth-cont-fn-test-1.sch
+++ b/test/tests/gen/auth-cont-fn-tests/auth-cont-fn-test-1/auth-cont-fn-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/auth-cont-tests/auth-cont-test-1/auth-cont-test-1.sch
+++ b/test/tests/gen/auth-cont-tests/auth-cont-test-1/auth-cont-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/auth-cont-title-tests/auth-cont-title-test/auth-cont-title-test.sch
+++ b/test/tests/gen/auth-cont-title-tests/auth-cont-title-test/auth-cont-title-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/auth-contrib-group/corresp-presence-test/corresp-presence-test.sch
+++ b/test/tests/gen/auth-contrib-group/corresp-presence-test/corresp-presence-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/auth-contrib-group/duplicate-author-test/duplicate-author-test.sch
+++ b/test/tests/gen/auth-contrib-group/duplicate-author-test/duplicate-author-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/auth-contrib-group/duplicate-orcid-test/duplicate-orcid-test.sch
+++ b/test/tests/gen/auth-contrib-group/duplicate-orcid-test/duplicate-orcid-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/auth-kwd-style/auth-kwd-check-2/auth-kwd-check-2.sch
+++ b/test/tests/gen/auth-kwd-style/auth-kwd-check-2/auth-kwd-check-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/auth-kwd-style/auth-kwd-check-3/auth-kwd-check-3.sch
+++ b/test/tests/gen/auth-kwd-style/auth-kwd-check-3/auth-kwd-check-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/auth-kwd-style/auth-kwd-check-4/auth-kwd-check-4.sch
+++ b/test/tests/gen/auth-kwd-style/auth-kwd-check-4/auth-kwd-check-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/auth-kwd-style/auth-kwd-check-5/auth-kwd-check-5.sch
+++ b/test/tests/gen/auth-kwd-style/auth-kwd-check-5/auth-kwd-check-5.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/auth-kwd-style/auth-kwd-check-6/auth-kwd-check-6.sch
+++ b/test/tests/gen/auth-kwd-style/auth-kwd-check-6/auth-kwd-check-6.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/auth-kwd-style/auth-kwd-check-7/auth-kwd-check-7.sch
+++ b/test/tests/gen/auth-kwd-style/auth-kwd-check-7/auth-kwd-check-7.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/auth-kwd-style/auth-kwd-check/auth-kwd-check.sch
+++ b/test/tests/gen/auth-kwd-style/auth-kwd-check/auth-kwd-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/author-aff-tests/final-auth-aff-test-1/final-auth-aff-test-1.sch
+++ b/test/tests/gen/author-aff-tests/final-auth-aff-test-1/final-auth-aff-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/author-aff-tests/final-auth-aff-test-2/final-auth-aff-test-2.sch
+++ b/test/tests/gen/author-aff-tests/final-auth-aff-test-2/final-auth-aff-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/author-aff-tests/final-auth-aff-test-3/final-auth-aff-test-3.sch
+++ b/test/tests/gen/author-aff-tests/final-auth-aff-test-3/final-auth-aff-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/author-aff-tests/pre-auth-aff-test-1/pre-auth-aff-test-1.sch
+++ b/test/tests/gen/author-aff-tests/pre-auth-aff-test-1/pre-auth-aff-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/author-aff-tests/pre-auth-aff-test-2/pre-auth-aff-test-2.sch
+++ b/test/tests/gen/author-aff-tests/pre-auth-aff-test-2/pre-auth-aff-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/author-aff-tests/pre-auth-aff-test-3/pre-auth-aff-test-3.sch
+++ b/test/tests/gen/author-aff-tests/pre-auth-aff-test-3/pre-auth-aff-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/author-children-tests/author-children-test/author-children-test.sch
+++ b/test/tests/gen/author-children-tests/author-children-test/author-children-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/author-contrib-ids/author-id-1/author-id-1.sch
+++ b/test/tests/gen/author-contrib-ids/author-id-1/author-id-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/author-notes-children/author-notes-child-conformance/author-notes-child-conformance.sch
+++ b/test/tests/gen/author-notes-children/author-notes-child-conformance/author-notes-child-conformance.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/author-xref-tests/author-xref-test-1/author-xref-test-1.sch
+++ b/test/tests/gen/author-xref-tests/author-xref-test-1/author-xref-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/author-xref-tests/author-xref-test-2/author-xref-test-2.sch
+++ b/test/tests/gen/author-xref-tests/author-xref-test-2/author-xref-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/author-xref-tests/author-xref-test-3/author-xref-test-3.sch
+++ b/test/tests/gen/author-xref-tests/author-xref-test-3/author-xref-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/author-xref-tests/author-xref-test-4/author-xref-test-4.sch
+++ b/test/tests/gen/author-xref-tests/author-xref-test-4/author-xref-test-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/award-group-ids/award-group-test-1/award-group-test-1.sch
+++ b/test/tests/gen/award-group-ids/award-group-test-1/award-group-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/award-group-tests/award-group-test-2/award-group-test-2.sch
+++ b/test/tests/gen/award-group-tests/award-group-test-2/award-group-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/award-group-tests/award-group-test-4/award-group-test-4.sch
+++ b/test/tests/gen/award-group-tests/award-group-test-4/award-group-test-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/award-group-tests/award-group-test-5/award-group-test-5.sch
+++ b/test/tests/gen/award-group-tests/award-group-test-5/award-group-test-5.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/award-group-tests/award-group-test-6/award-group-test-6.sch
+++ b/test/tests/gen/award-group-tests/award-group-test-6/award-group-test-6.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/award-group-tests/award-group-test-8/award-group-test-8.sch
+++ b/test/tests/gen/award-group-tests/award-group-test-8/award-group-test-8.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/award-group-tests/final-award-group-test-3/final-award-group-test-3.sch
+++ b/test/tests/gen/award-group-tests/final-award-group-test-3/final-award-group-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/award-group-tests/final-award-group-test-7/final-award-group-test-7.sch
+++ b/test/tests/gen/award-group-tests/final-award-group-test-7/final-award-group-test-7.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/award-group-tests/pre-award-group-test-3/pre-award-group-test-3.sch
+++ b/test/tests/gen/award-group-tests/pre-award-group-test-3/pre-award-group-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/award-group-tests/pre-award-group-test-7/pre-award-group-test-7.sch
+++ b/test/tests/gen/award-group-tests/pre-award-group-test-7/pre-award-group-test-7.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/award-id-tests/award-id-test-1/award-id-test-1.sch
+++ b/test/tests/gen/award-id-tests/award-id-test-1/award-id-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/award-id-tests/award-id-test-2/award-id-test-2.sch
+++ b/test/tests/gen/award-id-tests/award-id-test-2/award-id-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/award-id-tests/award-id-test-3/award-id-test-3.sch
+++ b/test/tests/gen/award-id-tests/award-id-test-3/award-id-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/award-id-tests/award-id-test-4/award-id-test-4.sch
+++ b/test/tests/gen/award-id-tests/award-id-test-4/award-id-test-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/back-source-code-tests/back-source-code-position/back-source-code-position.sch
+++ b/test/tests/gen/back-source-code-tests/back-source-code-position/back-source-code-position.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/back-source-data-tests/back-source-data-position/back-source-data-position.sch
+++ b/test/tests/gen/back-source-data-tests/back-source-data-position/back-source-data-position.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/back-supplementary-file-tests/back-supplementary-file-position/back-supplementary-file-position.sch
+++ b/test/tests/gen/back-supplementary-file-tests/back-supplementary-file-position/back-supplementary-file-position.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/back-tests/back-test-1/back-test-1.sch
+++ b/test/tests/gen/back-tests/back-test-1/back-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/back-tests/back-test-10/back-test-10.sch
+++ b/test/tests/gen/back-tests/back-test-10/back-test-10.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/back-tests/back-test-11/back-test-11.sch
+++ b/test/tests/gen/back-tests/back-test-11/back-test-11.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/back-tests/back-test-12/back-test-12.sch
+++ b/test/tests/gen/back-tests/back-test-12/back-test-12.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/back-tests/back-test-2/back-test-2.sch
+++ b/test/tests/gen/back-tests/back-test-2/back-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/back-tests/back-test-3/back-test-3.sch
+++ b/test/tests/gen/back-tests/back-test-3/back-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/back-tests/back-test-4/back-test-4.sch
+++ b/test/tests/gen/back-tests/back-test-4/back-test-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/back-tests/back-test-5/back-test-5.sch
+++ b/test/tests/gen/back-tests/back-test-5/back-test-5.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/back-tests/back-test-6/back-test-6.sch
+++ b/test/tests/gen/back-tests/back-test-6/back-test-6.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/back-tests/back-test-7/back-test-7.sch
+++ b/test/tests/gen/back-tests/back-test-7/back-test-7.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/back-tests/back-test-8/back-test-8.sch
+++ b/test/tests/gen/back-tests/back-test-8/back-test-8.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/back-tests/back-test-9/back-test-9.sch
+++ b/test/tests/gen/back-tests/back-test-9/back-test-9.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/back-top-level-sec-ids/back-top-level-sec-id-test/back-top-level-sec-id-test.sch
+++ b/test/tests/gen/back-top-level-sec-ids/back-top-level-sec-id-test/back-top-level-sec-id-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/body-table-label-tests/body-table-label-test-1/body-table-label-test-1.sch
+++ b/test/tests/gen/body-table-label-tests/body-table-label-test-1/body-table-label-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/body-table-pos-conformance/final-body-table-report/final-body-table-report.sch
+++ b/test/tests/gen/body-table-pos-conformance/final-body-table-report/final-body-table-report.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/body-table-pos-conformance/pre-body-table-report/pre-body-table-report.sch
+++ b/test/tests/gen/body-table-pos-conformance/pre-body-table-report/pre-body-table-report.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/body-top-level-sec-ids/body-top-level-sec-id-test/body-top-level-sec-id-test.sch
+++ b/test/tests/gen/body-top-level-sec-ids/body-top-level-sec-id-test/body-top-level-sec-id-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/body-video-specific/fig-video-check-1/fig-video-check-1.sch
+++ b/test/tests/gen/body-video-specific/fig-video-check-1/fig-video-check-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/body-video-specific/fig-video-label-test/fig-video-label-test.sch
+++ b/test/tests/gen/body-video-specific/fig-video-label-test/fig-video-label-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/body-video-specific/fig-video-position-test/fig-video-position-test.sch
+++ b/test/tests/gen/body-video-specific/fig-video-position-test/fig-video-position-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/body-video-specific/final-body-video-position-test-1/final-body-video-position-test-1.sch
+++ b/test/tests/gen/body-video-specific/final-body-video-position-test-1/final-body-video-position-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/body-video-specific/pre-body-video-position-test-1/pre-body-video-position-test-1.sch
+++ b/test/tests/gen/body-video-specific/pre-body-video-position-test-1/pre-body-video-position-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/body-xref-tests/empty-xref-test/empty-xref-test.sch
+++ b/test/tests/gen/body-xref-tests/empty-xref-test/empty-xref-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/body-xref-tests/semi-colon-xref-test/semi-colon-xref-test.sch
+++ b/test/tests/gen/body-xref-tests/semi-colon-xref-test/semi-colon-xref-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/book-chapter-tests/book-chapter-test-1/book-chapter-test-1.sch
+++ b/test/tests/gen/book-chapter-tests/book-chapter-test-1/book-chapter-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/book-chapter-tests/book-chapter-test-2/book-chapter-test-2.sch
+++ b/test/tests/gen/book-chapter-tests/book-chapter-test-2/book-chapter-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/box-fig-ids/box-fig-id-1/box-fig-id-1.sch
+++ b/test/tests/gen/box-fig-ids/box-fig-id-1/box-fig-id-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/box-fig-ids/box-fig-id-2/box-fig-id-2.sch
+++ b/test/tests/gen/box-fig-ids/box-fig-id-2/box-fig-id-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/box-fig-tests/box-fig-test-1/box-fig-test-1.sch
+++ b/test/tests/gen/box-fig-tests/box-fig-test-1/box-fig-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/box-vid-ids/box-vid-id-1/box-vid-id-1.sch
+++ b/test/tests/gen/box-vid-ids/box-vid-id-1/box-vid-id-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/box-vid-ids/box-vid-id-2/box-vid-id-2.sch
+++ b/test/tests/gen/box-vid-ids/box-vid-id-2/box-vid-id-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/bracket-tests/bracket-test-1/bracket-test-1.sch
+++ b/test/tests/gen/bracket-tests/bracket-test-1/bracket-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/bracket-tests/bracket-test-2/bracket-test-2.sch
+++ b/test/tests/gen/bracket-tests/bracket-test-2/bracket-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/bracket-tests/bracket-test-3/bracket-test-3.sch
+++ b/test/tests/gen/bracket-tests/bracket-test-3/bracket-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/bracket-tests/bracket-test-4/bracket-test-4.sch
+++ b/test/tests/gen/bracket-tests/bracket-test-4/bracket-test-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/city-tests/city-number-presence/city-number-presence.sch
+++ b/test/tests/gen/city-tests/city-number-presence/city-number-presence.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/city-tests/city-replacement-character-presence/city-replacement-character-presence.sch
+++ b/test/tests/gen/city-tests/city-replacement-character-presence/city-replacement-character-presence.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/city-tests/city-street-presence/city-street-presence.sch
+++ b/test/tests/gen/city-tests/city-street-presence/city-street-presence.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/city-tests/final-US-states-test/final-US-states-test.sch
+++ b/test/tests/gen/city-tests/final-US-states-test/final-US-states-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/city-tests/pre-US-states-test/pre-US-states-test.sch
+++ b/test/tests/gen/city-tests/pre-US-states-test/pre-US-states-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/city-tests/singapore-test-2/singapore-test-2.sch
+++ b/test/tests/gen/city-tests/singapore-test-2/singapore-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/clintrial-related-object/clintrial-related-object-1/clintrial-related-object-1.sch
+++ b/test/tests/gen/clintrial-related-object/clintrial-related-object-1/clintrial-related-object-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/clintrial-related-object/clintrial-related-object-10/clintrial-related-object-10.sch
+++ b/test/tests/gen/clintrial-related-object/clintrial-related-object-10/clintrial-related-object-10.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/clintrial-related-object/clintrial-related-object-11/clintrial-related-object-11.sch
+++ b/test/tests/gen/clintrial-related-object/clintrial-related-object-11/clintrial-related-object-11.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/clintrial-related-object/clintrial-related-object-2/clintrial-related-object-2.sch
+++ b/test/tests/gen/clintrial-related-object/clintrial-related-object-2/clintrial-related-object-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/clintrial-related-object/clintrial-related-object-3/clintrial-related-object-3.sch
+++ b/test/tests/gen/clintrial-related-object/clintrial-related-object-3/clintrial-related-object-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/clintrial-related-object/clintrial-related-object-4/clintrial-related-object-4.sch
+++ b/test/tests/gen/clintrial-related-object/clintrial-related-object-4/clintrial-related-object-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/clintrial-related-object/clintrial-related-object-5/clintrial-related-object-5.sch
+++ b/test/tests/gen/clintrial-related-object/clintrial-related-object-5/clintrial-related-object-5.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/clintrial-related-object/clintrial-related-object-6/clintrial-related-object-6.sch
+++ b/test/tests/gen/clintrial-related-object/clintrial-related-object-6/clintrial-related-object-6.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/clintrial-related-object/clintrial-related-object-7/clintrial-related-object-7.sch
+++ b/test/tests/gen/clintrial-related-object/clintrial-related-object-7/clintrial-related-object-7.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/clintrial-related-object/clintrial-related-object-8/clintrial-related-object-8.sch
+++ b/test/tests/gen/clintrial-related-object/clintrial-related-object-8/clintrial-related-object-8.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/clintrial-related-object/clintrial-related-object-9/clintrial-related-object-9.sch
+++ b/test/tests/gen/clintrial-related-object/clintrial-related-object-9/clintrial-related-object-9.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/code-fork/code-fork-info/code-fork-info.sch
+++ b/test/tests/gen/code-fork/code-fork-info/code-fork-info.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/code-tests-2/code-sibling-test/code-sibling-test.sch
+++ b/test/tests/gen/code-tests-2/code-sibling-test/code-sibling-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/code-tests-3/code-sibling-test-2/code-sibling-test-2.sch
+++ b/test/tests/gen/code-tests-3/code-sibling-test-2/code-sibling-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/code-tests/code-child-test/code-child-test.sch
+++ b/test/tests/gen/code-tests/code-child-test/code-child-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/code-tests/code-parent-test/code-parent-test.sch
+++ b/test/tests/gen/code-tests/code-parent-test/code-parent-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/collab-cont-tests/collab-cont-test-1/collab-cont-test-1.sch
+++ b/test/tests/gen/collab-cont-tests/collab-cont-test-1/collab-cont-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/collab-tests-2/auth-and-member-test/auth-and-member-test.sch
+++ b/test/tests/gen/collab-tests-2/auth-and-member-test/auth-and-member-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/collab-tests/duplicate-member-orcid-test/duplicate-member-orcid-test.sch
+++ b/test/tests/gen/collab-tests/duplicate-member-orcid-test/duplicate-member-orcid-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/collab-tests/duplicate-member-test/duplicate-member-test.sch
+++ b/test/tests/gen/collab-tests/duplicate-member-test/duplicate-member-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/colour-named-content/colour-named-content-check/colour-named-content-check.sch
+++ b/test/tests/gen/colour-named-content/colour-named-content-check/colour-named-content-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/colour-named-content/final-named-content-type-check/final-named-content-type-check.sch
+++ b/test/tests/gen/colour-named-content/final-named-content-type-check/final-named-content-type-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/colour-named-content/pre-named-content-type-check/pre-named-content-type-check.sch
+++ b/test/tests/gen/colour-named-content/pre-named-content-type-check/pre-named-content-type-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/colour-styled-content/final-colour-styled-content-check/final-colour-styled-content-check.sch
+++ b/test/tests/gen/colour-styled-content/final-colour-styled-content-check/final-colour-styled-content-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/colour-styled-content/pre-colour-styled-content-check/pre-colour-styled-content-check.sch
+++ b/test/tests/gen/colour-styled-content/pre-colour-styled-content-check/pre-colour-styled-content-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/colour-table-2/final-colour-check-table-2/final-colour-check-table-2.sch
+++ b/test/tests/gen/colour-table-2/final-colour-check-table-2/final-colour-check-table-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/colour-table-2/pre-colour-check-table-2/pre-colour-check-table-2.sch
+++ b/test/tests/gen/colour-table-2/pre-colour-check-table-2/pre-colour-check-table-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/colour-table/colour-check-table/colour-check-table.sch
+++ b/test/tests/gen/colour-table/colour-check-table/colour-check-table.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/comp-int-fn-group-tests/comp-int-fn-group-test-1/comp-int-fn-group-test-1.sch
+++ b/test/tests/gen/comp-int-fn-group-tests/comp-int-fn-group-test-1/comp-int-fn-group-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/comp-int-fn-group-tests/comp-int-fn-test-1/comp-int-fn-test-1.sch
+++ b/test/tests/gen/comp-int-fn-group-tests/comp-int-fn-test-1/comp-int-fn-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/comp-int-fn-tests/comp-int-fn-test-2/comp-int-fn-test-2.sch
+++ b/test/tests/gen/comp-int-fn-tests/comp-int-fn-test-2/comp-int-fn-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/comp-int-title-tests/comp-int-title-test/comp-int-title-test.sch
+++ b/test/tests/gen/comp-int-title-tests/comp-int-title-test/comp-int-title-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/contrib-tests/COI-test/COI-test.sch
+++ b/test/tests/gen/contrib-tests/COI-test/COI-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/contrib-tests/contrib-email-1/contrib-email-1.sch
+++ b/test/tests/gen/contrib-tests/contrib-email-1/contrib-email-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/contrib-tests/contrib-email-2/contrib-email-2.sch
+++ b/test/tests/gen/contrib-tests/contrib-email-2/contrib-email-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/contrib-tests/contrib-test-1/contrib-test-1.sch
+++ b/test/tests/gen/contrib-tests/contrib-test-1/contrib-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/contrib-tests/contrib-test-2/contrib-test-2.sch
+++ b/test/tests/gen/contrib-tests/contrib-test-2/contrib-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/contrib-tests/contrib-test-3/contrib-test-3.sch
+++ b/test/tests/gen/contrib-tests/contrib-test-3/contrib-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/contrib-tests/contrib-test-4/contrib-test-4.sch
+++ b/test/tests/gen/contrib-tests/contrib-test-4/contrib-test-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/contrib-tests/contrib-test-5/contrib-test-5.sch
+++ b/test/tests/gen/contrib-tests/contrib-test-5/contrib-test-5.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/contrib-tests/deceased-test-1/deceased-test-1.sch
+++ b/test/tests/gen/contrib-tests/deceased-test-1/deceased-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/contrib-tests/deceased-test-2/deceased-test-2.sch
+++ b/test/tests/gen/contrib-tests/deceased-test-2/deceased-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/contrib-tests/name-test/name-test.sch
+++ b/test/tests/gen/contrib-tests/name-test/name-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/correction-test/related-articles-test-8/related-articles-test-8.sch
+++ b/test/tests/gen/correction-test/related-articles-test-8/related-articles-test-8.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/correction-tests/corr-COI-presence/corr-COI-presence.sch
+++ b/test/tests/gen/correction-tests/corr-COI-presence/corr-COI-presence.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/correction-tests/corr-SE-BRE/corr-SE-BRE.sch
+++ b/test/tests/gen/correction-tests/corr-SE-BRE/corr-SE-BRE.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/correction-tests/corr-abstract-presence/corr-abstract-presence.sch
+++ b/test/tests/gen/correction-tests/corr-abstract-presence/corr-abstract-presence.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/correction-tests/corr-aff-presence/corr-aff-presence.sch
+++ b/test/tests/gen/correction-tests/corr-aff-presence/corr-aff-presence.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/correction-tests/corr-back-sec/corr-back-sec.sch
+++ b/test/tests/gen/correction-tests/corr-back-sec/corr-back-sec.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/correction-tests/corr-impact-statement/corr-impact-statement.sch
+++ b/test/tests/gen/correction-tests/corr-impact-statement/corr-impact-statement.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/correction-tests/corr-self-uri-presence/corr-self-uri-presence.sch
+++ b/test/tests/gen/correction-tests/corr-self-uri-presence/corr-self-uri-presence.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/corresp-author-initial-tests/corresp-author-initial-test/corresp-author-initial-test.sch
+++ b/test/tests/gen/corresp-author-initial-tests/corresp-author-initial-test/corresp-author-initial-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/country-tests/gen-country-test/gen-country-test.sch
+++ b/test/tests/gen/country-tests/gen-country-test/gen-country-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/country-tests/n-korea-test/n-korea-test.sch
+++ b/test/tests/gen/country-tests/n-korea-test/n-korea-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/country-tests/s-korea-test/s-korea-test.sch
+++ b/test/tests/gen/country-tests/s-korea-test/s-korea-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/country-tests/singapore-test-1/singapore-test-1.sch
+++ b/test/tests/gen/country-tests/singapore-test-1/singapore-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/country-tests/taiwan-test/taiwan-test.sch
+++ b/test/tests/gen/country-tests/taiwan-test/taiwan-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/country-tests/united-kingdom-test-2/united-kingdom-test-2.sch
+++ b/test/tests/gen/country-tests/united-kingdom-test-2/united-kingdom-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/country-tests/united-states-test-1/united-states-test-1.sch
+++ b/test/tests/gen/country-tests/united-states-test-1/united-states-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/country-tests/united-states-test-2/united-states-test-2.sch
+++ b/test/tests/gen/country-tests/united-states-test-2/united-states-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/custom-meta-group-tests/custom-meta-presence/custom-meta-presence.sch
+++ b/test/tests/gen/custom-meta-group-tests/custom-meta-presence/custom-meta-presence.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/custom-meta-group-tests/features-custom-meta-presence/features-custom-meta-presence.sch
+++ b/test/tests/gen/custom-meta-group-tests/features-custom-meta-presence/features-custom-meta-presence.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/custom-meta-tests/custom-meta-test-1/custom-meta-test-1.sch
+++ b/test/tests/gen/custom-meta-tests/custom-meta-test-1/custom-meta-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/custom-meta-tests/custom-meta-test-14/custom-meta-test-14.sch
+++ b/test/tests/gen/custom-meta-tests/custom-meta-test-14/custom-meta-test-14.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/custom-meta-tests/custom-meta-test-15/custom-meta-test-15.sch
+++ b/test/tests/gen/custom-meta-tests/custom-meta-test-15/custom-meta-test-15.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/custom-meta-tests/custom-meta-test-2/custom-meta-test-2.sch
+++ b/test/tests/gen/custom-meta-tests/custom-meta-test-2/custom-meta-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/custom-meta-tests/custom-meta-test-3/custom-meta-test-3.sch
+++ b/test/tests/gen/custom-meta-tests/custom-meta-test-3/custom-meta-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/das-elem-citation-children/das-elem-citation-child-1/das-elem-citation-child-1.sch
+++ b/test/tests/gen/das-elem-citation-children/das-elem-citation-child-1/das-elem-citation-child-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/das-elem-citation-data-pub-id/das-pub-id-1/das-pub-id-1.sch
+++ b/test/tests/gen/das-elem-citation-data-pub-id/das-pub-id-1/das-pub-id-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/das-elem-citation-data-pub-id/final-das-pub-id-2/final-das-pub-id-2.sch
+++ b/test/tests/gen/das-elem-citation-data-pub-id/final-das-pub-id-2/final-das-pub-id-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/das-elem-citation-data-pub-id/pre-das-pub-id-2/pre-das-pub-id-2.sch
+++ b/test/tests/gen/das-elem-citation-data-pub-id/pre-das-pub-id-2/pre-das-pub-id-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/das-elem-citation-year-tests/das-elem-citation-year-1/das-elem-citation-year-1.sch
+++ b/test/tests/gen/das-elem-citation-year-tests/das-elem-citation-year-1/das-elem-citation-year-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/das-elem-citation-year-tests/final-das-elem-citation-year-2/final-das-elem-citation-year-2.sch
+++ b/test/tests/gen/das-elem-citation-year-tests/final-das-elem-citation-year-2/final-das-elem-citation-year-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/das-elem-citation-year-tests/pre-das-elem-citation-year-2/pre-das-elem-citation-year-2.sch
+++ b/test/tests/gen/das-elem-citation-year-tests/pre-das-elem-citation-year-2/pre-das-elem-citation-year-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-availability-statement/das-doi-conformity-1/das-doi-conformity-1.sch
+++ b/test/tests/gen/data-availability-statement/das-doi-conformity-1/das-doi-conformity-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-availability-statement/das-request-conformity-1/das-request-conformity-1.sch
+++ b/test/tests/gen/data-availability-statement/das-request-conformity-1/das-request-conformity-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-availability-statement/das-sentence-conformity/das-sentence-conformity.sch
+++ b/test/tests/gen/data-availability-statement/das-sentence-conformity/das-sentence-conformity.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-availability-statement/das-supplemental-conformity/das-supplemental-conformity.sch
+++ b/test/tests/gen/data-availability-statement/das-supplemental-conformity/das-supplemental-conformity.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-availability-statement/final-das-dryad-conformity/final-das-dryad-conformity.sch
+++ b/test/tests/gen/data-availability-statement/final-das-dryad-conformity/final-das-dryad-conformity.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-availability-statement/pre-das-dryad-conformity/pre-das-dryad-conformity.sch
+++ b/test/tests/gen/data-availability-statement/pre-das-dryad-conformity/pre-das-dryad-conformity.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-content-tests/data-p-presence/data-p-presence.sch
+++ b/test/tests/gen/data-content-tests/data-p-presence/data-p-presence.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-given-names/data-ref-given-names-test-1/data-ref-given-names-test-1.sch
+++ b/test/tests/gen/data-ref-given-names/data-ref-given-names-test-1/data-ref-given-names-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-arrayexpress-test-1/data-arrayexpress-test-1.sch
+++ b/test/tests/gen/data-ref-tests/data-arrayexpress-test-1/data-arrayexpress-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-arrayexpress-test-2/data-arrayexpress-test-2.sch
+++ b/test/tests/gen/data-ref-tests/data-arrayexpress-test-2/data-arrayexpress-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-arrayexpress-test-3/data-arrayexpress-test-3.sch
+++ b/test/tests/gen/data-ref-tests/data-arrayexpress-test-3/data-arrayexpress-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-assembly-test/data-assembly-test.sch
+++ b/test/tests/gen/data-ref-tests/data-assembly-test/data-assembly-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-bioproject-test/data-bioproject-test.sch
+++ b/test/tests/gen/data-ref-tests/data-bioproject-test/data-bioproject-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-biosample-test/data-biosample-test.sch
+++ b/test/tests/gen/data-ref-tests/data-biosample-test/data-biosample-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-bmrb-test-1/data-bmrb-test-1.sch
+++ b/test/tests/gen/data-ref-tests/data-bmrb-test-1/data-bmrb-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-bmrb-test-2/data-bmrb-test-2.sch
+++ b/test/tests/gen/data-ref-tests/data-bmrb-test-2/data-bmrb-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-bmrb-test-3/data-bmrb-test-3.sch
+++ b/test/tests/gen/data-ref-tests/data-bmrb-test-3/data-bmrb-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-crcns-test-1/data-crcns-test-1.sch
+++ b/test/tests/gen/data-ref-tests/data-crcns-test-1/data-crcns-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-crcns-test-2/data-crcns-test-2.sch
+++ b/test/tests/gen/data-ref-tests/data-crcns-test-2/data-crcns-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-crcns-test-3/data-crcns-test-3.sch
+++ b/test/tests/gen/data-ref-tests/data-crcns-test-3/data-crcns-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-dbgap-test/data-dbgap-test.sch
+++ b/test/tests/gen/data-ref-tests/data-dbgap-test/data-dbgap-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-dryad-test-1/data-dryad-test-1.sch
+++ b/test/tests/gen/data-ref-tests/data-dryad-test-1/data-dryad-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-dryad-test-2/data-dryad-test-2.sch
+++ b/test/tests/gen/data-ref-tests/data-dryad-test-2/data-dryad-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-dryad-test-3/data-dryad-test-3.sch
+++ b/test/tests/gen/data-ref-tests/data-dryad-test-3/data-dryad-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-edatashare-test-1/data-edatashare-test-1.sch
+++ b/test/tests/gen/data-ref-tests/data-edatashare-test-1/data-edatashare-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-edatashare-test-2/data-edatashare-test-2.sch
+++ b/test/tests/gen/data-ref-tests/data-edatashare-test-2/data-edatashare-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-edatashare-test-3/data-edatashare-test-3.sch
+++ b/test/tests/gen/data-ref-tests/data-edatashare-test-3/data-edatashare-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-emdb-test-1/data-emdb-test-1.sch
+++ b/test/tests/gen/data-ref-tests/data-emdb-test-1/data-emdb-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-emdb-test-2/data-emdb-test-2.sch
+++ b/test/tests/gen/data-ref-tests/data-emdb-test-2/data-emdb-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-emdb-test-3/data-emdb-test-3.sch
+++ b/test/tests/gen/data-ref-tests/data-emdb-test-3/data-emdb-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-emdr-test-1/data-emdr-test-1.sch
+++ b/test/tests/gen/data-ref-tests/data-emdr-test-1/data-emdr-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-emdr-test-2/data-emdr-test-2.sch
+++ b/test/tests/gen/data-ref-tests/data-emdr-test-2/data-emdr-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-emdr-test-3/data-emdr-test-3.sch
+++ b/test/tests/gen/data-ref-tests/data-emdr-test-3/data-emdr-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-empiar-test-1/data-empiar-test-1.sch
+++ b/test/tests/gen/data-ref-tests/data-empiar-test-1/data-empiar-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-empiar-test-2/data-empiar-test-2.sch
+++ b/test/tests/gen/data-ref-tests/data-empiar-test-2/data-empiar-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-encode-test-1/data-encode-test-1.sch
+++ b/test/tests/gen/data-ref-tests/data-encode-test-1/data-encode-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-encode-test-2/data-encode-test-2.sch
+++ b/test/tests/gen/data-ref-tests/data-encode-test-2/data-encode-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-encode-test-3/data-encode-test-3.sch
+++ b/test/tests/gen/data-ref-tests/data-encode-test-3/data-encode-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-eth-test-1/data-eth-test-1.sch
+++ b/test/tests/gen/data-ref-tests/data-eth-test-1/data-eth-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-eth-test-2/data-eth-test-2.sch
+++ b/test/tests/gen/data-ref-tests/data-eth-test-2/data-eth-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-eth-test-3/data-eth-test-3.sch
+++ b/test/tests/gen/data-ref-tests/data-eth-test-3/data-eth-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-figshare-test-1/data-figshare-test-1.sch
+++ b/test/tests/gen/data-ref-tests/data-figshare-test-1/data-figshare-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-figshare-test-2/data-figshare-test-2.sch
+++ b/test/tests/gen/data-ref-tests/data-figshare-test-2/data-figshare-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-figshare-test-3/data-figshare-test-3.sch
+++ b/test/tests/gen/data-ref-tests/data-figshare-test-3/data-figshare-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-geo-test/data-geo-test.sch
+++ b/test/tests/gen/data-ref-tests/data-geo-test/data-geo-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-harvard-dataverse-test-1/data-harvard-dataverse-test-1.sch
+++ b/test/tests/gen/data-ref-tests/data-harvard-dataverse-test-1/data-harvard-dataverse-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-harvard-dataverse-test-2/data-harvard-dataverse-test-2.sch
+++ b/test/tests/gen/data-ref-tests/data-harvard-dataverse-test-2/data-harvard-dataverse-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-harvard-dataverse-test-3/data-harvard-dataverse-test-3.sch
+++ b/test/tests/gen/data-ref-tests/data-harvard-dataverse-test-3/data-harvard-dataverse-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-mendeley-test-1/data-mendeley-test-1.sch
+++ b/test/tests/gen/data-ref-tests/data-mendeley-test-1/data-mendeley-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-mendeley-test-2/data-mendeley-test-2.sch
+++ b/test/tests/gen/data-ref-tests/data-mendeley-test-2/data-mendeley-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-mendeley-test-3/data-mendeley-test-3.sch
+++ b/test/tests/gen/data-ref-tests/data-mendeley-test-3/data-mendeley-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-morphdbase-test-1/data-morphdbase-test-1.sch
+++ b/test/tests/gen/data-ref-tests/data-morphdbase-test-1/data-morphdbase-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-morphdbase-test-2/data-morphdbase-test-2.sch
+++ b/test/tests/gen/data-ref-tests/data-morphdbase-test-2/data-morphdbase-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-morphdbase-test-3/data-morphdbase-test-3.sch
+++ b/test/tests/gen/data-ref-tests/data-morphdbase-test-3/data-morphdbase-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-morphosource-test-1/data-morphosource-test-1.sch
+++ b/test/tests/gen/data-ref-tests/data-morphosource-test-1/data-morphosource-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-morphosource-test-2/data-morphosource-test-2.sch
+++ b/test/tests/gen/data-ref-tests/data-morphosource-test-2/data-morphosource-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-morphosource-test-3/data-morphosource-test-3.sch
+++ b/test/tests/gen/data-ref-tests/data-morphosource-test-3/data-morphosource-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-ncbi-test-1/data-ncbi-test-1.sch
+++ b/test/tests/gen/data-ref-tests/data-ncbi-test-1/data-ncbi-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-ncbi-test-2/data-ncbi-test-2.sch
+++ b/test/tests/gen/data-ref-tests/data-ncbi-test-2/data-ncbi-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-ncbi-test-3/data-ncbi-test-3.sch
+++ b/test/tests/gen/data-ref-tests/data-ncbi-test-3/data-ncbi-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-ncbi-test-4/data-ncbi-test-4.sch
+++ b/test/tests/gen/data-ref-tests/data-ncbi-test-4/data-ncbi-test-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-neurovault-test-1/data-neurovault-test-1.sch
+++ b/test/tests/gen/data-ref-tests/data-neurovault-test-1/data-neurovault-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-neurovault-test-2/data-neurovault-test-2.sch
+++ b/test/tests/gen/data-ref-tests/data-neurovault-test-2/data-neurovault-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-neurovault-test-3/data-neurovault-test-3.sch
+++ b/test/tests/gen/data-ref-tests/data-neurovault-test-3/data-neurovault-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-nucleotide-test/data-nucleotide-test.sch
+++ b/test/tests/gen/data-ref-tests/data-nucleotide-test/data-nucleotide-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-openneuro-test-1/data-openneuro-test-1.sch
+++ b/test/tests/gen/data-ref-tests/data-openneuro-test-1/data-openneuro-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-openneuro-test-2/data-openneuro-test-2.sch
+++ b/test/tests/gen/data-ref-tests/data-openneuro-test-2/data-openneuro-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-openneuro-test-3/data-openneuro-test-3.sch
+++ b/test/tests/gen/data-ref-tests/data-openneuro-test-3/data-openneuro-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-osf-test-1/data-osf-test-1.sch
+++ b/test/tests/gen/data-ref-tests/data-osf-test-1/data-osf-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-osf-test-2/data-osf-test-2.sch
+++ b/test/tests/gen/data-ref-tests/data-osf-test-2/data-osf-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-osf-test-3/data-osf-test-3.sch
+++ b/test/tests/gen/data-ref-tests/data-osf-test-3/data-osf-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-osf-test-4/data-osf-test-4.sch
+++ b/test/tests/gen/data-ref-tests/data-osf-test-4/data-osf-test-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-osf-test-5/data-osf-test-5.sch
+++ b/test/tests/gen/data-ref-tests/data-osf-test-5/data-osf-test-5.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-popset-test/data-popset-test.sch
+++ b/test/tests/gen/data-ref-tests/data-popset-test/data-popset-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-pride-test-1/data-pride-test-1.sch
+++ b/test/tests/gen/data-ref-tests/data-pride-test-1/data-pride-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-pride-test-2/data-pride-test-2.sch
+++ b/test/tests/gen/data-ref-tests/data-pride-test-2/data-pride-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-pride-test-3/data-pride-test-3.sch
+++ b/test/tests/gen/data-ref-tests/data-pride-test-3/data-pride-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-protein-test/data-protein-test.sch
+++ b/test/tests/gen/data-ref-tests/data-protein-test/data-protein-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-proteomexchange-test-1/data-proteomexchange-test-1.sch
+++ b/test/tests/gen/data-ref-tests/data-proteomexchange-test-1/data-proteomexchange-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-proteomexchange-test-2/data-proteomexchange-test-2.sch
+++ b/test/tests/gen/data-ref-tests/data-proteomexchange-test-2/data-proteomexchange-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-proteomexchange-test-3/data-proteomexchange-test-3.sch
+++ b/test/tests/gen/data-ref-tests/data-proteomexchange-test-3/data-proteomexchange-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-rcsbpbd-test-1/data-rcsbpbd-test-1.sch
+++ b/test/tests/gen/data-ref-tests/data-rcsbpbd-test-1/data-rcsbpbd-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-rcsbpbd-test-2/data-rcsbpbd-test-2.sch
+++ b/test/tests/gen/data-ref-tests/data-rcsbpbd-test-2/data-rcsbpbd-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-rcsbpbd-test-3/data-rcsbpbd-test-3.sch
+++ b/test/tests/gen/data-ref-tests/data-rcsbpbd-test-3/data-rcsbpbd-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-sbgdb-test-1/data-sbgdb-test-1.sch
+++ b/test/tests/gen/data-ref-tests/data-sbgdb-test-1/data-sbgdb-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-sbgdb-test-2/data-sbgdb-test-2.sch
+++ b/test/tests/gen/data-ref-tests/data-sbgdb-test-2/data-sbgdb-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-sbgdb-test-3/data-sbgdb-test-3.sch
+++ b/test/tests/gen/data-ref-tests/data-sbgdb-test-3/data-sbgdb-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-sra-test/data-sra-test.sch
+++ b/test/tests/gen/data-ref-tests/data-sra-test/data-sra-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-synapse-test-1/data-synapse-test-1.sch
+++ b/test/tests/gen/data-ref-tests/data-synapse-test-1/data-synapse-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-synapse-test-2/data-synapse-test-2.sch
+++ b/test/tests/gen/data-ref-tests/data-synapse-test-2/data-synapse-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-synapse-test-3/data-synapse-test-3.sch
+++ b/test/tests/gen/data-ref-tests/data-synapse-test-3/data-synapse-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-wwpdb-test-1/data-wwpdb-test-1.sch
+++ b/test/tests/gen/data-ref-tests/data-wwpdb-test-1/data-wwpdb-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-wwpdb-test-2/data-wwpdb-test-2.sch
+++ b/test/tests/gen/data-ref-tests/data-wwpdb-test-2/data-wwpdb-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-wwpdb-test-3/data-wwpdb-test-3.sch
+++ b/test/tests/gen/data-ref-tests/data-wwpdb-test-3/data-wwpdb-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-zenodo-test-1/data-zenodo-test-1.sch
+++ b/test/tests/gen/data-ref-tests/data-zenodo-test-1/data-zenodo-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-zenodo-test-2/data-zenodo-test-2.sch
+++ b/test/tests/gen/data-ref-tests/data-zenodo-test-2/data-zenodo-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/data-ref-tests/data-zenodo-test-3/data-zenodo-test-3.sch
+++ b/test/tests/gen/data-ref-tests/data-zenodo-test-3/data-zenodo-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/date-tests/date-test-1/date-test-1.sch
+++ b/test/tests/gen/date-tests/date-test-1/date-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/date-tests/date-test-2/date-test-2.sch
+++ b/test/tests/gen/date-tests/date-test-2/date-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/date-tests/date-test-3/date-test-3.sch
+++ b/test/tests/gen/date-tests/date-test-3/date-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/date-tests/date-test-4/date-test-4.sch
+++ b/test/tests/gen/date-tests/date-test-4/date-test-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/day-tests/day-conformity/day-conformity.sch
+++ b/test/tests/gen/day-tests/day-conformity/day-conformity.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/dec-fig-tests/dec-fig-test-1/dec-fig-test-1.sch
+++ b/test/tests/gen/dec-fig-tests/dec-fig-test-1/dec-fig-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/dec-fig-tests/dec-fig-test-2/dec-fig-test-2.sch
+++ b/test/tests/gen/dec-fig-tests/dec-fig-test-2/dec-fig-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/dec-letter-body-p-tests/dec-letter-body-test-2/dec-letter-body-test-2.sch
+++ b/test/tests/gen/dec-letter-body-p-tests/dec-letter-body-test-2/dec-letter-body-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/dec-letter-body-tests/dec-letter-body-test-1/dec-letter-body-test-1.sch
+++ b/test/tests/gen/dec-letter-body-tests/dec-letter-body-test-1/dec-letter-body-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/dec-letter-editor-tests-2/dec-letter-editor-test-3/dec-letter-editor-test-3.sch
+++ b/test/tests/gen/dec-letter-editor-tests-2/dec-letter-editor-test-3/dec-letter-editor-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/dec-letter-editor-tests/dec-letter-editor-test-1/dec-letter-editor-test-1.sch
+++ b/test/tests/gen/dec-letter-editor-tests/dec-letter-editor-test-1/dec-letter-editor-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/dec-letter-editor-tests/dec-letter-editor-test-2/dec-letter-editor-test-2.sch
+++ b/test/tests/gen/dec-letter-editor-tests/dec-letter-editor-test-2/dec-letter-editor-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/dec-letter-front-tests/dec-letter-front-test-1/dec-letter-front-test-1.sch
+++ b/test/tests/gen/dec-letter-front-tests/dec-letter-front-test-1/dec-letter-front-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/dec-letter-front-tests/dec-letter-front-test-2/dec-letter-front-test-2.sch
+++ b/test/tests/gen/dec-letter-front-tests/dec-letter-front-test-2/dec-letter-front-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/dec-letter-front-tests/dec-letter-front-test-3/dec-letter-front-test-3.sch
+++ b/test/tests/gen/dec-letter-front-tests/dec-letter-front-test-3/dec-letter-front-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/dec-letter-front-tests/dec-letter-front-test-4/dec-letter-front-test-4.sch
+++ b/test/tests/gen/dec-letter-front-tests/dec-letter-front-test-4/dec-letter-front-test-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/dec-letter-reply-content-tests/dec-letter-reply-test-5/dec-letter-reply-test-5.sch
+++ b/test/tests/gen/dec-letter-reply-content-tests/dec-letter-reply-test-5/dec-letter-reply-test-5.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/dec-letter-reply-content-tests/dec-letter-reply-test-6/dec-letter-reply-test-6.sch
+++ b/test/tests/gen/dec-letter-reply-content-tests/dec-letter-reply-test-6/dec-letter-reply-test-6.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/dec-letter-reply-tests/dec-letter-reply-test-1/dec-letter-reply-test-1.sch
+++ b/test/tests/gen/dec-letter-reply-tests/dec-letter-reply-test-1/dec-letter-reply-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/dec-letter-reply-tests/dec-letter-reply-test-2/dec-letter-reply-test-2.sch
+++ b/test/tests/gen/dec-letter-reply-tests/dec-letter-reply-test-2/dec-letter-reply-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/dec-letter-reply-tests/dec-letter-reply-test-3/dec-letter-reply-test-3.sch
+++ b/test/tests/gen/dec-letter-reply-tests/dec-letter-reply-test-3/dec-letter-reply-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/dec-letter-reply-tests/dec-letter-reply-test-4/dec-letter-reply-test-4.sch
+++ b/test/tests/gen/dec-letter-reply-tests/dec-letter-reply-test-4/dec-letter-reply-test-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/dec-letter-reviewer-tests-2/dec-letter-reviewer-test-3/dec-letter-reviewer-test-3.sch
+++ b/test/tests/gen/dec-letter-reviewer-tests-2/dec-letter-reviewer-test-3/dec-letter-reviewer-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/dec-letter-reviewer-tests/dec-letter-reviewer-test-1/dec-letter-reviewer-test-1.sch
+++ b/test/tests/gen/dec-letter-reviewer-tests/dec-letter-reviewer-test-1/dec-letter-reviewer-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/dec-letter-reviewer-tests/dec-letter-reviewer-test-2/dec-letter-reviewer-test-2.sch
+++ b/test/tests/gen/dec-letter-reviewer-tests/dec-letter-reviewer-test-2/dec-letter-reviewer-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/dec-letter-reviewer-tests/dec-letter-reviewer-test-6/dec-letter-reviewer-test-6.sch
+++ b/test/tests/gen/dec-letter-reviewer-tests/dec-letter-reviewer-test-6/dec-letter-reviewer-test-6.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/dec-letter-title-tests/dec-letter-title-test/dec-letter-title-test.sch
+++ b/test/tests/gen/dec-letter-title-tests/dec-letter-title-test/dec-letter-title-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/decision-missing-table-tests/decision-missing-table-test/decision-missing-table-test.sch
+++ b/test/tests/gen/decision-missing-table-tests/decision-missing-table-test/decision-missing-table-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/department-tests/dept-replacement-character-presence/dept-replacement-character-presence.sch
+++ b/test/tests/gen/department-tests/dept-replacement-character-presence/dept-replacement-character-presence.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/digest-tests/digest-test-1/digest-test-1.sch
+++ b/test/tests/gen/digest-tests/digest-test-1/digest-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/digest-tests/final-digest-test-2/final-digest-test-2.sch
+++ b/test/tests/gen/digest-tests/final-digest-test-2/final-digest-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/disp-channel-checks/disp-subj-value-test-1/disp-subj-value-test-1.sch
+++ b/test/tests/gen/disp-channel-checks/disp-subj-value-test-1/disp-subj-value-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/disp-channel-checks/disp-subj-value-test-2/disp-subj-value-test-2.sch
+++ b/test/tests/gen/disp-channel-checks/disp-subj-value-test-2/disp-subj-value-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/disp-channel-checks/disp-subj-value-test-3/disp-subj-value-test-3.sch
+++ b/test/tests/gen/disp-channel-checks/disp-subj-value-test-3/disp-subj-value-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/disp-channel-checks/disp-subj-value-test-4/disp-subj-value-test-4.sch
+++ b/test/tests/gen/disp-channel-checks/disp-subj-value-test-4/disp-subj-value-test-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/disp-channel-checks/disp-subj-value-test-5/disp-subj-value-test-5.sch
+++ b/test/tests/gen/disp-channel-checks/disp-subj-value-test-5/disp-subj-value-test-5.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/disp-channel-checks/disp-subj-value-test-6/disp-subj-value-test-6.sch
+++ b/test/tests/gen/disp-channel-checks/disp-subj-value-test-6/disp-subj-value-test-6.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/disp-channel-checks/disp-subj-value-test-7/disp-subj-value-test-7.sch
+++ b/test/tests/gen/disp-channel-checks/disp-subj-value-test-7/disp-subj-value-test-7.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/disp-channel-checks/disp-subj-value-test-8/disp-subj-value-test-8.sch
+++ b/test/tests/gen/disp-channel-checks/disp-subj-value-test-8/disp-subj-value-test-8.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/disp-formula-child-tests/disp-formula-child-test-1/disp-formula-child-test-1.sch
+++ b/test/tests/gen/disp-formula-child-tests/disp-formula-child-test-1/disp-formula-child-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/disp-formula-ids/disp-formula-id-test/disp-formula-id-test.sch
+++ b/test/tests/gen/disp-formula-ids/disp-formula-id-test/disp-formula-id-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/disp-formula-ids/sub-disp-formula-id-test/sub-disp-formula-id-test.sch
+++ b/test/tests/gen/disp-formula-ids/sub-disp-formula-id-test/sub-disp-formula-id-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/disp-formula-tests/disp-formula-test-2/disp-formula-test-2.sch
+++ b/test/tests/gen/disp-formula-tests/disp-formula-test-2/disp-formula-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/disp-formula-tests/disp-formula-test-3/disp-formula-test-3.sch
+++ b/test/tests/gen/disp-formula-tests/disp-formula-test-3/disp-formula-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/disp-formula-tests/disp-formula-test-4/disp-formula-test-4.sch
+++ b/test/tests/gen/disp-formula-tests/disp-formula-test-4/disp-formula-test-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/disp-quote-tests/disp-quote-test-1/disp-quote-test-1.sch
+++ b/test/tests/gen/disp-quote-tests/disp-quote-test-1/disp-quote-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/disp-quote-tests/disp-quote-test-2/disp-quote-test-2.sch
+++ b/test/tests/gen/disp-quote-tests/disp-quote-test-2/disp-quote-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/doi-book-ref-checks/book-doi-test-1/book-doi-test-1.sch
+++ b/test/tests/gen/doi-book-ref-checks/book-doi-test-1/book-doi-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/doi-conf-ref-checks/conf-doi-test-1/conf-doi-test-1.sch
+++ b/test/tests/gen/doi-conf-ref-checks/conf-doi-test-1/conf-doi-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/doi-journal-ref-checks/journal-doi-test-1/journal-doi-test-1.sch
+++ b/test/tests/gen/doi-journal-ref-checks/journal-doi-test-1/journal-doi-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/doi-software-ref-checks/software-doi-test-1/software-doi-test-1.sch
+++ b/test/tests/gen/doi-software-ref-checks/software-doi-test-1/software-doi-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/doi-software-ref-checks/software-doi-test-2/software-doi-test-2.sch
+++ b/test/tests/gen/doi-software-ref-checks/software-doi-test-2/software-doi-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/duplicate-ref/duplicate-ref-test-1/duplicate-ref-test-1.sch
+++ b/test/tests/gen/duplicate-ref/duplicate-ref-test-1/duplicate-ref-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/duplicate-ref/duplicate-ref-test-2/duplicate-ref-test-2.sch
+++ b/test/tests/gen/duplicate-ref/duplicate-ref-test-2/duplicate-ref-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/duplicate-ref/duplicate-ref-test-3/duplicate-ref-test-3.sch
+++ b/test/tests/gen/duplicate-ref/duplicate-ref-test-3/duplicate-ref-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/duplicate-ref/duplicate-ref-test-4/duplicate-ref-test-4.sch
+++ b/test/tests/gen/duplicate-ref/duplicate-ref-test-4/duplicate-ref-test-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/duplicate-ref/duplicate-ref-test-6/duplicate-ref-test-6.sch
+++ b/test/tests/gen/duplicate-ref/duplicate-ref-test-6/duplicate-ref-test-6.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/editorial-metadata/editorial-editors-presence/editorial-editors-presence.sch
+++ b/test/tests/gen/editorial-metadata/editorial-editors-presence/editorial-editors-presence.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-book-chapter-title/err-elem-cit-book-22/err-elem-cit-book-22.sch
+++ b/test/tests/gen/elem-citation-book-chapter-title/err-elem-cit-book-22/err-elem-cit-book-22.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-book-chapter-title/err-elem-cit-book-28-1/err-elem-cit-book-28-1.sch
+++ b/test/tests/gen/elem-citation-book-chapter-title/err-elem-cit-book-28-1/err-elem-cit-book-28-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-book-chapter-title/err-elem-cit-book-31/err-elem-cit-book-31.sch
+++ b/test/tests/gen/elem-citation-book-chapter-title/err-elem-cit-book-31/err-elem-cit-book-31.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-book-comment/err-elem-cit-book-13/err-elem-cit-book-13.sch
+++ b/test/tests/gen/elem-citation-book-comment/err-elem-cit-book-13/err-elem-cit-book-13.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-book-comment/err-elem-cit-book-6-4/err-elem-cit-book-6-4.sch
+++ b/test/tests/gen/elem-citation-book-comment/err-elem-cit-book-6-4/err-elem-cit-book-6-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-book-edition/err-elem-cit-book-15/err-elem-cit-book-15.sch
+++ b/test/tests/gen/elem-citation-book-edition/err-elem-cit-book-15/err-elem-cit-book-15.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-book-person-group/err-elem-cit-book-2-1/err-elem-cit-book-2-1.sch
+++ b/test/tests/gen/elem-citation-book-person-group/err-elem-cit-book-2-1/err-elem-cit-book-2-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-book-pub-id-pmid/err-elem-cit-book-18/err-elem-cit-book-18.sch
+++ b/test/tests/gen/elem-citation-book-pub-id-pmid/err-elem-cit-book-18/err-elem-cit-book-18.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-book-pub-id/err-elem-cit-book-17/err-elem-cit-book-17.sch
+++ b/test/tests/gen/elem-citation-book-pub-id/err-elem-cit-book-17/err-elem-cit-book-17.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-book-publisher-name/err-elem-cit-book-13-2/err-elem-cit-book-13-2.sch
+++ b/test/tests/gen/elem-citation-book-publisher-name/err-elem-cit-book-13-2/err-elem-cit-book-13-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-book/err-elem-cit-book-10-2-2/err-elem-cit-book-10-2-2.sch
+++ b/test/tests/gen/elem-citation-book/err-elem-cit-book-10-2-2/err-elem-cit-book-10-2-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-book/err-elem-cit-book-16/err-elem-cit-book-16.sch
+++ b/test/tests/gen/elem-citation-book/err-elem-cit-book-16/err-elem-cit-book-16.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-book/err-elem-cit-book-2-2/err-elem-cit-book-2-2.sch
+++ b/test/tests/gen/elem-citation-book/err-elem-cit-book-2-2/err-elem-cit-book-2-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-book/err-elem-cit-book-2-3/err-elem-cit-book-2-3.sch
+++ b/test/tests/gen/elem-citation-book/err-elem-cit-book-2-3/err-elem-cit-book-2-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-book/err-elem-cit-book-36-2/err-elem-cit-book-36-2.sch
+++ b/test/tests/gen/elem-citation-book/err-elem-cit-book-36-2/err-elem-cit-book-36-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-book/err-elem-cit-book-36-6/err-elem-cit-book-36-6.sch
+++ b/test/tests/gen/elem-citation-book/err-elem-cit-book-36-6/err-elem-cit-book-36-6.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-book/err-elem-cit-book-36/err-elem-cit-book-36.sch
+++ b/test/tests/gen/elem-citation-book/err-elem-cit-book-36/err-elem-cit-book-36.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-book/err-elem-cit-book-40/err-elem-cit-book-40.sch
+++ b/test/tests/gen/elem-citation-book/err-elem-cit-book-40/err-elem-cit-book-40.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-book/final-err-elem-cit-book-10-1/final-err-elem-cit-book-10-1.sch
+++ b/test/tests/gen/elem-citation-book/final-err-elem-cit-book-10-1/final-err-elem-cit-book-10-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-book/final-err-elem-cit-book-13-1/final-err-elem-cit-book-13-1.sch
+++ b/test/tests/gen/elem-citation-book/final-err-elem-cit-book-13-1/final-err-elem-cit-book-13-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-book/pre-err-elem-cit-book-10-1/pre-err-elem-cit-book-10-1.sch
+++ b/test/tests/gen/elem-citation-book/pre-err-elem-cit-book-10-1/pre-err-elem-cit-book-10-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-book/pre-err-elem-cit-book-13-1/pre-err-elem-cit-book-13-1.sch
+++ b/test/tests/gen/elem-citation-book/pre-err-elem-cit-book-13-1/pre-err-elem-cit-book-13-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-book/warning-elem-cit-book-13-3/warning-elem-cit-book-13-3.sch
+++ b/test/tests/gen/elem-citation-book/warning-elem-cit-book-13-3/warning-elem-cit-book-13-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-confproc-article-title/err-elem-cit-confproc-8-2/err-elem-cit-confproc-8-2.sch
+++ b/test/tests/gen/elem-citation-confproc-article-title/err-elem-cit-confproc-8-2/err-elem-cit-confproc-8-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-confproc-conf-loc/err-elem-cit-confproc-11-2/err-elem-cit-confproc-11-2.sch
+++ b/test/tests/gen/elem-citation-confproc-conf-loc/err-elem-cit-confproc-11-2/err-elem-cit-confproc-11-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-confproc-conf-name/err-elem-cit-confproc-10-2/err-elem-cit-confproc-10-2.sch
+++ b/test/tests/gen/elem-citation-confproc-conf-name/err-elem-cit-confproc-10-2/err-elem-cit-confproc-10-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-confproc-fpage/err-elem-cit-confproc-12-5/err-elem-cit-confproc-12-5.sch
+++ b/test/tests/gen/elem-citation-confproc-fpage/err-elem-cit-confproc-12-5/err-elem-cit-confproc-12-5.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-confproc-preson-group/err-elem-cit-confproc-2-2/err-elem-cit-confproc-2-2.sch
+++ b/test/tests/gen/elem-citation-confproc-preson-group/err-elem-cit-confproc-2-2/err-elem-cit-confproc-2-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-confproc-pub-id/err-elem-cit-confproc-16-2/err-elem-cit-confproc-16-2.sch
+++ b/test/tests/gen/elem-citation-confproc-pub-id/err-elem-cit-confproc-16-2/err-elem-cit-confproc-16-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-confproc-source/err-elem-cit-confproc-9-2-2/err-elem-cit-confproc-9-2-2.sch
+++ b/test/tests/gen/elem-citation-confproc-source/err-elem-cit-confproc-9-2-2/err-elem-cit-confproc-9-2-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-confproc/err-elem-cit-confproc-10-1/err-elem-cit-confproc-10-1.sch
+++ b/test/tests/gen/elem-citation-confproc/err-elem-cit-confproc-10-1/err-elem-cit-confproc-10-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-confproc/err-elem-cit-confproc-12-1/err-elem-cit-confproc-12-1.sch
+++ b/test/tests/gen/elem-citation-confproc/err-elem-cit-confproc-12-1/err-elem-cit-confproc-12-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-confproc/err-elem-cit-confproc-12-2/err-elem-cit-confproc-12-2.sch
+++ b/test/tests/gen/elem-citation-confproc/err-elem-cit-confproc-12-2/err-elem-cit-confproc-12-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-confproc/err-elem-cit-confproc-12-3/err-elem-cit-confproc-12-3.sch
+++ b/test/tests/gen/elem-citation-confproc/err-elem-cit-confproc-12-3/err-elem-cit-confproc-12-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-confproc/err-elem-cit-confproc-12-4/err-elem-cit-confproc-12-4.sch
+++ b/test/tests/gen/elem-citation-confproc/err-elem-cit-confproc-12-4/err-elem-cit-confproc-12-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-confproc/err-elem-cit-confproc-16-1/err-elem-cit-confproc-16-1.sch
+++ b/test/tests/gen/elem-citation-confproc/err-elem-cit-confproc-16-1/err-elem-cit-confproc-16-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-confproc/err-elem-cit-confproc-17/err-elem-cit-confproc-17.sch
+++ b/test/tests/gen/elem-citation-confproc/err-elem-cit-confproc-17/err-elem-cit-confproc-17.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-confproc/err-elem-cit-confproc-2-1/err-elem-cit-confproc-2-1.sch
+++ b/test/tests/gen/elem-citation-confproc/err-elem-cit-confproc-2-1/err-elem-cit-confproc-2-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-confproc/err-elem-cit-confproc-8-1/err-elem-cit-confproc-8-1.sch
+++ b/test/tests/gen/elem-citation-confproc/err-elem-cit-confproc-8-1/err-elem-cit-confproc-8-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-confproc/err-elem-cit-confproc-9-1/err-elem-cit-confproc-9-1.sch
+++ b/test/tests/gen/elem-citation-confproc/err-elem-cit-confproc-9-1/err-elem-cit-confproc-9-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-data-pub-id-doi/err-elem-cit-data-14-2/err-elem-cit-data-14-2.sch
+++ b/test/tests/gen/elem-citation-data-pub-id-doi/err-elem-cit-data-14-2/err-elem-cit-data-14-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-data-pub-id/err-elem-cit-data-13-2/err-elem-cit-data-13-2.sch
+++ b/test/tests/gen/elem-citation-data-pub-id/err-elem-cit-data-13-2/err-elem-cit-data-13-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-data-pub-id/err-elem-cit-data-14-1/err-elem-cit-data-14-1.sch
+++ b/test/tests/gen/elem-citation-data-pub-id/err-elem-cit-data-14-1/err-elem-cit-data-14-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-data/err-elem-cit-data-11-3-2/err-elem-cit-data-11-3-2.sch
+++ b/test/tests/gen/elem-citation-data/err-elem-cit-data-11-3-2/err-elem-cit-data-11-3-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-data/err-elem-cit-data-13-1/err-elem-cit-data-13-1.sch
+++ b/test/tests/gen/elem-citation-data/err-elem-cit-data-13-1/err-elem-cit-data-13-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-data/err-elem-cit-data-17-1/err-elem-cit-data-17-1.sch
+++ b/test/tests/gen/elem-citation-data/err-elem-cit-data-17-1/err-elem-cit-data-17-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-data/err-elem-cit-data-18/err-elem-cit-data-18.sch
+++ b/test/tests/gen/elem-citation-data/err-elem-cit-data-18/err-elem-cit-data-18.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-data/err-elem-cit-data-3-1/err-elem-cit-data-3-1.sch
+++ b/test/tests/gen/elem-citation-data/err-elem-cit-data-3-1/err-elem-cit-data-3-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-data/err-elem-cit-data-3-2/err-elem-cit-data-3-2.sch
+++ b/test/tests/gen/elem-citation-data/err-elem-cit-data-3-2/err-elem-cit-data-3-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-data/final-err-elem-cit-data-10/final-err-elem-cit-data-10.sch
+++ b/test/tests/gen/elem-citation-data/final-err-elem-cit-data-10/final-err-elem-cit-data-10.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-data/final-err-elem-cit-data-11-2/final-err-elem-cit-data-11-2.sch
+++ b/test/tests/gen/elem-citation-data/final-err-elem-cit-data-11-2/final-err-elem-cit-data-11-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-data/pre-err-elem-cit-data-10/pre-err-elem-cit-data-10.sch
+++ b/test/tests/gen/elem-citation-data/pre-err-elem-cit-data-10/pre-err-elem-cit-data-10.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-data/pre-err-elem-cit-data-11-2/pre-err-elem-cit-data-11-2.sch
+++ b/test/tests/gen/elem-citation-data/pre-err-elem-cit-data-11-2/pre-err-elem-cit-data-11-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-ext-link/ext-link-attribute-content-match/ext-link-attribute-content-match.sch
+++ b/test/tests/gen/elem-citation-ext-link/ext-link-attribute-content-match/ext-link-attribute-content-match.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-ext-link/link-href-conformance/link-href-conformance.sch
+++ b/test/tests/gen/elem-citation-ext-link/link-href-conformance/link-href-conformance.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-gen-name-3-1/err-elem-cit-gen-name-3-1/err-elem-cit-gen-name-3-1.sch
+++ b/test/tests/gen/elem-citation-gen-name-3-1/err-elem-cit-gen-name-3-1/err-elem-cit-gen-name-3-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-gen-name-3-2/err-elem-cit-gen-name-3-2/err-elem-cit-gen-name-3-2.sch
+++ b/test/tests/gen/elem-citation-gen-name-3-2/err-elem-cit-gen-name-3-2/err-elem-cit-gen-name-3-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-gen-name-4/err-elem-cit-gen-name-4/err-elem-cit-gen-name-4.sch
+++ b/test/tests/gen/elem-citation-gen-name-4/err-elem-cit-gen-name-4/err-elem-cit-gen-name-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-general/err-elem-cit-gen-date-1-9/err-elem-cit-gen-date-1-9.sch
+++ b/test/tests/gen/elem-citation-general/err-elem-cit-gen-date-1-9/err-elem-cit-gen-date-1-9.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-general/err-elem-cit-gen-name-5/err-elem-cit-gen-name-5.sch
+++ b/test/tests/gen/elem-citation-general/err-elem-cit-gen-name-5/err-elem-cit-gen-name-5.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-general/fpage-lpage-test-1/fpage-lpage-test-1.sch
+++ b/test/tests/gen/elem-citation-general/fpage-lpage-test-1/fpage-lpage-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-journal-article-title/err-elem-cit-journal-3-2/err-elem-cit-journal-3-2.sch
+++ b/test/tests/gen/elem-citation-journal-article-title/err-elem-cit-journal-3-2/err-elem-cit-journal-3-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-journal-comment/err-elem-cit-journal-13/err-elem-cit-journal-13.sch
+++ b/test/tests/gen/elem-citation-journal-comment/err-elem-cit-journal-13/err-elem-cit-journal-13.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-journal-comment/err-elem-cit-journal-6-4/err-elem-cit-journal-6-4.sch
+++ b/test/tests/gen/elem-citation-journal-comment/err-elem-cit-journal-6-4/err-elem-cit-journal-6-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-journal-elocation-id/err-elem-cit-journal-6-3/err-elem-cit-journal-6-3.sch
+++ b/test/tests/gen/elem-citation-journal-elocation-id/err-elem-cit-journal-6-3/err-elem-cit-journal-6-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-journal-fpage/err-elem-cit-journal-6-2/err-elem-cit-journal-6-2.sch
+++ b/test/tests/gen/elem-citation-journal-fpage/err-elem-cit-journal-6-2/err-elem-cit-journal-6-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-journal-fpage/err-elem-cit-journal-6-6/err-elem-cit-journal-6-6.sch
+++ b/test/tests/gen/elem-citation-journal-fpage/err-elem-cit-journal-6-6/err-elem-cit-journal-6-6.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-journal-pub-id-pmid/err-elem-cit-journal-10/err-elem-cit-journal-10.sch
+++ b/test/tests/gen/elem-citation-journal-pub-id-pmid/err-elem-cit-journal-10/err-elem-cit-journal-10.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-journal-pub-id/err-elem-cit-journal-9-1/err-elem-cit-journal-9-1.sch
+++ b/test/tests/gen/elem-citation-journal-pub-id/err-elem-cit-journal-9-1/err-elem-cit-journal-9-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-journal-volume/err-elem-cit-journal-5-1-2/err-elem-cit-journal-5-1-2.sch
+++ b/test/tests/gen/elem-citation-journal-volume/err-elem-cit-journal-5-1-2/err-elem-cit-journal-5-1-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-journal/err-elem-cit-journal-12/err-elem-cit-journal-12.sch
+++ b/test/tests/gen/elem-citation-journal/err-elem-cit-journal-12/err-elem-cit-journal-12.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-journal/err-elem-cit-journal-2-1/err-elem-cit-journal-2-1.sch
+++ b/test/tests/gen/elem-citation-journal/err-elem-cit-journal-2-1/err-elem-cit-journal-2-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-journal/err-elem-cit-journal-2-2/err-elem-cit-journal-2-2.sch
+++ b/test/tests/gen/elem-citation-journal/err-elem-cit-journal-2-2/err-elem-cit-journal-2-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-journal/err-elem-cit-journal-4-2-2/err-elem-cit-journal-4-2-2.sch
+++ b/test/tests/gen/elem-citation-journal/err-elem-cit-journal-4-2-2/err-elem-cit-journal-4-2-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-journal/err-elem-cit-journal-5-1-3/err-elem-cit-journal-5-1-3.sch
+++ b/test/tests/gen/elem-citation-journal/err-elem-cit-journal-5-1-3/err-elem-cit-journal-5-1-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-journal/err-elem-cit-journal-6-5-1/err-elem-cit-journal-6-5-1.sch
+++ b/test/tests/gen/elem-citation-journal/err-elem-cit-journal-6-5-1/err-elem-cit-journal-6-5-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-journal/err-elem-cit-journal-6-5-2/err-elem-cit-journal-6-5-2.sch
+++ b/test/tests/gen/elem-citation-journal/err-elem-cit-journal-6-5-2/err-elem-cit-journal-6-5-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-journal/err-elem-cit-journal-6-7/err-elem-cit-journal-6-7.sch
+++ b/test/tests/gen/elem-citation-journal/err-elem-cit-journal-6-7/err-elem-cit-journal-6-7.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-journal/final-err-elem-cit-journal-3-1/final-err-elem-cit-journal-3-1.sch
+++ b/test/tests/gen/elem-citation-journal/final-err-elem-cit-journal-3-1/final-err-elem-cit-journal-3-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-journal/final-err-elem-cit-journal-4-1/final-err-elem-cit-journal-4-1.sch
+++ b/test/tests/gen/elem-citation-journal/final-err-elem-cit-journal-4-1/final-err-elem-cit-journal-4-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-journal/pre-err-elem-cit-journal-3-1/pre-err-elem-cit-journal-3-1.sch
+++ b/test/tests/gen/elem-citation-journal/pre-err-elem-cit-journal-3-1/pre-err-elem-cit-journal-3-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-journal/pre-err-elem-cit-journal-4-1/pre-err-elem-cit-journal-4-1.sch
+++ b/test/tests/gen/elem-citation-journal/pre-err-elem-cit-journal-4-1/pre-err-elem-cit-journal-4-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-patent-article-title/err-elem-cit-patent-8-2-1/err-elem-cit-patent-8-2-1.sch
+++ b/test/tests/gen/elem-citation-patent-article-title/err-elem-cit-patent-8-2-1/err-elem-cit-patent-8-2-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-patent-article-title/err-elem-cit-patent-8-2-2/err-elem-cit-patent-8-2-2.sch
+++ b/test/tests/gen/elem-citation-patent-article-title/err-elem-cit-patent-8-2-2/err-elem-cit-patent-8-2-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-patent-patent/err-elem-cit-patent-10-1-2/err-elem-cit-patent-10-1-2.sch
+++ b/test/tests/gen/elem-citation-patent-patent/err-elem-cit-patent-10-1-2/err-elem-cit-patent-10-1-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-patent-patent/err-elem-cit-patent-10-2/err-elem-cit-patent-10-2.sch
+++ b/test/tests/gen/elem-citation-patent-patent/err-elem-cit-patent-10-2/err-elem-cit-patent-10-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-patent-source/err-elem-cit-patent-9-2-2/err-elem-cit-patent-9-2-2.sch
+++ b/test/tests/gen/elem-citation-patent-source/err-elem-cit-patent-9-2-2/err-elem-cit-patent-9-2-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-patent/err-elem-cit-patent-18/err-elem-cit-patent-18.sch
+++ b/test/tests/gen/elem-citation-patent/err-elem-cit-patent-18/err-elem-cit-patent-18.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-patent/err-elem-cit-patent-2-1/err-elem-cit-patent-2-1.sch
+++ b/test/tests/gen/elem-citation-patent/err-elem-cit-patent-2-1/err-elem-cit-patent-2-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-patent/err-elem-cit-patent-2-3/err-elem-cit-patent-2-3.sch
+++ b/test/tests/gen/elem-citation-patent/err-elem-cit-patent-2-3/err-elem-cit-patent-2-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-patent/err-elem-cit-patent-2A/err-elem-cit-patent-2A.sch
+++ b/test/tests/gen/elem-citation-patent/err-elem-cit-patent-2A/err-elem-cit-patent-2A.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-patent/err-elem-cit-patent-8-1/err-elem-cit-patent-8-1.sch
+++ b/test/tests/gen/elem-citation-patent/err-elem-cit-patent-8-1/err-elem-cit-patent-8-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-patent/err-elem-cit-patent-9-1/err-elem-cit-patent-9-1.sch
+++ b/test/tests/gen/elem-citation-patent/err-elem-cit-patent-9-1/err-elem-cit-patent-9-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-patent/final-err-elem-cit-patent-10-1-1/final-err-elem-cit-patent-10-1-1.sch
+++ b/test/tests/gen/elem-citation-patent/final-err-elem-cit-patent-10-1-1/final-err-elem-cit-patent-10-1-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-patent/final-err-elem-cit-patent-11-1/final-err-elem-cit-patent-11-1.sch
+++ b/test/tests/gen/elem-citation-patent/final-err-elem-cit-patent-11-1/final-err-elem-cit-patent-11-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-patent/pre-err-elem-cit-patent-10-1-1/pre-err-elem-cit-patent-10-1-1.sch
+++ b/test/tests/gen/elem-citation-patent/pre-err-elem-cit-patent-10-1-1/pre-err-elem-cit-patent-10-1-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-patent/pre-err-elem-cit-patent-11-1/pre-err-elem-cit-patent-11-1.sch
+++ b/test/tests/gen/elem-citation-patent/pre-err-elem-cit-patent-11-1/pre-err-elem-cit-patent-11-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-periodical-article-title/err-elem-cit-periodical-8-2/err-elem-cit-periodical-8-2.sch
+++ b/test/tests/gen/elem-citation-periodical-article-title/err-elem-cit-periodical-8-2/err-elem-cit-periodical-8-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-periodical-day/err-elem-cit-periodical-14-6/err-elem-cit-periodical-14-6.sch
+++ b/test/tests/gen/elem-citation-periodical-day/err-elem-cit-periodical-14-6/err-elem-cit-periodical-14-6.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-periodical-day/err-elem-cit-periodical-14-7/err-elem-cit-periodical-14-7.sch
+++ b/test/tests/gen/elem-citation-periodical-day/err-elem-cit-periodical-14-7/err-elem-cit-periodical-14-7.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-periodical-fpage/err-elem-cit-periodical-11-5/err-elem-cit-periodical-11-5.sch
+++ b/test/tests/gen/elem-citation-periodical-fpage/err-elem-cit-periodical-11-5/err-elem-cit-periodical-11-5.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-periodical-month/err-elem-cit-periodical-14-4/err-elem-cit-periodical-14-4.sch
+++ b/test/tests/gen/elem-citation-periodical-month/err-elem-cit-periodical-14-4/err-elem-cit-periodical-14-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-periodical-month/err-elem-cit-periodical-14-5/err-elem-cit-periodical-14-5.sch
+++ b/test/tests/gen/elem-citation-periodical-month/err-elem-cit-periodical-14-5/err-elem-cit-periodical-14-5.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-periodical-string-date/err-elem-cit-periodical-14-2/err-elem-cit-periodical-14-2.sch
+++ b/test/tests/gen/elem-citation-periodical-string-date/err-elem-cit-periodical-14-2/err-elem-cit-periodical-14-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-periodical-string-date/err-elem-cit-periodical-14-3/err-elem-cit-periodical-14-3.sch
+++ b/test/tests/gen/elem-citation-periodical-string-date/err-elem-cit-periodical-14-3/err-elem-cit-periodical-14-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-periodical-string-date/err-elem-cit-periodical-14-8/err-elem-cit-periodical-14-8.sch
+++ b/test/tests/gen/elem-citation-periodical-string-date/err-elem-cit-periodical-14-8/err-elem-cit-periodical-14-8.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-periodical-string-date/err-elem-cit-periodical-7-3/err-elem-cit-periodical-7-3.sch
+++ b/test/tests/gen/elem-citation-periodical-string-date/err-elem-cit-periodical-7-3/err-elem-cit-periodical-7-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-periodical-string-date/err-elem-cit-periodical-7-5/err-elem-cit-periodical-7-5.sch
+++ b/test/tests/gen/elem-citation-periodical-string-date/err-elem-cit-periodical-7-5/err-elem-cit-periodical-7-5.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-periodical-volume/err-elem-cit-periodical-10-1-2/err-elem-cit-periodical-10-1-2.sch
+++ b/test/tests/gen/elem-citation-periodical-volume/err-elem-cit-periodical-10-1-2/err-elem-cit-periodical-10-1-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-periodical-year/err-elem-cit-periodical-7-2/err-elem-cit-periodical-7-2.sch
+++ b/test/tests/gen/elem-citation-periodical-year/err-elem-cit-periodical-7-2/err-elem-cit-periodical-7-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-periodical-year/err-elem-cit-periodical-7-4-1/err-elem-cit-periodical-7-4-1.sch
+++ b/test/tests/gen/elem-citation-periodical-year/err-elem-cit-periodical-7-4-1/err-elem-cit-periodical-7-4-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-periodical-year/err-elem-cit-periodical-7-4-2/err-elem-cit-periodical-7-4-2.sch
+++ b/test/tests/gen/elem-citation-periodical-year/err-elem-cit-periodical-7-4-2/err-elem-cit-periodical-7-4-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-periodical-year/err-elem-cit-periodical-7-6/err-elem-cit-periodical-7-6.sch
+++ b/test/tests/gen/elem-citation-periodical-year/err-elem-cit-periodical-7-6/err-elem-cit-periodical-7-6.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-periodical-year/err-elem-cit-periodical-7-7/err-elem-cit-periodical-7-7.sch
+++ b/test/tests/gen/elem-citation-periodical-year/err-elem-cit-periodical-7-7/err-elem-cit-periodical-7-7.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-periodical-year/err-elem-cit-periodical-7-8/err-elem-cit-periodical-7-8.sch
+++ b/test/tests/gen/elem-citation-periodical-year/err-elem-cit-periodical-7-8/err-elem-cit-periodical-7-8.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-periodical/err-elem-cit-periodical-10-1-3/err-elem-cit-periodical-10-1-3.sch
+++ b/test/tests/gen/elem-citation-periodical/err-elem-cit-periodical-10-1-3/err-elem-cit-periodical-10-1-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-periodical/err-elem-cit-periodical-11-1/err-elem-cit-periodical-11-1.sch
+++ b/test/tests/gen/elem-citation-periodical/err-elem-cit-periodical-11-1/err-elem-cit-periodical-11-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-periodical/err-elem-cit-periodical-11-2/err-elem-cit-periodical-11-2.sch
+++ b/test/tests/gen/elem-citation-periodical/err-elem-cit-periodical-11-2/err-elem-cit-periodical-11-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-periodical/err-elem-cit-periodical-11-3/err-elem-cit-periodical-11-3.sch
+++ b/test/tests/gen/elem-citation-periodical/err-elem-cit-periodical-11-3/err-elem-cit-periodical-11-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-periodical/err-elem-cit-periodical-11-4/err-elem-cit-periodical-11-4.sch
+++ b/test/tests/gen/elem-citation-periodical/err-elem-cit-periodical-11-4/err-elem-cit-periodical-11-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-periodical/err-elem-cit-periodical-13/err-elem-cit-periodical-13.sch
+++ b/test/tests/gen/elem-citation-periodical/err-elem-cit-periodical-13/err-elem-cit-periodical-13.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-periodical/err-elem-cit-periodical-14-1/err-elem-cit-periodical-14-1.sch
+++ b/test/tests/gen/elem-citation-periodical/err-elem-cit-periodical-14-1/err-elem-cit-periodical-14-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-periodical/err-elem-cit-periodical-2-1/err-elem-cit-periodical-2-1.sch
+++ b/test/tests/gen/elem-citation-periodical/err-elem-cit-periodical-2-1/err-elem-cit-periodical-2-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-periodical/err-elem-cit-periodical-2-2/err-elem-cit-periodical-2-2.sch
+++ b/test/tests/gen/elem-citation-periodical/err-elem-cit-periodical-2-2/err-elem-cit-periodical-2-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-periodical/err-elem-cit-periodical-7-1/err-elem-cit-periodical-7-1.sch
+++ b/test/tests/gen/elem-citation-periodical/err-elem-cit-periodical-7-1/err-elem-cit-periodical-7-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-periodical/err-elem-cit-periodical-8-1/err-elem-cit-periodical-8-1.sch
+++ b/test/tests/gen/elem-citation-periodical/err-elem-cit-periodical-8-1/err-elem-cit-periodical-8-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-periodical/err-elem-cit-periodical-9-1/err-elem-cit-periodical-9-1.sch
+++ b/test/tests/gen/elem-citation-periodical/err-elem-cit-periodical-9-1/err-elem-cit-periodical-9-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-periodical/err-elem-cit-periodical-9-2-2/err-elem-cit-periodical-9-2-2.sch
+++ b/test/tests/gen/elem-citation-periodical/err-elem-cit-periodical-9-2-2/err-elem-cit-periodical-9-2-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-preprint-article-title/err-elem-cit-preprint-8-2-1/err-elem-cit-preprint-8-2-1.sch
+++ b/test/tests/gen/elem-citation-preprint-article-title/err-elem-cit-preprint-8-2-1/err-elem-cit-preprint-8-2-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-preprint-article-title/err-elem-cit-preprint-8-2-2/err-elem-cit-preprint-8-2-2.sch
+++ b/test/tests/gen/elem-citation-preprint-article-title/err-elem-cit-preprint-8-2-2/err-elem-cit-preprint-8-2-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-preprint-person-group/err-elem-cit-preprint-2-2/err-elem-cit-preprint-2-2.sch
+++ b/test/tests/gen/elem-citation-preprint-person-group/err-elem-cit-preprint-2-2/err-elem-cit-preprint-2-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-preprint-pub-id/err-elem-cit-preprint-10-2/err-elem-cit-preprint-10-2.sch
+++ b/test/tests/gen/elem-citation-preprint-pub-id/err-elem-cit-preprint-10-2/err-elem-cit-preprint-10-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-preprint-source/err-elem-cit-preprint-9-2-2/err-elem-cit-preprint-9-2-2.sch
+++ b/test/tests/gen/elem-citation-preprint-source/err-elem-cit-preprint-9-2-2/err-elem-cit-preprint-9-2-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-preprint/err-elem-cit-preprint-10-1/err-elem-cit-preprint-10-1.sch
+++ b/test/tests/gen/elem-citation-preprint/err-elem-cit-preprint-10-1/err-elem-cit-preprint-10-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-preprint/err-elem-cit-preprint-10-3/err-elem-cit-preprint-10-3.sch
+++ b/test/tests/gen/elem-citation-preprint/err-elem-cit-preprint-10-3/err-elem-cit-preprint-10-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-preprint/err-elem-cit-preprint-13/err-elem-cit-preprint-13.sch
+++ b/test/tests/gen/elem-citation-preprint/err-elem-cit-preprint-13/err-elem-cit-preprint-13.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-preprint/err-elem-cit-preprint-2-1/err-elem-cit-preprint-2-1.sch
+++ b/test/tests/gen/elem-citation-preprint/err-elem-cit-preprint-2-1/err-elem-cit-preprint-2-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-preprint/err-elem-cit-preprint-8-1/err-elem-cit-preprint-8-1.sch
+++ b/test/tests/gen/elem-citation-preprint/err-elem-cit-preprint-8-1/err-elem-cit-preprint-8-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-preprint/err-elem-cit-preprint-9-1/err-elem-cit-preprint-9-1.sch
+++ b/test/tests/gen/elem-citation-preprint/err-elem-cit-preprint-9-1/err-elem-cit-preprint-9-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-report-preson-group/err-elem-cit-report-2-2/err-elem-cit-report-2-2.sch
+++ b/test/tests/gen/elem-citation-report-preson-group/err-elem-cit-report-2-2/err-elem-cit-report-2-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-report-pub-id/err-elem-cit-report-12-2/err-elem-cit-report-12-2.sch
+++ b/test/tests/gen/elem-citation-report-pub-id/err-elem-cit-report-12-2/err-elem-cit-report-12-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-report-publisher-name/err-elem-cit-report-11-2/err-elem-cit-report-11-2.sch
+++ b/test/tests/gen/elem-citation-report-publisher-name/err-elem-cit-report-11-2/err-elem-cit-report-11-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-report-source/err-elem-cit-report-9-2-2/err-elem-cit-report-9-2-2.sch
+++ b/test/tests/gen/elem-citation-report-source/err-elem-cit-report-9-2-2/err-elem-cit-report-9-2-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-report/err-elem-cit-report-11-1/err-elem-cit-report-11-1.sch
+++ b/test/tests/gen/elem-citation-report/err-elem-cit-report-11-1/err-elem-cit-report-11-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-report/err-elem-cit-report-15/err-elem-cit-report-15.sch
+++ b/test/tests/gen/elem-citation-report/err-elem-cit-report-15/err-elem-cit-report-15.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-report/err-elem-cit-report-2-1/err-elem-cit-report-2-1.sch
+++ b/test/tests/gen/elem-citation-report/err-elem-cit-report-2-1/err-elem-cit-report-2-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-report/err-elem-cit-report-9-1/err-elem-cit-report-9-1.sch
+++ b/test/tests/gen/elem-citation-report/err-elem-cit-report-9-1/err-elem-cit-report-9-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-report/warning-elem-cit-report-11-3/warning-elem-cit-report-11-3.sch
+++ b/test/tests/gen/elem-citation-report/warning-elem-cit-report-11-3/warning-elem-cit-report-11-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-software-data-title/err-elem-cit-software-10-2/err-elem-cit-software-10-2.sch
+++ b/test/tests/gen/elem-citation-software-data-title/err-elem-cit-software-10-2/err-elem-cit-software-10-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-software/err-elem-cit-software-10-1/err-elem-cit-software-10-1.sch
+++ b/test/tests/gen/elem-citation-software/err-elem-cit-software-10-1/err-elem-cit-software-10-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-software/err-elem-cit-software-16/err-elem-cit-software-16.sch
+++ b/test/tests/gen/elem-citation-software/err-elem-cit-software-16/err-elem-cit-software-16.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-software/err-elem-cit-software-2-1/err-elem-cit-software-2-1.sch
+++ b/test/tests/gen/elem-citation-software/err-elem-cit-software-2-1/err-elem-cit-software-2-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-software/err-elem-cit-software-2-2/err-elem-cit-software-2-2.sch
+++ b/test/tests/gen/elem-citation-software/err-elem-cit-software-2-2/err-elem-cit-software-2-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-source/elem-cit-source/elem-cit-source.sch
+++ b/test/tests/gen/elem-citation-source/elem-cit-source/elem-cit-source.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-thesis-article-title/err-elem-cit-thesis-8-2/err-elem-cit-thesis-8-2.sch
+++ b/test/tests/gen/elem-citation-thesis-article-title/err-elem-cit-thesis-8-2/err-elem-cit-thesis-8-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-thesis-preson-group/err-elem-cit-thesis-2-2/err-elem-cit-thesis-2-2.sch
+++ b/test/tests/gen/elem-citation-thesis-preson-group/err-elem-cit-thesis-2-2/err-elem-cit-thesis-2-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-thesis-preson-group/err-elem-cit-thesis-2-3/err-elem-cit-thesis-2-3.sch
+++ b/test/tests/gen/elem-citation-thesis-preson-group/err-elem-cit-thesis-2-3/err-elem-cit-thesis-2-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-thesis-pub-id/err-elem-cit-thesis-11-2/err-elem-cit-thesis-11-2.sch
+++ b/test/tests/gen/elem-citation-thesis-pub-id/err-elem-cit-thesis-11-2/err-elem-cit-thesis-11-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-thesis-publisher-loc/err-elem-cit-thesis-10-2/err-elem-cit-thesis-10-2.sch
+++ b/test/tests/gen/elem-citation-thesis-publisher-loc/err-elem-cit-thesis-10-2/err-elem-cit-thesis-10-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-thesis-publisher-name/err-elem-cit-thesis-9-2/err-elem-cit-thesis-9-2.sch
+++ b/test/tests/gen/elem-citation-thesis-publisher-name/err-elem-cit-thesis-9-2/err-elem-cit-thesis-9-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-thesis/err-elem-cit-thesis-11-1/err-elem-cit-thesis-11-1.sch
+++ b/test/tests/gen/elem-citation-thesis/err-elem-cit-thesis-11-1/err-elem-cit-thesis-11-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-thesis/err-elem-cit-thesis-13/err-elem-cit-thesis-13.sch
+++ b/test/tests/gen/elem-citation-thesis/err-elem-cit-thesis-13/err-elem-cit-thesis-13.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-thesis/err-elem-cit-thesis-2-1/err-elem-cit-thesis-2-1.sch
+++ b/test/tests/gen/elem-citation-thesis/err-elem-cit-thesis-2-1/err-elem-cit-thesis-2-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-thesis/err-elem-cit-thesis-3/err-elem-cit-thesis-3.sch
+++ b/test/tests/gen/elem-citation-thesis/err-elem-cit-thesis-3/err-elem-cit-thesis-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-thesis/err-elem-cit-thesis-6/err-elem-cit-thesis-6.sch
+++ b/test/tests/gen/elem-citation-thesis/err-elem-cit-thesis-6/err-elem-cit-thesis-6.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-thesis/err-elem-cit-thesis-8-1/err-elem-cit-thesis-8-1.sch
+++ b/test/tests/gen/elem-citation-thesis/err-elem-cit-thesis-8-1/err-elem-cit-thesis-8-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-thesis/err-elem-cit-thesis-9-1/err-elem-cit-thesis-9-1.sch
+++ b/test/tests/gen/elem-citation-thesis/err-elem-cit-thesis-9-1/err-elem-cit-thesis-9-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-web-article-title/err-elem-cit-web-8-2-1/err-elem-cit-web-8-2-1.sch
+++ b/test/tests/gen/elem-citation-web-article-title/err-elem-cit-web-8-2-1/err-elem-cit-web-8-2-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-web-article-title/err-elem-cit-web-8-2-2/err-elem-cit-web-8-2-2.sch
+++ b/test/tests/gen/elem-citation-web-article-title/err-elem-cit-web-8-2-2/err-elem-cit-web-8-2-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-web-date-in-citation/err-elem-cit-web-11-2-1/err-elem-cit-web-11-2-1.sch
+++ b/test/tests/gen/elem-citation-web-date-in-citation/err-elem-cit-web-11-2-1/err-elem-cit-web-11-2-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-web-date-in-citation/err-elem-cit-web-11-2-2/err-elem-cit-web-11-2-2.sch
+++ b/test/tests/gen/elem-citation-web-date-in-citation/err-elem-cit-web-11-2-2/err-elem-cit-web-11-2-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-web-date-in-citation/err-elem-cit-web-11-3/err-elem-cit-web-11-3.sch
+++ b/test/tests/gen/elem-citation-web-date-in-citation/err-elem-cit-web-11-3/err-elem-cit-web-11-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-web-date-in-citation/err-elem-cit-web-11-4/err-elem-cit-web-11-4.sch
+++ b/test/tests/gen/elem-citation-web-date-in-citation/err-elem-cit-web-11-4/err-elem-cit-web-11-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-web-date-in-citation/err-elem-cit-web-11-5/err-elem-cit-web-11-5.sch
+++ b/test/tests/gen/elem-citation-web-date-in-citation/err-elem-cit-web-11-5/err-elem-cit-web-11-5.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-web-person-group/err-elem-cit-web-2-2/err-elem-cit-web-2-2.sch
+++ b/test/tests/gen/elem-citation-web-person-group/err-elem-cit-web-2-2/err-elem-cit-web-2-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-web-source/err-elem-cit-web-9-2-2/err-elem-cit-web-9-2-2.sch
+++ b/test/tests/gen/elem-citation-web-source/err-elem-cit-web-9-2-2/err-elem-cit-web-9-2-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-web/err-elem-cit-web-10-1/err-elem-cit-web-10-1.sch
+++ b/test/tests/gen/elem-citation-web/err-elem-cit-web-10-1/err-elem-cit-web-10-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-web/err-elem-cit-web-11-1-1/err-elem-cit-web-11-1-1.sch
+++ b/test/tests/gen/elem-citation-web/err-elem-cit-web-11-1-1/err-elem-cit-web-11-1-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-web/err-elem-cit-web-12/err-elem-cit-web-12.sch
+++ b/test/tests/gen/elem-citation-web/err-elem-cit-web-12/err-elem-cit-web-12.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-web/err-elem-cit-web-2-1/err-elem-cit-web-2-1.sch
+++ b/test/tests/gen/elem-citation-web/err-elem-cit-web-2-1/err-elem-cit-web-2-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-web/err-elem-cit-web-9-1/err-elem-cit-web-9-1.sch
+++ b/test/tests/gen/elem-citation-web/err-elem-cit-web-9-1/err-elem-cit-web-9-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-web/final-err-elem-cit-web-11-1/final-err-elem-cit-web-11-1.sch
+++ b/test/tests/gen/elem-citation-web/final-err-elem-cit-web-11-1/final-err-elem-cit-web-11-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-web/final-err-elem-cit-web-8-1/final-err-elem-cit-web-8-1.sch
+++ b/test/tests/gen/elem-citation-web/final-err-elem-cit-web-8-1/final-err-elem-cit-web-8-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-web/pre-err-elem-cit-web-11-1/pre-err-elem-cit-web-11-1.sch
+++ b/test/tests/gen/elem-citation-web/pre-err-elem-cit-web-11-1/pre-err-elem-cit-web-11-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-web/pre-err-elem-cit-web-8-1/pre-err-elem-cit-web-8-1.sch
+++ b/test/tests/gen/elem-citation-web/pre-err-elem-cit-web-8-1/pre-err-elem-cit-web-8-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-year/err-elem-cit-gen-date-1-2/err-elem-cit-gen-date-1-2.sch
+++ b/test/tests/gen/elem-citation-year/err-elem-cit-gen-date-1-2/err-elem-cit-gen-date-1-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-year/err-elem-cit-gen-date-1-3/err-elem-cit-gen-date-1-3.sch
+++ b/test/tests/gen/elem-citation-year/err-elem-cit-gen-date-1-3/err-elem-cit-gen-date-1-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-year/err-elem-cit-gen-date-1-4/err-elem-cit-gen-date-1-4.sch
+++ b/test/tests/gen/elem-citation-year/err-elem-cit-gen-date-1-4/err-elem-cit-gen-date-1-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-year/err-elem-cit-gen-date-1-6/err-elem-cit-gen-date-1-6.sch
+++ b/test/tests/gen/elem-citation-year/err-elem-cit-gen-date-1-6/err-elem-cit-gen-date-1-6.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-year/err-elem-cit-gen-date-1-7/err-elem-cit-gen-date-1-7.sch
+++ b/test/tests/gen/elem-citation-year/err-elem-cit-gen-date-1-7/err-elem-cit-gen-date-1-7.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-year/final-err-elem-cit-gen-date-1-5/final-err-elem-cit-gen-date-1-5.sch
+++ b/test/tests/gen/elem-citation-year/final-err-elem-cit-gen-date-1-5/final-err-elem-cit-gen-date-1-5.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation-year/pre-err-elem-cit-gen-date-1-5/pre-err-elem-cit-gen-date-1-5.sch
+++ b/test/tests/gen/elem-citation-year/pre-err-elem-cit-gen-date-1-5/pre-err-elem-cit-gen-date-1-5.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation/err-elem-cit-high-6-1/err-elem-cit-high-6-1.sch
+++ b/test/tests/gen/elem-citation/err-elem-cit-high-6-1/err-elem-cit-high-6-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation/err-elem-cit-high-6-2/err-elem-cit-high-6-2.sch
+++ b/test/tests/gen/elem-citation/err-elem-cit-high-6-2/err-elem-cit-high-6-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation/final-element-cite-string-date/final-element-cite-string-date.sch
+++ b/test/tests/gen/elem-citation/final-element-cite-string-date/final-element-cite-string-date.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation/final-element-cite-year/final-element-cite-year.sch
+++ b/test/tests/gen/elem-citation/final-element-cite-year/final-element-cite-year.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation/pre-element-cite-string-date/pre-element-cite-string-date.sch
+++ b/test/tests/gen/elem-citation/pre-element-cite-string-date/pre-element-cite-string-date.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elem-citation/pre-element-cite-year/pre-element-cite-year.sch
+++ b/test/tests/gen/elem-citation/pre-element-cite-year/pre-element-cite-year.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/element-allowlist/element-conformity/element-conformity.sch
+++ b/test/tests/gen/element-allowlist/element-conformity/element-conformity.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/element-citation-descendants/final-empty-elem-cit-des/final-empty-elem-cit-des.sch
+++ b/test/tests/gen/element-citation-descendants/final-empty-elem-cit-des/final-empty-elem-cit-des.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/element-citation-descendants/pre-empty-elem-cit-des/pre-empty-elem-cit-des.sch
+++ b/test/tests/gen/element-citation-descendants/pre-empty-elem-cit-des/pre-empty-elem-cit-des.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/elocation-id-tests/test-elocation-conformance/test-elocation-conformance.sch
+++ b/test/tests/gen/elocation-id-tests/test-elocation-conformance/test-elocation-conformance.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/email-tests/email-test/email-test.sch
+++ b/test/tests/gen/email-tests/email-test/email-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/empty-attribute-test/final-empty-attribute-conformance/final-empty-attribute-conformance.sch
+++ b/test/tests/gen/empty-attribute-test/final-empty-attribute-conformance/final-empty-attribute-conformance.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/empty-attribute-test/pre-empty-attribute-conformance/pre-empty-attribute-conformance.sch
+++ b/test/tests/gen/empty-attribute-test/pre-empty-attribute-conformance/pre-empty-attribute-conformance.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/equal-author-tests/equal-author-test-1/equal-author-test-1.sch
+++ b/test/tests/gen/equal-author-tests/equal-author-test-1/equal-author-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/equal-author-tests/equal-author-test-2/equal-author-test-2.sch
+++ b/test/tests/gen/equal-author-tests/equal-author-test-2/equal-author-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/equation-label-tests/equation-label-conformance-1/equation-label-conformance-1.sch
+++ b/test/tests/gen/equation-label-tests/equation-label-conformance-1/equation-label-conformance-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/equation-label-tests/equation-label-conformance-2/equation-label-conformance-2.sch
+++ b/test/tests/gen/equation-label-tests/equation-label-conformance-2/equation-label-conformance-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/equation-xref-conformance/equ-xref-conformity-1/equ-xref-conformity-1.sch
+++ b/test/tests/gen/equation-xref-conformance/equ-xref-conformity-1/equ-xref-conformity-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/equation-xref-conformance/equ-xref-conformity-2/equ-xref-conformity-2.sch
+++ b/test/tests/gen/equation-xref-conformance/equ-xref-conformity-2/equ-xref-conformity-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/equation-xref-conformance/equ-xref-conformity-3/equ-xref-conformity-3.sch
+++ b/test/tests/gen/equation-xref-conformance/equ-xref-conformity-3/equ-xref-conformity-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/equation-xref-conformance/equ-xref-conformity-4/equ-xref-conformity-4.sch
+++ b/test/tests/gen/equation-xref-conformance/equ-xref-conformity-4/equ-xref-conformity-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ethics-fn-tests/ethics-test-4/ethics-test-4.sch
+++ b/test/tests/gen/ethics-fn-tests/ethics-test-4/ethics-test-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ethics-info/ethics-info-conformity/ethics-info-conformity.sch
+++ b/test/tests/gen/ethics-info/ethics-info-conformity/ethics-info-conformity.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ethics-info/ethics-info-supplemental-conformity/ethics-info-supplemental-conformity.sch
+++ b/test/tests/gen/ethics-info/ethics-info-supplemental-conformity/ethics-info-supplemental-conformity.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ethics-tests/ethics-test-1/ethics-test-1.sch
+++ b/test/tests/gen/ethics-tests/ethics-test-1/ethics-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ethics-tests/ethics-test-2/ethics-test-2.sch
+++ b/test/tests/gen/ethics-tests/ethics-test-2/ethics-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ethics-tests/ethics-test-3/ethics-test-3.sch
+++ b/test/tests/gen/ethics-tests/ethics-test-3/ethics-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ethics-title-tests/ethics-broken-unicode-test/ethics-broken-unicode-test.sch
+++ b/test/tests/gen/ethics-title-tests/ethics-broken-unicode-test/ethics-broken-unicode-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ethics-title-tests/ethics-title-test/ethics-title-test.sch
+++ b/test/tests/gen/ethics-title-tests/ethics-title-test/ethics-title-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ext-link-tests/ext-link-child-test-2/ext-link-child-test-2.sch
+++ b/test/tests/gen/ext-link-tests/ext-link-child-test-2/ext-link-child-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ext-link-tests/ext-link-child-test-3/ext-link-child-test-3.sch
+++ b/test/tests/gen/ext-link-tests/ext-link-child-test-3/ext-link-child-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ext-link-tests/ext-link-child-test-4/ext-link-child-test-4.sch
+++ b/test/tests/gen/ext-link-tests/ext-link-child-test-4/ext-link-child-test-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ext-link-tests/ext-link-child-test-5/ext-link-child-test-5.sch
+++ b/test/tests/gen/ext-link-tests/ext-link-child-test-5/ext-link-child-test-5.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ext-link-tests/ext-link-child-test/ext-link-child-test.sch
+++ b/test/tests/gen/ext-link-tests/ext-link-child-test/ext-link-child-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ext-link-tests/ext-link-parent-test/ext-link-parent-test.sch
+++ b/test/tests/gen/ext-link-tests/ext-link-parent-test/ext-link-parent-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ext-link-tests/ftp-credentials-flag/ftp-credentials-flag.sch
+++ b/test/tests/gen/ext-link-tests/ftp-credentials-flag/ftp-credentials-flag.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ext-link-tests/url-conformance-test/url-conformance-test.sch
+++ b/test/tests/gen/ext-link-tests/url-conformance-test/url-conformance-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ext-link-tests/url-fullstop-report/url-fullstop-report.sch
+++ b/test/tests/gen/ext-link-tests/url-fullstop-report/url-fullstop-report.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/featmeta-value-tests/feat-custom-meta-test-1/feat-custom-meta-test-1.sch
+++ b/test/tests/gen/featmeta-value-tests/feat-custom-meta-test-1/feat-custom-meta-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/featmeta-value-tests/feat-custom-meta-test-2/feat-custom-meta-test-2.sch
+++ b/test/tests/gen/featmeta-value-tests/feat-custom-meta-test-2/feat-custom-meta-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/featmeta-value-tests/feat-custom-meta-test-3/feat-custom-meta-test-3.sch
+++ b/test/tests/gen/featmeta-value-tests/feat-custom-meta-test-3/feat-custom-meta-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/featmeta-value-tests/feat-custom-meta-test-4/feat-custom-meta-test-4.sch
+++ b/test/tests/gen/featmeta-value-tests/feat-custom-meta-test-4/feat-custom-meta-test-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/featmeta-value-tests/feat-custom-meta-test-5/feat-custom-meta-test-5.sch
+++ b/test/tests/gen/featmeta-value-tests/feat-custom-meta-test-5/feat-custom-meta-test-5.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/featmeta-value-tests/feat-custom-meta-test-info/feat-custom-meta-test-info.sch
+++ b/test/tests/gen/featmeta-value-tests/feat-custom-meta-test-info/feat-custom-meta-test-info.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/feature-abstract-tests/feature-abstract-test-1/feature-abstract-test-1.sch
+++ b/test/tests/gen/feature-abstract-tests/feature-abstract-test-1/feature-abstract-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/feature-abstract-tests/feature-abstract-test-2/feature-abstract-test-2.sch
+++ b/test/tests/gen/feature-abstract-tests/feature-abstract-test-2/feature-abstract-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/feature-article-category-tests/feature-article-category-test-1/feature-article-category-test-1.sch
+++ b/test/tests/gen/feature-article-category-tests/feature-article-category-test-1/feature-article-category-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/feature-author-tests/feature-author-test-1/feature-author-test-1.sch
+++ b/test/tests/gen/feature-author-tests/feature-author-test-1/feature-author-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/feature-bio-tests/feature-bio-test-1/feature-bio-test-1.sch
+++ b/test/tests/gen/feature-bio-tests/feature-bio-test-1/feature-bio-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/feature-bio-tests/feature-bio-test-2/feature-bio-test-2.sch
+++ b/test/tests/gen/feature-bio-tests/feature-bio-test-2/feature-bio-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/feature-bio-tests/feature-bio-test-3/feature-bio-test-3.sch
+++ b/test/tests/gen/feature-bio-tests/feature-bio-test-3/feature-bio-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/feature-bio-tests/feature-bio-test-4/feature-bio-test-4.sch
+++ b/test/tests/gen/feature-bio-tests/feature-bio-test-4/feature-bio-test-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/feature-bio-tests/feature-bio-test-5/feature-bio-test-5.sch
+++ b/test/tests/gen/feature-bio-tests/feature-bio-test-5/feature-bio-test-5.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/feature-bio-tests/feature-bio-test-6/feature-bio-test-6.sch
+++ b/test/tests/gen/feature-bio-tests/feature-bio-test-6/feature-bio-test-6.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/feature-comment-tests/final-feat-ok-test/final-feat-ok-test.sch
+++ b/test/tests/gen/feature-comment-tests/final-feat-ok-test/final-feat-ok-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/feature-subj-tests/feature-subj-test-2/feature-subj-test-2.sch
+++ b/test/tests/gen/feature-subj-tests/feature-subj-test-2/feature-subj-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/feature-subj-tests/feature-subj-test-3/feature-subj-test-3.sch
+++ b/test/tests/gen/feature-subj-tests/feature-subj-test-3/feature-subj-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/feature-subj-tests/feature-subj-test-4/feature-subj-test-4.sch
+++ b/test/tests/gen/feature-subj-tests/feature-subj-test-4/feature-subj-test-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/feature-template-tests/feature-template-test-1/feature-template-test-1.sch
+++ b/test/tests/gen/feature-template-tests/feature-template-test-1/feature-template-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/feature-template-tests/feature-template-test-2/feature-template-test-2.sch
+++ b/test/tests/gen/feature-template-tests/feature-template-test-2/feature-template-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/feature-template-tests/feature-template-test-3/feature-template-test-3.sch
+++ b/test/tests/gen/feature-template-tests/feature-template-test-3/feature-template-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/feature-template-tests/feature-template-test-4/feature-template-test-4.sch
+++ b/test/tests/gen/feature-template-tests/feature-template-test-4/feature-template-test-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/feature-template-tests/feature-templates-author-cont/feature-templates-author-cont.sch
+++ b/test/tests/gen/feature-template-tests/feature-templates-author-cont/feature-templates-author-cont.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/feature-template-tests/feature-templates-no-bre/feature-templates-no-bre.sch
+++ b/test/tests/gen/feature-template-tests/feature-templates-no-bre/feature-templates-no-bre.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/feature-title-tests/feature-title-test-1/feature-title-test-1.sch
+++ b/test/tests/gen/feature-title-tests/feature-title-test-1/feature-title-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-caption-tests/fig-caption-test-1/fig-caption-test-1.sch
+++ b/test/tests/gen/fig-caption-tests/fig-caption-test-1/fig-caption-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-caption-tests/fig-caption-test-2/fig-caption-test-2.sch
+++ b/test/tests/gen/fig-caption-tests/fig-caption-test-2/fig-caption-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-children/fig-child-conformance/fig-child-conformance.sch
+++ b/test/tests/gen/fig-children/fig-child-conformance/fig-child-conformance.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-group-child-tests/fig-group-child-test-1/fig-group-child-test-1.sch
+++ b/test/tests/gen/fig-group-child-tests/fig-group-child-test-1/fig-group-child-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-group-child-tests/fig-group-child-test-2/fig-group-child-test-2.sch
+++ b/test/tests/gen/fig-group-child-tests/fig-group-child-test-2/fig-group-child-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-group-tests/fig-group-test-1/fig-group-test-1.sch
+++ b/test/tests/gen/fig-group-tests/fig-group-test-1/fig-group-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-group-tests/fig-group-test-2/fig-group-test-2.sch
+++ b/test/tests/gen/fig-group-tests/fig-group-test-2/fig-group-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-ids/fig-id-test-1/fig-id-test-1.sch
+++ b/test/tests/gen/fig-ids/fig-id-test-1/fig-id-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-ids/fig-id-test-2/fig-id-test-2.sch
+++ b/test/tests/gen/fig-ids/fig-id-test-2/fig-id-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-label-tests/fig-label-test-1/fig-label-test-1.sch
+++ b/test/tests/gen/fig-label-tests/fig-label-test-1/fig-label-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-panel-tests/fig-panel-test-1/fig-panel-test-1.sch
+++ b/test/tests/gen/fig-panel-tests/fig-panel-test-1/fig-panel-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-permissions-2/fig-permissions-test-15/fig-permissions-test-15.sch
+++ b/test/tests/gen/fig-permissions-2/fig-permissions-test-15/fig-permissions-test-15.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-permissions-check/reproduce-test-1/reproduce-test-1.sch
+++ b/test/tests/gen/fig-permissions-check/reproduce-test-1/reproduce-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-permissions-check/reproduce-test-2/reproduce-test-2.sch
+++ b/test/tests/gen/fig-permissions-check/reproduce-test-2/reproduce-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-permissions-check/reproduce-test-3/reproduce-test-3.sch
+++ b/test/tests/gen/fig-permissions-check/reproduce-test-3/reproduce-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-permissions-check/reproduce-test-4/reproduce-test-4.sch
+++ b/test/tests/gen/fig-permissions-check/reproduce-test-4/reproduce-test-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-permissions-check/reproduce-test-5/reproduce-test-5.sch
+++ b/test/tests/gen/fig-permissions-check/reproduce-test-5/reproduce-test-5.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-permissions-check/reproduce-test-6/reproduce-test-6.sch
+++ b/test/tests/gen/fig-permissions-check/reproduce-test-6/reproduce-test-6.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-permissions-check/reproduce-test-7/reproduce-test-7.sch
+++ b/test/tests/gen/fig-permissions-check/reproduce-test-7/reproduce-test-7.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-permissions-check/reproduce-test-8/reproduce-test-8.sch
+++ b/test/tests/gen/fig-permissions-check/reproduce-test-8/reproduce-test-8.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-permissions/fig-permissions-test-1/fig-permissions-test-1.sch
+++ b/test/tests/gen/fig-permissions/fig-permissions-test-1/fig-permissions-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-permissions/fig-permissions-test-10/fig-permissions-test-10.sch
+++ b/test/tests/gen/fig-permissions/fig-permissions-test-10/fig-permissions-test-10.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-permissions/fig-permissions-test-11/fig-permissions-test-11.sch
+++ b/test/tests/gen/fig-permissions/fig-permissions-test-11/fig-permissions-test-11.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-permissions/fig-permissions-test-14/fig-permissions-test-14.sch
+++ b/test/tests/gen/fig-permissions/fig-permissions-test-14/fig-permissions-test-14.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-permissions/fig-permissions-test-2/fig-permissions-test-2.sch
+++ b/test/tests/gen/fig-permissions/fig-permissions-test-2/fig-permissions-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-permissions/fig-permissions-test-3/fig-permissions-test-3.sch
+++ b/test/tests/gen/fig-permissions/fig-permissions-test-3/fig-permissions-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-permissions/fig-permissions-test-4/fig-permissions-test-4.sch
+++ b/test/tests/gen/fig-permissions/fig-permissions-test-4/fig-permissions-test-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-permissions/fig-permissions-test-5/fig-permissions-test-5.sch
+++ b/test/tests/gen/fig-permissions/fig-permissions-test-5/fig-permissions-test-5.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-permissions/fig-permissions-test-6/fig-permissions-test-6.sch
+++ b/test/tests/gen/fig-permissions/fig-permissions-test-6/fig-permissions-test-6.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-permissions/fig-permissions-test-7/fig-permissions-test-7.sch
+++ b/test/tests/gen/fig-permissions/fig-permissions-test-7/fig-permissions-test-7.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-permissions/fig-permissions-test-8/fig-permissions-test-8.sch
+++ b/test/tests/gen/fig-permissions/fig-permissions-test-8/fig-permissions-test-8.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-permissions/fig-permissions-test-9/fig-permissions-test-9.sch
+++ b/test/tests/gen/fig-permissions/fig-permissions-test-9/fig-permissions-test-9.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-permissions/permissions-notification/permissions-notification.sch
+++ b/test/tests/gen/fig-permissions/permissions-notification/permissions-notification.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-permissions/permissions-parent/permissions-parent.sch
+++ b/test/tests/gen/fig-permissions/permissions-parent/permissions-parent.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-source-code-tests/fig-code-test-2/fig-code-test-2.sch
+++ b/test/tests/gen/fig-source-code-tests/fig-code-test-2/fig-code-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-source-data-tests/fig-data-test-2/fig-data-test-2.sch
+++ b/test/tests/gen/fig-source-data-tests/fig-data-test-2/fig-data-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-specific-tests/feat-fig-specific-test-4/feat-fig-specific-test-4.sch
+++ b/test/tests/gen/fig-specific-tests/feat-fig-specific-test-4/feat-fig-specific-test-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-specific-tests/fig-specific-test-1/fig-specific-test-1.sch
+++ b/test/tests/gen/fig-specific-tests/fig-specific-test-1/fig-specific-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-specific-tests/fig-specific-test-3/fig-specific-test-3.sch
+++ b/test/tests/gen/fig-specific-tests/fig-specific-test-3/fig-specific-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-specific-tests/fig-specific-test-5/fig-specific-test-5.sch
+++ b/test/tests/gen/fig-specific-tests/fig-specific-test-5/fig-specific-test-5.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-specific-tests/fig-specific-test-6/fig-specific-test-6.sch
+++ b/test/tests/gen/fig-specific-tests/fig-specific-test-6/fig-specific-test-6.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-specific-tests/fig-specific-test-7/fig-specific-test-7.sch
+++ b/test/tests/gen/fig-specific-tests/fig-specific-test-7/fig-specific-test-7.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-specific-tests/final-fig-specific-test-2/final-fig-specific-test-2.sch
+++ b/test/tests/gen/fig-specific-tests/final-fig-specific-test-2/final-fig-specific-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-specific-tests/final-fig-specific-test-4/final-fig-specific-test-4.sch
+++ b/test/tests/gen/fig-specific-tests/final-fig-specific-test-4/final-fig-specific-test-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-specific-tests/pre-fig-specific-test-2/pre-fig-specific-test-2.sch
+++ b/test/tests/gen/fig-specific-tests/pre-fig-specific-test-2/pre-fig-specific-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-specific-tests/pre-fig-specific-test-4/pre-fig-specific-test-4.sch
+++ b/test/tests/gen/fig-specific-tests/pre-fig-specific-test-4/pre-fig-specific-test-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-sup-ids/fig-sup-id-test/fig-sup-id-test.sch
+++ b/test/tests/gen/fig-sup-ids/fig-sup-id-test/fig-sup-id-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-sup-tests/fig-sup-test-1/fig-sup-test-1.sch
+++ b/test/tests/gen/fig-sup-tests/fig-sup-test-1/fig-sup-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-sup-tests/fig-sup-test-2/fig-sup-test-2.sch
+++ b/test/tests/gen/fig-sup-tests/fig-sup-test-2/fig-sup-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-sup-tests/fig-sup-test-3/fig-sup-test-3.sch
+++ b/test/tests/gen/fig-sup-tests/fig-sup-test-3/fig-sup-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-sup-tests/fig-sup-test-4/fig-sup-test-4.sch
+++ b/test/tests/gen/fig-sup-tests/fig-sup-test-4/fig-sup-test-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-sup-tests/fig-sup-test-5/fig-sup-test-5.sch
+++ b/test/tests/gen/fig-sup-tests/fig-sup-test-5/fig-sup-test-5.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-sup-tests/fig-sup-test-6/fig-sup-test-6.sch
+++ b/test/tests/gen/fig-sup-tests/fig-sup-test-6/fig-sup-test-6.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-tests/feat-fig-test-3/feat-fig-test-3.sch
+++ b/test/tests/gen/fig-tests/feat-fig-test-3/feat-fig-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-tests/fig-test-2/fig-test-2.sch
+++ b/test/tests/gen/fig-tests/fig-test-2/fig-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-tests/fig-test-3/fig-test-3.sch
+++ b/test/tests/gen/fig-tests/fig-test-3/fig-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-tests/fig-test-6/fig-test-6.sch
+++ b/test/tests/gen/fig-tests/fig-test-6/fig-test-6.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-tests/final-fig-test-4/final-fig-test-4.sch
+++ b/test/tests/gen/fig-tests/final-fig-test-4/final-fig-test-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-tests/final-fig-test-5/final-fig-test-5.sch
+++ b/test/tests/gen/fig-tests/final-fig-test-5/final-fig-test-5.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-tests/final-fig-test-7/final-fig-test-7.sch
+++ b/test/tests/gen/fig-tests/final-fig-test-7/final-fig-test-7.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-tests/pre-fig-test-4/pre-fig-test-4.sch
+++ b/test/tests/gen/fig-tests/pre-fig-test-4/pre-fig-test-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-tests/pre-fig-test-5/pre-fig-test-5.sch
+++ b/test/tests/gen/fig-tests/pre-fig-test-5/pre-fig-test-5.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-tests/pre-fig-test-7/pre-fig-test-7.sch
+++ b/test/tests/gen/fig-tests/pre-fig-test-7/pre-fig-test-7.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-title-tests/fig-title-test-1/fig-title-test-1.sch
+++ b/test/tests/gen/fig-title-tests/fig-title-test-1/fig-title-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-title-tests/fig-title-test-2/fig-title-test-2.sch
+++ b/test/tests/gen/fig-title-tests/fig-title-test-2/fig-title-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-title-tests/fig-title-test-3/fig-title-test-3.sch
+++ b/test/tests/gen/fig-title-tests/fig-title-test-3/fig-title-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-title-tests/fig-title-test-4/fig-title-test-4.sch
+++ b/test/tests/gen/fig-title-tests/fig-title-test-4/fig-title-test-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-title-tests/fig-title-test-5/fig-title-test-5.sch
+++ b/test/tests/gen/fig-title-tests/fig-title-test-5/fig-title-test-5.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-title-tests/fig-title-test-6/fig-title-test-6.sch
+++ b/test/tests/gen/fig-title-tests/fig-title-test-6/fig-title-test-6.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-title-tests/fig-title-test-7/fig-title-test-7.sch
+++ b/test/tests/gen/fig-title-tests/fig-title-test-7/fig-title-test-7.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-title-tests/fig-title-test-8/fig-title-test-8.sch
+++ b/test/tests/gen/fig-title-tests/fig-title-test-8/fig-title-test-8.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-video-specific/fig-video-position-test-2/fig-video-position-test-2.sch
+++ b/test/tests/gen/fig-video-specific/fig-video-position-test-2/fig-video-position-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-xref-conformance/fig-xref-conformity-1/fig-xref-conformity-1.sch
+++ b/test/tests/gen/fig-xref-conformance/fig-xref-conformity-1/fig-xref-conformity-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-xref-conformance/fig-xref-conformity-2/fig-xref-conformity-2.sch
+++ b/test/tests/gen/fig-xref-conformance/fig-xref-conformity-2/fig-xref-conformity-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-xref-conformance/fig-xref-conformity-3/fig-xref-conformity-3.sch
+++ b/test/tests/gen/fig-xref-conformance/fig-xref-conformity-3/fig-xref-conformity-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-xref-conformance/fig-xref-conformity-4/fig-xref-conformity-4.sch
+++ b/test/tests/gen/fig-xref-conformance/fig-xref-conformity-4/fig-xref-conformity-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-xref-conformance/fig-xref-conformity-5/fig-xref-conformity-5.sch
+++ b/test/tests/gen/fig-xref-conformance/fig-xref-conformity-5/fig-xref-conformity-5.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-xref-conformance/fig-xref-conformity-6/fig-xref-conformity-6.sch
+++ b/test/tests/gen/fig-xref-conformance/fig-xref-conformity-6/fig-xref-conformity-6.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-xref-conformance/fig-xref-test-10/fig-xref-test-10.sch
+++ b/test/tests/gen/fig-xref-conformance/fig-xref-test-10/fig-xref-test-10.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-xref-conformance/fig-xref-test-11/fig-xref-test-11.sch
+++ b/test/tests/gen/fig-xref-conformance/fig-xref-test-11/fig-xref-test-11.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-xref-conformance/fig-xref-test-12/fig-xref-test-12.sch
+++ b/test/tests/gen/fig-xref-conformance/fig-xref-test-12/fig-xref-test-12.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-xref-conformance/fig-xref-test-13/fig-xref-test-13.sch
+++ b/test/tests/gen/fig-xref-conformance/fig-xref-test-13/fig-xref-test-13.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-xref-conformance/fig-xref-test-14/fig-xref-test-14.sch
+++ b/test/tests/gen/fig-xref-conformance/fig-xref-test-14/fig-xref-test-14.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-xref-conformance/fig-xref-test-15/fig-xref-test-15.sch
+++ b/test/tests/gen/fig-xref-conformance/fig-xref-test-15/fig-xref-test-15.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-xref-conformance/fig-xref-test-16/fig-xref-test-16.sch
+++ b/test/tests/gen/fig-xref-conformance/fig-xref-test-16/fig-xref-test-16.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-xref-conformance/fig-xref-test-17/fig-xref-test-17.sch
+++ b/test/tests/gen/fig-xref-conformance/fig-xref-test-17/fig-xref-test-17.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-xref-conformance/fig-xref-test-18/fig-xref-test-18.sch
+++ b/test/tests/gen/fig-xref-conformance/fig-xref-test-18/fig-xref-test-18.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-xref-conformance/fig-xref-test-2/fig-xref-test-2.sch
+++ b/test/tests/gen/fig-xref-conformance/fig-xref-test-2/fig-xref-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-xref-conformance/fig-xref-test-3/fig-xref-test-3.sch
+++ b/test/tests/gen/fig-xref-conformance/fig-xref-test-3/fig-xref-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-xref-conformance/fig-xref-test-4/fig-xref-test-4.sch
+++ b/test/tests/gen/fig-xref-conformance/fig-xref-test-4/fig-xref-test-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-xref-conformance/fig-xref-test-5/fig-xref-test-5.sch
+++ b/test/tests/gen/fig-xref-conformance/fig-xref-test-5/fig-xref-test-5.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-xref-conformance/fig-xref-test-6/fig-xref-test-6.sch
+++ b/test/tests/gen/fig-xref-conformance/fig-xref-test-6/fig-xref-test-6.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-xref-conformance/fig-xref-test-7/fig-xref-test-7.sch
+++ b/test/tests/gen/fig-xref-conformance/fig-xref-test-7/fig-xref-test-7.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-xref-conformance/fig-xref-test-8/fig-xref-test-8.sch
+++ b/test/tests/gen/fig-xref-conformance/fig-xref-test-8/fig-xref-test-8.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fig-xref-conformance/fig-xref-test-9/fig-xref-test-9.sch
+++ b/test/tests/gen/fig-xref-conformance/fig-xref-test-9/fig-xref-test-9.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/final-latin-conformance/latin-conformance-info/latin-conformance-info.sch
+++ b/test/tests/gen/final-latin-conformance/latin-conformance-info/latin-conformance-info.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/final-latin-conformance/latin-italic-info/latin-italic-info.sch
+++ b/test/tests/gen/final-latin-conformance/latin-italic-info/latin-italic-info.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/final-latin-conformance/latin-roman-info/fail.xml
+++ b/test/tests/gen/final-latin-conformance/latin-roman-info/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="latin-roman-info.sch"?>
 <!--Context: article
 Test: report    ($roman-count != 0) and ($italic-count gt $roman-count)
-Message: Latin terms are not consistenly either roman or italic. There are  italic terms which is more common, and  roman term(s). The following terms should be unitalicised: . -->
+Message: Latin terms are not consistenly either roman or italic. There are  italic terms which is more common, and  roman term(s). The following terms should be italicised: . -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>
     <body>

--- a/test/tests/gen/final-latin-conformance/latin-roman-info/latin-roman-info.sch
+++ b/test/tests/gen/final-latin-conformance/latin-roman-info/latin-roman-info.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">
@@ -858,7 +858,7 @@
       <let name="latin-terms" value="e:get-latin-terms(.,$latin-regex)"/>
       <let name="roman-count" value="sum(for $x in $latin-terms//*:list[@list-type='roman']//*:match return number($x/@count))"/>
       <let name="italic-count" value="sum(for $x in $latin-terms//*:list[@list-type='italic']//*:match return number($x/@count))"/>
-      <report test="($roman-count != 0) and ($italic-count gt $roman-count)" role="warning" id="latin-roman-info">Latin terms are not consistenly either roman or italic. There are <value-of select="$italic-count"/> italic terms which is more common, and <value-of select="$roman-count"/> roman term(s). The following terms should be unitalicised: <value-of select="e:print-latin-terms($latin-terms//*:list[@list-type='italic'])"/>.</report>
+      <report test="($roman-count != 0) and ($italic-count gt $roman-count)" role="warning" id="latin-roman-info">Latin terms are not consistenly either roman or italic. There are <value-of select="$italic-count"/> italic terms which is more common, and <value-of select="$roman-count"/> roman term(s). The following terms should be italicised: <value-of select="e:print-latin-terms($latin-terms//*:list[@list-type='roman'])"/>.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/final-latin-conformance/latin-roman-info/pass.xml
+++ b/test/tests/gen/final-latin-conformance/latin-roman-info/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="latin-roman-info.sch"?>
 <!--Context: article
 Test: report    ($roman-count != 0) and ($italic-count gt $roman-count)
-Message: Latin terms are not consistenly either roman or italic. There are  italic terms which is more common, and  roman term(s). The following terms should be unitalicised: . -->
+Message: Latin terms are not consistenly either roman or italic. There are  italic terms which is more common, and  roman term(s). The following terms should be italicised: . -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>
     <body>

--- a/test/tests/gen/final-package/graphic-media-presence/graphic-media-presence.sch
+++ b/test/tests/gen/final-package/graphic-media-presence/graphic-media-presence.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fn-ids/fn-id-test/fn-id-test.sch
+++ b/test/tests/gen/fn-ids/fn-id-test/fn-id-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fn-tests/fn-xref-presence-test/fn-xref-presence-test.sch
+++ b/test/tests/gen/fn-tests/fn-xref-presence-test/fn-xref-presence-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/front-permissions-tests/permissions-info/permissions-info.sch
+++ b/test/tests/gen/front-permissions-tests/permissions-info/permissions-info.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/front-permissions-tests/permissions-test-1/permissions-test-1.sch
+++ b/test/tests/gen/front-permissions-tests/permissions-test-1/permissions-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/front-permissions-tests/permissions-test-2/permissions-test-2.sch
+++ b/test/tests/gen/front-permissions-tests/permissions-test-2/permissions-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/front-permissions-tests/permissions-test-3/permissions-test-3.sch
+++ b/test/tests/gen/front-permissions-tests/permissions-test-3/permissions-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/front-permissions-tests/permissions-test-4/permissions-test-4.sch
+++ b/test/tests/gen/front-permissions-tests/permissions-test-4/permissions-test-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/front-permissions-tests/permissions-test-5/permissions-test-5.sch
+++ b/test/tests/gen/front-permissions-tests/permissions-test-5/permissions-test-5.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/front-permissions-tests/permissions-test-6/permissions-test-6.sch
+++ b/test/tests/gen/front-permissions-tests/permissions-test-6/permissions-test-6.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/front-permissions-tests/permissions-test-7/permissions-test-7.sch
+++ b/test/tests/gen/front-permissions-tests/permissions-test-7/permissions-test-7.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/front-permissions-tests/permissions-test-8/permissions-test-8.sch
+++ b/test/tests/gen/front-permissions-tests/permissions-test-8/permissions-test-8.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/front-permissions-tests/permissions-test-9/permissions-test-9.sch
+++ b/test/tests/gen/front-permissions-tests/permissions-test-9/permissions-test-9.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/funding-group-tests/funding-group-test-1/funding-group-test-1.sch
+++ b/test/tests/gen/funding-group-tests/funding-group-test-1/funding-group-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/funding-group-tests/funding-group-test-2/funding-group-test-2.sch
+++ b/test/tests/gen/funding-group-tests/funding-group-test-2/funding-group-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/funding-group-tests/funding-group-test-3/funding-group-test-3.sch
+++ b/test/tests/gen/funding-group-tests/funding-group-test-3/funding-group-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/funding-group-tests/funding-group-test-4/funding-group-test-4.sch
+++ b/test/tests/gen/funding-group-tests/funding-group-test-4/funding-group-test-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/fundref-rule/fundref-test-1/fundref-test-1.sch
+++ b/test/tests/gen/fundref-rule/fundref-test-1/fundref-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/gen-aff-tests/gen-aff-test-1/gen-aff-test-1.sch
+++ b/test/tests/gen/gen-aff-tests/gen-aff-test-1/gen-aff-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/gen-aff-tests/gen-aff-test-2/gen-aff-test-2.sch
+++ b/test/tests/gen/gen-aff-tests/gen-aff-test-2/gen-aff-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/gen-aff-tests/gen-aff-test-3/gen-aff-test-3.sch
+++ b/test/tests/gen/gen-aff-tests/gen-aff-test-3/gen-aff-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/gen-aff-tests/gen-aff-test-4/gen-aff-test-4.sch
+++ b/test/tests/gen/gen-aff-tests/gen-aff-test-4/gen-aff-test-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/gen-aff-tests/gen-aff-test-5/gen-aff-test-5.sch
+++ b/test/tests/gen/gen-aff-tests/gen-aff-test-5/gen-aff-test-5.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/gen-aff-tests/gen-aff-test-6/gen-aff-test-6.sch
+++ b/test/tests/gen/gen-aff-tests/gen-aff-test-6/gen-aff-test-6.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/gen-das-tests/das-elem-cit-1/das-elem-cit-1.sch
+++ b/test/tests/gen/gen-das-tests/das-elem-cit-1/das-elem-cit-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/gen-das-tests/das-elem-cit-2/das-elem-cit-2.sch
+++ b/test/tests/gen/gen-das-tests/das-elem-cit-2/das-elem-cit-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/gen-das-tests/das-elem-cit-4/das-elem-cit-4.sch
+++ b/test/tests/gen/gen-das-tests/das-elem-cit-4/das-elem-cit-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/gen-das-tests/das-elem-cit-5/das-elem-cit-5.sch
+++ b/test/tests/gen/gen-das-tests/das-elem-cit-5/das-elem-cit-5.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/gen-das-tests/das-elem-person-group-2/das-elem-person-group-2.sch
+++ b/test/tests/gen/gen-das-tests/das-elem-person-group-2/das-elem-person-group-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/gen-das-tests/final-das-elem-cit-3/final-das-elem-cit-3.sch
+++ b/test/tests/gen/gen-das-tests/final-das-elem-cit-3/final-das-elem-cit-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/gen-das-tests/final-das-elem-data-title-1/final-das-elem-data-title-1.sch
+++ b/test/tests/gen/gen-das-tests/final-das-elem-data-title-1/final-das-elem-data-title-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/gen-das-tests/final-das-elem-person-1/final-das-elem-person-1.sch
+++ b/test/tests/gen/gen-das-tests/final-das-elem-person-1/final-das-elem-person-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/gen-das-tests/final-das-elem-person-group-1/final-das-elem-person-group-1.sch
+++ b/test/tests/gen/gen-das-tests/final-das-elem-person-group-1/final-das-elem-person-group-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/gen-das-tests/final-das-elem-pub-id-1/final-das-elem-pub-id-1.sch
+++ b/test/tests/gen/gen-das-tests/final-das-elem-pub-id-1/final-das-elem-pub-id-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/gen-das-tests/final-das-elem-pub-id-2/final-das-elem-pub-id-2.sch
+++ b/test/tests/gen/gen-das-tests/final-das-elem-pub-id-2/final-das-elem-pub-id-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/gen-das-tests/final-das-elem-source-1/final-das-elem-source-1.sch
+++ b/test/tests/gen/gen-das-tests/final-das-elem-source-1/final-das-elem-source-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/gen-das-tests/final-das-elem-year-1/final-das-elem-year-1.sch
+++ b/test/tests/gen/gen-das-tests/final-das-elem-year-1/final-das-elem-year-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/gen-das-tests/pre-das-elem-cit-3/pre-das-elem-cit-3.sch
+++ b/test/tests/gen/gen-das-tests/pre-das-elem-cit-3/pre-das-elem-cit-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/gen-das-tests/pre-das-elem-data-title-1/pre-das-elem-data-title-1.sch
+++ b/test/tests/gen/gen-das-tests/pre-das-elem-data-title-1/pre-das-elem-data-title-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/gen-das-tests/pre-das-elem-person-1/pre-das-elem-person-1.sch
+++ b/test/tests/gen/gen-das-tests/pre-das-elem-person-1/pre-das-elem-person-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/gen-das-tests/pre-das-elem-person-group-1/pre-das-elem-person-group-1.sch
+++ b/test/tests/gen/gen-das-tests/pre-das-elem-person-group-1/pre-das-elem-person-group-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/gen-das-tests/pre-das-elem-pub-id-1/pre-das-elem-pub-id-1.sch
+++ b/test/tests/gen/gen-das-tests/pre-das-elem-pub-id-1/pre-das-elem-pub-id-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/gen-das-tests/pre-das-elem-pub-id-2/pre-das-elem-pub-id-2.sch
+++ b/test/tests/gen/gen-das-tests/pre-das-elem-pub-id-2/pre-das-elem-pub-id-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/gen-das-tests/pre-das-elem-source-1/pre-das-elem-source-1.sch
+++ b/test/tests/gen/gen-das-tests/pre-das-elem-source-1/pre-das-elem-source-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/gen-das-tests/pre-das-elem-year-1/pre-das-elem-year-1.sch
+++ b/test/tests/gen/gen-das-tests/pre-das-elem-year-1/pre-das-elem-year-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/gene-primer-sequence/gene-primer-sequence-test/gene-primer-sequence-test.sch
+++ b/test/tests/gen/gene-primer-sequence/gene-primer-sequence-test/gene-primer-sequence-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/general-video/final-video-cite/final-video-cite.sch
+++ b/test/tests/gen/general-video/final-video-cite/final-video-cite.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/general-video/pre-video-cite/pre-video-cite.sch
+++ b/test/tests/gen/general-video/pre-video-cite/pre-video-cite.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/general-video/video-placement-1/video-placement-1.sch
+++ b/test/tests/gen/general-video/video-placement-1/video-placement-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/general-video/video-placement-2/video-placement-2.sch
+++ b/test/tests/gen/general-video/video-placement-2/video-placement-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/generic-label-tests/distinct-label-conformance/distinct-label-conformance.sch
+++ b/test/tests/gen/generic-label-tests/distinct-label-conformance/distinct-label-conformance.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/generic-label-tests/label-fig-group-conformance-1/label-fig-group-conformance-1.sch
+++ b/test/tests/gen/generic-label-tests/label-fig-group-conformance-1/label-fig-group-conformance-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/generic-label-tests/label-fig-group-conformance-2/label-fig-group-conformance-2.sch
+++ b/test/tests/gen/generic-label-tests/label-fig-group-conformance-2/label-fig-group-conformance-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/given-names-tests/final-given-names-test-16/final-given-names-test-16.sch
+++ b/test/tests/gen/given-names-tests/final-given-names-test-16/final-given-names-test-16.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/given-names-tests/given-names-test-10/given-names-test-10.sch
+++ b/test/tests/gen/given-names-tests/given-names-test-10/given-names-test-10.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/given-names-tests/given-names-test-11/given-names-test-11.sch
+++ b/test/tests/gen/given-names-tests/given-names-test-11/given-names-test-11.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/given-names-tests/given-names-test-12/given-names-test-12.sch
+++ b/test/tests/gen/given-names-tests/given-names-test-12/given-names-test-12.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/given-names-tests/given-names-test-13/given-names-test-13.sch
+++ b/test/tests/gen/given-names-tests/given-names-test-13/given-names-test-13.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/given-names-tests/given-names-test-14/given-names-test-14.sch
+++ b/test/tests/gen/given-names-tests/given-names-test-14/given-names-test-14.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/given-names-tests/given-names-test-15/given-names-test-15.sch
+++ b/test/tests/gen/given-names-tests/given-names-test-15/given-names-test-15.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/given-names-tests/given-names-test-3/given-names-test-3.sch
+++ b/test/tests/gen/given-names-tests/given-names-test-3/given-names-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/given-names-tests/given-names-test-4/given-names-test-4.sch
+++ b/test/tests/gen/given-names-tests/given-names-test-4/given-names-test-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/given-names-tests/given-names-test-5/given-names-test-5.sch
+++ b/test/tests/gen/given-names-tests/given-names-test-5/given-names-test-5.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/given-names-tests/given-names-test-6/given-names-test-6.sch
+++ b/test/tests/gen/given-names-tests/given-names-test-6/given-names-test-6.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/given-names-tests/given-names-test-7/given-names-test-7.sch
+++ b/test/tests/gen/given-names-tests/given-names-test-7/given-names-test-7.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/given-names-tests/given-names-test-8/given-names-test-8.sch
+++ b/test/tests/gen/given-names-tests/given-names-test-8/given-names-test-8.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/given-names-tests/given-names-test-9/given-names-test-9.sch
+++ b/test/tests/gen/given-names-tests/given-names-test-9/given-names-test-9.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/given-names-tests/pre-given-names-test-16/pre-given-names-test-16.sch
+++ b/test/tests/gen/given-names-tests/pre-given-names-test-16/pre-given-names-test-16.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/graphic-tests/graphic-test-1/graphic-test-1.sch
+++ b/test/tests/gen/graphic-tests/graphic-test-1/graphic-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/graphic-tests/graphic-test-2/graphic-test-2.sch
+++ b/test/tests/gen/graphic-tests/graphic-test-2/graphic-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/graphic-tests/graphic-test-3/graphic-test-3.sch
+++ b/test/tests/gen/graphic-tests/graphic-test-3/graphic-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/graphic-tests/graphic-test-4/graphic-test-4.sch
+++ b/test/tests/gen/graphic-tests/graphic-test-4/graphic-test-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/graphic-tests/graphic-test-5/graphic-test-5.sch
+++ b/test/tests/gen/graphic-tests/graphic-test-5/graphic-test-5.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/graphic-tests/graphic-test-6/graphic-test-6.sch
+++ b/test/tests/gen/graphic-tests/graphic-test-6/graphic-test-6.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/graphic-tests/graphic-test-8/graphic-test-8.sch
+++ b/test/tests/gen/graphic-tests/graphic-test-8/graphic-test-8.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/head-subj-checks/head-subj-test-1/head-subj-test-1.sch
+++ b/test/tests/gen/head-subj-checks/head-subj-test-1/head-subj-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/history-tests/history-date-test-1/history-date-test-1.sch
+++ b/test/tests/gen/history-tests/history-date-test-1/history-date-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/history-tests/history-date-test-2/history-date-test-2.sch
+++ b/test/tests/gen/history-tests/history-date-test-2/history-date-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/inline-formula-child-tests/inline-formula-child-test-1/inline-formula-child-test-1.sch
+++ b/test/tests/gen/inline-formula-child-tests/inline-formula-child-test-1/inline-formula-child-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/inline-formula-tests/inline-formula-test-1/inline-formula-test-1.sch
+++ b/test/tests/gen/inline-formula-tests/inline-formula-test-1/inline-formula-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/inline-formula-tests/inline-formula-test-2/inline-formula-test-2.sch
+++ b/test/tests/gen/inline-formula-tests/inline-formula-test-2/inline-formula-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/inline-formula-tests/inline-formula-test-3/inline-formula-test-3.sch
+++ b/test/tests/gen/inline-formula-tests/inline-formula-test-3/inline-formula-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/inline-formula-tests/inline-formula-test-4/inline-formula-test-4.sch
+++ b/test/tests/gen/inline-formula-tests/inline-formula-test-4/inline-formula-test-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/insight-asbtract-tests/insight-abstract-impact-test-1/insight-abstract-impact-test-1.sch
+++ b/test/tests/gen/insight-asbtract-tests/insight-abstract-impact-test-1/insight-abstract-impact-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/insight-asbtract-tests/insight-abstract-impact-test-2/insight-abstract-impact-test-2.sch
+++ b/test/tests/gen/insight-asbtract-tests/insight-abstract-impact-test-2/insight-abstract-impact-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/insight-related-article-tests/insight-box-test-1/insight-box-test-1.sch
+++ b/test/tests/gen/insight-related-article-tests/insight-box-test-1/insight-box-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/insight-related-article-tests/insight-related-article-test-1/insight-related-article-test-1.sch
+++ b/test/tests/gen/insight-related-article-tests/insight-related-article-test-1/insight-related-article-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/insight-test/related-articles-test-2/related-articles-test-2.sch
+++ b/test/tests/gen/insight-test/related-articles-test-2/related-articles-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/institution-id-tests/institution-id-test-2/institution-id-test-2.sch
+++ b/test/tests/gen/institution-id-tests/institution-id-test-2/institution-id-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/institution-id-tests/institution-id-test-3/institution-id-test-3.sch
+++ b/test/tests/gen/institution-id-tests/institution-id-test-3/institution-id-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/institution-id-tests/institution-id-test-4/institution-id-test-4.sch
+++ b/test/tests/gen/institution-id-tests/institution-id-test-4/institution-id-test-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/institution-id-tests/institution-id-test-5/institution-id-test-5.sch
+++ b/test/tests/gen/institution-id-tests/institution-id-test-5/institution-id-test-5.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/institution-tests/UC-no-test-2/UC-no-test-2.sch
+++ b/test/tests/gen/institution-tests/UC-no-test-2/UC-no-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/institution-tests/UC-no-test-3/UC-no-test-3.sch
+++ b/test/tests/gen/institution-tests/UC-no-test-3/UC-no-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/institution-tests/UC-no-test1/UC-no-test1.sch
+++ b/test/tests/gen/institution-tests/UC-no-test1/UC-no-test1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/institution-tests/institution-replacement-character-presence/institution-replacement-character-presence.sch
+++ b/test/tests/gen/institution-tests/institution-replacement-character-presence/institution-replacement-character-presence.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/institution-tests/institution-street-presence/institution-street-presence.sch
+++ b/test/tests/gen/institution-tests/institution-street-presence/institution-street-presence.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/institution-wrap-tests/institution-id-test/institution-id-test.sch
+++ b/test/tests/gen/institution-wrap-tests/institution-id-test/institution-id-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/isbn-conformity-2/isbn-conformity-test-2/isbn-conformity-test-2.sch
+++ b/test/tests/gen/isbn-conformity-2/isbn-conformity-test-2/isbn-conformity-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/isbn-conformity/isbn-conformity-test/isbn-conformity-test.sch
+++ b/test/tests/gen/isbn-conformity/isbn-conformity-test/isbn-conformity-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/italic-house-style/final-et-al-italic-test/final-et-al-italic-test.sch
+++ b/test/tests/gen/italic-house-style/final-et-al-italic-test/final-et-al-italic-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/italic-house-style/pre-a-posteriori-italic-test/pre-a-posteriori-italic-test.sch
+++ b/test/tests/gen/italic-house-style/pre-a-posteriori-italic-test/pre-a-posteriori-italic-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/italic-house-style/pre-a-priori-italic-test/pre-a-priori-italic-test.sch
+++ b/test/tests/gen/italic-house-style/pre-a-priori-italic-test/pre-a-priori-italic-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/italic-house-style/pre-ad-libitum-italic-test/pre-ad-libitum-italic-test.sch
+++ b/test/tests/gen/italic-house-style/pre-ad-libitum-italic-test/pre-ad-libitum-italic-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/italic-house-style/pre-de-novo-italic-test/pre-de-novo-italic-test.sch
+++ b/test/tests/gen/italic-house-style/pre-de-novo-italic-test/pre-de-novo-italic-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/italic-house-style/pre-et-al-italic-test/pre-et-al-italic-test.sch
+++ b/test/tests/gen/italic-house-style/pre-et-al-italic-test/pre-et-al-italic-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/italic-house-style/pre-ex-vivo-italic-test/pre-ex-vivo-italic-test.sch
+++ b/test/tests/gen/italic-house-style/pre-ex-vivo-italic-test/pre-ex-vivo-italic-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/italic-house-style/pre-in-natura-italic-test/pre-in-natura-italic-test.sch
+++ b/test/tests/gen/italic-house-style/pre-in-natura-italic-test/pre-in-natura-italic-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/italic-house-style/pre-in-ovo-italic-test/pre-in-ovo-italic-test.sch
+++ b/test/tests/gen/italic-house-style/pre-in-ovo-italic-test/pre-in-ovo-italic-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/italic-house-style/pre-in-planta-italic-test/pre-in-planta-italic-test.sch
+++ b/test/tests/gen/italic-house-style/pre-in-planta-italic-test/pre-in-planta-italic-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/italic-house-style/pre-in-situ-italic-test/pre-in-situ-italic-test.sch
+++ b/test/tests/gen/italic-house-style/pre-in-situ-italic-test/pre-in-situ-italic-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/italic-house-style/pre-in-utero-italic-test/pre-in-utero-italic-test.sch
+++ b/test/tests/gen/italic-house-style/pre-in-utero-italic-test/pre-in-utero-italic-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/italic-house-style/pre-in-vitro-italic-test/pre-in-vitro-italic-test.sch
+++ b/test/tests/gen/italic-house-style/pre-in-vitro-italic-test/pre-in-vitro-italic-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/italic-house-style/pre-in-vivo-italic-test/pre-in-vivo-italic-test.sch
+++ b/test/tests/gen/italic-house-style/pre-in-vivo-italic-test/pre-in-vivo-italic-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/italic-house-style/pre-nomen-novum-italic-test/pre-nomen-novum-italic-test.sch
+++ b/test/tests/gen/italic-house-style/pre-nomen-novum-italic-test/pre-nomen-novum-italic-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/italic-house-style/pre-rete-mirabile-italic-test/pre-rete-mirabile-italic-test.sch
+++ b/test/tests/gen/italic-house-style/pre-rete-mirabile-italic-test/pre-rete-mirabile-italic-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/italic-house-style/pre-sensu-italic-test/pre-sensu-italic-test.sch
+++ b/test/tests/gen/italic-house-style/pre-sensu-italic-test/pre-sensu-italic-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/italic-org-tests/italic-org-test-1/italic-org-test-1.sch
+++ b/test/tests/gen/italic-org-tests/italic-org-test-1/italic-org-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/italic-org-tests/italic-org-test-2/italic-org-test-2.sch
+++ b/test/tests/gen/italic-org-tests/italic-org-test-2/italic-org-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/journal-tests/elife-ref-check/elife-ref-check.sch
+++ b/test/tests/gen/journal-tests/elife-ref-check/elife-ref-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/journal-tests/eloc-page-assert/eloc-page-assert.sch
+++ b/test/tests/gen/journal-tests/eloc-page-assert/eloc-page-assert.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/journal-tests/journal-conference-ref-check-1/journal-conference-ref-check-1.sch
+++ b/test/tests/gen/journal-tests/journal-conference-ref-check-1/journal-conference-ref-check-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/journal-tests/journal-conference-ref-check-2/journal-conference-ref-check-2.sch
+++ b/test/tests/gen/journal-tests/journal-conference-ref-check-2/journal-conference-ref-check-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/journal-tests/journal-preprint-check/journal-preprint-check.sch
+++ b/test/tests/gen/journal-tests/journal-preprint-check/journal-preprint-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/journal-tests/volume-assert/volume-assert.sch
+++ b/test/tests/gen/journal-tests/volume-assert/volume-assert.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/journal-title-tests/G3/G3.sch
+++ b/test/tests/gen/journal-title-tests/G3/G3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/journal-title-tests/PLOS-1/PLOS-1.sch
+++ b/test/tests/gen/journal-title-tests/PLOS-1/PLOS-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/journal-title-tests/PLOS-2/PLOS-2.sch
+++ b/test/tests/gen/journal-title-tests/PLOS-2/PLOS-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/journal-title-tests/PNAS/PNAS.sch
+++ b/test/tests/gen/journal-title-tests/PNAS/PNAS.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/journal-title-tests/RNA/RNA.sch
+++ b/test/tests/gen/journal-title-tests/RNA/RNA.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/journal-title-tests/Research-gate-check/Research-gate-check.sch
+++ b/test/tests/gen/journal-title-tests/Research-gate-check/Research-gate-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/journal-title-tests/ampersand-check/ampersand-check.sch
+++ b/test/tests/gen/journal-title-tests/ampersand-check/ampersand-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/journal-title-tests/bmj/bmj.sch
+++ b/test/tests/gen/journal-title-tests/bmj/bmj.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/journal-title-tests/elife-check/elife-check.sch
+++ b/test/tests/gen/journal-title-tests/elife-check/elife-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/journal-title-tests/handbook-presence/handbook-presence.sch
+++ b/test/tests/gen/journal-title-tests/handbook-presence/handbook-presence.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/journal-title-tests/journal-off-presence/journal-off-presence.sch
+++ b/test/tests/gen/journal-title-tests/journal-off-presence/journal-off-presence.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/journal-title-tests/journal-replacement-character-presence/journal-replacement-character-presence.sch
+++ b/test/tests/gen/journal-title-tests/journal-replacement-character-presence/journal-replacement-character-presence.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/journal-title-tests/zenodo-check/zenodo-check.sch
+++ b/test/tests/gen/journal-title-tests/zenodo-check/zenodo-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/kr-table-body-tests/kr-table-body-1/kr-table-body-1.sch
+++ b/test/tests/gen/kr-table-body-tests/kr-table-body-1/kr-table-body-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/kr-table-heading-tests/kr-table-header-1/kr-table-header-1.sch
+++ b/test/tests/gen/kr-table-heading-tests/kr-table-header-1/kr-table-header-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/kr-table-heading-tests/kr-table-header-2/kr-table-header-2.sch
+++ b/test/tests/gen/kr-table-heading-tests/kr-table-header-2/kr-table-header-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/kr-table-heading-tests/kr-table-header-3/kr-table-header-3.sch
+++ b/test/tests/gen/kr-table-heading-tests/kr-table-header-3/kr-table-header-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/kr-table-heading-tests/kr-table-header-4/kr-table-header-4.sch
+++ b/test/tests/gen/kr-table-heading-tests/kr-table-header-4/kr-table-header-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/kr-table-heading-tests/kr-table-header-5/kr-table-header-5.sch
+++ b/test/tests/gen/kr-table-heading-tests/kr-table-header-5/kr-table-header-5.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/kr-table-heading-tests/kr-table-header-6/kr-table-header-6.sch
+++ b/test/tests/gen/kr-table-heading-tests/kr-table-header-6/kr-table-header-6.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/kr-table-heading-tests/kr-table-header-7/kr-table-header-7.sch
+++ b/test/tests/gen/kr-table-heading-tests/kr-table-header-7/kr-table-header-7.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/kr-table-heading-tests/kr-table-header-8/kr-table-header-8.sch
+++ b/test/tests/gen/kr-table-heading-tests/kr-table-header-8/kr-table-header-8.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/kwd-group-tests/kwd-group-type/kwd-group-type.sch
+++ b/test/tests/gen/kwd-group-tests/kwd-group-type/kwd-group-type.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/kwd-group-tests/non-ro-kwd-presence-test/non-ro-kwd-presence-test.sch
+++ b/test/tests/gen/kwd-group-tests/non-ro-kwd-presence-test/non-ro-kwd-presence-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/latex-tests/latex-test/latex-test.sch
+++ b/test/tests/gen/latex-tests/latex-test/latex-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/license-tests/license-test-1/license-test-1.sch
+++ b/test/tests/gen/license-tests/license-test-1/license-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/license-tests/license-test-2/license-test-2.sch
+++ b/test/tests/gen/license-tests/license-test-2/license-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/list-item-tests/alpha-lower-test-1/alpha-lower-test-1.sch
+++ b/test/tests/gen/list-item-tests/alpha-lower-test-1/alpha-lower-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/list-item-tests/alpha-upper-test-1/alpha-upper-test-1.sch
+++ b/test/tests/gen/list-item-tests/alpha-upper-test-1/alpha-upper-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/list-item-tests/bullet-test-1/bullet-test-1.sch
+++ b/test/tests/gen/list-item-tests/bullet-test-1/bullet-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/list-item-tests/bullet-test-2/bullet-test-2.sch
+++ b/test/tests/gen/list-item-tests/bullet-test-2/bullet-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/list-item-tests/list-item-test-1/list-item-test-1.sch
+++ b/test/tests/gen/list-item-tests/list-item-test-1/list-item-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/list-item-tests/order-test-1/order-test-1.sch
+++ b/test/tests/gen/list-item-tests/order-test-1/order-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/list-item-tests/roman-lower-test-1/roman-lower-test-1.sch
+++ b/test/tests/gen/list-item-tests/roman-lower-test-1/roman-lower-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/list-item-tests/roman-upper-test-1/roman-upper-test-1.sch
+++ b/test/tests/gen/list-item-tests/roman-upper-test-1/roman-upper-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/list-item-tests/simple-test-1/simple-test-1.sch
+++ b/test/tests/gen/list-item-tests/simple-test-1/simple-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/list-item-tests/simple-test-2/simple-test-2.sch
+++ b/test/tests/gen/list-item-tests/simple-test-2/simple-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/list-item-tests/simple-test-3/simple-test-3.sch
+++ b/test/tests/gen/list-item-tests/simple-test-3/simple-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/list-item-tests/simple-test-4/simple-test-4.sch
+++ b/test/tests/gen/list-item-tests/simple-test-4/simple-test-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/list-item-tests/simple-test-5/simple-test-5.sch
+++ b/test/tests/gen/list-item-tests/simple-test-5/simple-test-5.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/list-tests/continued-from-test-1/continued-from-test-1.sch
+++ b/test/tests/gen/list-tests/continued-from-test-1/continued-from-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/low-level-sec-ids/low-level-sec-id-test/low-level-sec-id-test.sch
+++ b/test/tests/gen/low-level-sec-ids/low-level-sec-id-test/low-level-sec-id-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/math-colour-tests/final-mathcolor-test-1/final-mathcolor-test-1.sch
+++ b/test/tests/gen/math-colour-tests/final-mathcolor-test-1/final-mathcolor-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/math-colour-tests/mathcolor-test-2/mathcolor-test-2.sch
+++ b/test/tests/gen/math-colour-tests/mathcolor-test-2/mathcolor-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/math-colour-tests/pre-mathcolor-test-1/pre-mathcolor-test-1.sch
+++ b/test/tests/gen/math-colour-tests/pre-mathcolor-test-1/pre-mathcolor-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/math-tests/math-test-1/math-test-1.sch
+++ b/test/tests/gen/math-tests/math-test-1/math-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/math-tests/math-test-10/math-test-10.sch
+++ b/test/tests/gen/math-tests/math-test-10/math-test-10.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/math-tests/math-test-11/math-test-11.sch
+++ b/test/tests/gen/math-tests/math-test-11/math-test-11.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/math-tests/math-test-12/math-test-12.sch
+++ b/test/tests/gen/math-tests/math-test-12/math-test-12.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/math-tests/math-test-13/math-test-13.sch
+++ b/test/tests/gen/math-tests/math-test-13/math-test-13.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/math-tests/math-test-14/math-test-14.sch
+++ b/test/tests/gen/math-tests/math-test-14/math-test-14.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/math-tests/math-test-15/math-test-15.sch
+++ b/test/tests/gen/math-tests/math-test-15/math-test-15.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/math-tests/math-test-16/math-test-16.sch
+++ b/test/tests/gen/math-tests/math-test-16/math-test-16.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/math-tests/math-test-17/math-test-17.sch
+++ b/test/tests/gen/math-tests/math-test-17/math-test-17.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/math-tests/math-test-18/math-test-18.sch
+++ b/test/tests/gen/math-tests/math-test-18/math-test-18.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/math-tests/math-test-19/fail.xml
+++ b/test/tests/gen/math-tests/math-test-19/fail.xml
@@ -1,0 +1,11 @@
+<?oxygen SCHSchema="math-test-19.sch"?>
+<!--Context: mml:math
+Test: report    descendant::mml:mi[(.='') and preceding-sibling::*[1][(local-name() = 'mi') and matches(.,'[A-Za-z]')] and following-sibling::*[1][(local-name() = 'mi') and matches(.,'[A-Za-z]')]]
+Message: Maths containing '' has what looks like words or terms which need separating with a space. With it's current markup the space will not be preserved on the eLife website. Please add in the space(s) using the latext '\;' in the appropriate place(s), so that the space is preserved in the HTML. -->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <body>
+      <p><inline-formula><mml:math id="inf1"><mml:mfrac><mml:mrow><mml:mi>r</mml:mi><mml:mi>e</mml:mi><mml:mi>d</mml:mi> <mml:mi/><mml:mi>b</mml:mi><mml:mi>l</mml:mi><mml:mi>o</mml:mi><mml:mi>o</mml:mi><mml:mi>d</mml:mi> <mml:mi/><mml:mi>c</mml:mi><mml:mi>e</mml:mi><mml:mi>l</mml:mi><mml:mi>l</mml:mi><mml:mi>s</mml:mi> <mml:mi/><mml:mi>*</mml:mi> <mml:mi/><mml:mi>m</mml:mi><mml:mi>e</mml:mi><mml:mi>a</mml:mi><mml:mi>n</mml:mi> <mml:mi/><mml:mi>c</mml:mi><mml:mi>o</mml:mi><mml:mi>r</mml:mi><mml:mi>p</mml:mi><mml:mi>u</mml:mi><mml:mi>s</mml:mi><mml:mi>c</mml:mi><mml:mi>u</mml:mi><mml:mi>l</mml:mi><mml:mi>a</mml:mi><mml:mi>r</mml:mi> <mml:mi/><mml:mi>v</mml:mi><mml:mi>o</mml:mi><mml:mi>l</mml:mi><mml:mi>u</mml:mi><mml:mi>m</mml:mi><mml:mi>e</mml:mi></mml:mrow><mml:mrow><mml:mn>10</mml:mn></mml:mrow></mml:mfrac></mml:math></inline-formula></p>
+    </body>
+  </article>
+</root>

--- a/test/tests/gen/math-tests/math-test-19/math-test-19.sch
+++ b/test/tests/gen/math-tests/math-test-19/math-test-19.sch
@@ -1,0 +1,868 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:java="http://www.java.com/" xmlns:file="java.io.File" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" queryBinding="xslt2">
+  <title>eLife Schematron</title>
+  <ns uri="http://www.niso.org/schemas/ali/1.0/" prefix="ali"/>
+  <ns uri="http://www.w3.org/XML/1998/namespace" prefix="xml"/>
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://www.w3.org/2001/XInclude" prefix="xi"/>
+  <ns uri="http://www.w3.org/1998/Math/MathML" prefix="mml"/>
+  <ns uri="http://saxon.sf.net/" prefix="saxon"/>
+  <ns uri="http://purl.org/dc/terms/" prefix="dc"/>
+  <ns uri="http://www.w3.org/2001/XMLSchema" prefix="xs"/>
+  <ns uri="https://elifesciences.org/namespace" prefix="e"/>
+  <ns uri="java.io.File" prefix="file"/>
+  <ns uri="http://www.java.com/" prefix="java"/>
+  <let name="allowed-article-types" value="('article-commentary', 'correction', 'discussion', 'editorial', 'research-article', 'retraction','review-article')"/>
+  <let name="allowed-disp-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Feature Article', 'Insight', 'Editorial', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="features-subj" value="('Feature Article', 'Insight', 'Editorial')"/>
+  <let name="features-article-types" value="('article-commentary','editorial','discussion')"/>
+  <let name="research-subj" value="('Research Article', 'Short Report', 'Tools and Resources', 'Research Advance', 'Registered Report', 'Replication Study', 'Research Communication', 'Correction', 'Retraction', 'Scientific Correspondence', 'Review Article')"/>
+  <let name="MSAs" value="('Biochemistry and Chemical Biology', 'Cancer Biology', 'Cell Biology', 'Chromosomes and Gene Expression', 'Computational and Systems Biology', 'Developmental Biology', 'Ecology', 'Epidemiology and Global Health', 'Evolutionary Biology', 'Genetics and Genomics', 'Medicine', 'Immunology and Inflammation', 'Microbiology and Infectious Disease', 'Neuroscience', 'Physics of Living Systems', 'Plant Biology', 'Stem Cells and Regenerative Medicine', 'Structural Biology and Molecular Biophysics')"/>
+  <xsl:function name="e:titleCaseToken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,'-')">
+        <xsl:value-of select="concat(           upper-case(substring(substring-before($s,'-'), 1, 1)),           lower-case(substring(substring-before($s,'-'),2)),           '-',           upper-case(substring(substring-after($s,'-'), 1, 1)),           lower-case(substring(substring-after($s,'-'),2)))"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of','in','as','at','by','for','a','to','up','but','yet')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna','mri','hiv','tor')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="concat(upper-case(substring($s, 1, 1)), lower-case(substring($s, 2)))"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:titleCase" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="contains($s,' ')">
+        <xsl:variable name="token1" select="substring-before($s,' ')"/>
+        <xsl:variable name="token2" select="substring-after($s,$token1)"/>
+        <xsl:choose>
+          <xsl:when test="lower-case($token1)=('rna','dna','hiv','aids','covid-19','covid')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="matches(lower-case($token1),'[1-4]d')">
+            <xsl:value-of select="concat(upper-case($token1),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:when>
+          <xsl:when test="contains($token1,'-')">
+            <xsl:value-of select="string-join(for $x in tokenize($s,'\s') return e:titleCaseToken($x),' ')"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(               concat(upper-case(substring($token1, 1, 1)), lower-case(substring($token1, 2))),               ' ',               string-join(for $x in tokenize(substring-after($token2,' '),'\s') return e:titleCaseToken($x),' ')               )"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('and','or','the','an','of')">
+        <xsl:value-of select="lower-case($s)"/>
+      </xsl:when>
+      <xsl:when test="lower-case($s)=('rna','dna')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:when test="matches(lower-case($s),'[1-4]d')">
+        <xsl:value-of select="upper-case($s)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="e:titleCaseToken($s)"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:article-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'Replication Study'">
+        <xsl:value-of select="'Replication Study:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Registered Report'">
+        <xsl:value-of select="'Registered report:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Correction'">
+        <xsl:value-of select="'Correction:'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'Retraction'">
+        <xsl:value-of select="'Retraction:'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:sec-type2title" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="$s = 'intro'">
+        <xsl:value-of select="'Introduction'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results'">
+        <xsl:value-of select="'Results'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'discussion'">
+        <xsl:value-of select="'Discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'materials|methods'">
+        <xsl:value-of select="'Materials and methods'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'results|discussion'">
+        <xsl:value-of select="'Results and discussion'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'methods'">
+        <xsl:value-of select="'Methods'"/>
+      </xsl:when>
+      
+      <xsl:when test="$s = 'additional-information'">
+        <xsl:value-of select="'Additional information'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'supplementary-material'">
+        <xsl:value-of select="'Additional files'"/>
+      </xsl:when>
+      <xsl:when test="$s = 'data-availability'">
+        <xsl:value-of select="'Data availability'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:fig-id-type" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^box[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Box figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^app[0-9]{1,3}fig[0-9]{1,3}s[0-9]{1,3}$')">
+        <xsl:value-of select="'Appendix figure supplement'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'^respfig[0-9]{1,3}$|^sa[0-9]fig[0-9]{1,3}$')">
+        <xsl:value-of select="'Author response figure'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:stripDiacritics" as="xs:string">
+    <xsl:param name="string" as="xs:string"/>
+    <xsl:value-of select="replace(replace(replace(translate(normalize-unicode($string,'NFD'),'ƀȼđɇǥħɨɉꝁłøɍŧɏƶ','bcdeghijklortyz'),'\p{M}',''),'æ','ae'),'ß','ss')"/>
+  </xsl:function>
+  <xsl:function name="e:citation-format1" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',$year/ancestor::element-citation/person-group[1]/collab[2],', ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al., ',$year)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:citation-format2" as="xs:string">
+    <xsl:param name="year"/>
+    <xsl:choose>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/name">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 1) and $year/ancestor::element-citation/person-group[1]/collab">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab,' and ',$year/ancestor::element-citation/person-group[1]/name/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 1) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/collab,' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/name) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1],' and ',$year/ancestor::element-citation/person-group[1]/name[2]/surname[1],' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) = 2) and (count($year/ancestor::element-citation/person-group[1]/collab) = 2)">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1],' and ',e:stripDiacritics($year/ancestor::element-citation/person-group[1]/collab[2]),' (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'collab'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/collab[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:when test="(count($year/ancestor::element-citation/person-group[1]/*) ge 2) and $year/ancestor::element-citation/person-group[1]/*[1]/local-name() = 'name'">
+        <xsl:value-of select="concat($year/ancestor::element-citation/person-group[1]/name[1]/surname[1], ' et al. (',$year,')')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undetermined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:ref-cite-list">
+    <xsl:param name="ref-list" as="node()"/>
+    <xsl:element name="list">
+      <xsl:for-each select="$ref-list/ref[element-citation[year]]">
+        <xsl:variable name="cite" select="e:citation-format1(./element-citation[1]/year[1])"/>
+        <xsl:element name="item">
+          <xsl:attribute name="id">
+            <xsl:value-of select="./@id"/>
+          </xsl:attribute>
+          <xsl:attribute name="no-suffix">
+            <xsl:value-of select="replace($cite,'[A-Za-z]$','')"/>
+          </xsl:attribute>
+          <xsl:value-of select="$cite"/>
+        </xsl:element>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:non-distinct-citations">
+    <xsl:param name="cite-list" as="node()"/>
+    <xsl:element name="list">
+    <xsl:for-each select="$cite-list//*:item">
+      <xsl:variable name="cite" select="./string()"/>
+      <xsl:choose>
+        <xsl:when test="./preceding::*:item/string() = $cite">
+          <xsl:element name="item">
+            <xsl:attribute name="id">
+              <xsl:value-of select="./@id"/>
+            </xsl:attribute>
+            <xsl:value-of select="$cite"/>
+          </xsl:element>
+        </xsl:when>
+        <xsl:when test="not(matches($cite,'[A-Za-z]$')) and (./preceding::*:item/@no-suffix/string() = $cite)">
+          <xsl:element name="item">
+            <xsl:attribute name="id">
+              <xsl:value-of select="./@id"/>
+            </xsl:attribute>
+          <xsl:value-of select="$cite"/>
+          </xsl:element>
+        </xsl:when>
+        <xsl:when test="not(matches($cite,'[A-Za-z]$')) and ./following::*:item/@no-suffix/string() = $cite">
+          <xsl:element name="item">
+            <xsl:attribute name="id">
+              <xsl:value-of select="./@id"/>
+            </xsl:attribute>
+          <xsl:value-of select="$cite"/>
+          </xsl:element>
+        </xsl:when>
+        <xsl:otherwise/>
+      </xsl:choose>
+    </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-name" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:choose>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and $name/suffix[1]">
+        <xsl:value-of select="concat($name/surname[1],' ',$name/suffix[1])"/>
+      </xsl:when>
+      <xsl:when test="$name/given-names[1] and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="concat($name/given-names[1],' ',$name/surname[1])"/>
+      </xsl:when>
+      <xsl:when test="not($name/given-names[1]) and $name/surname[1] and not($name/suffix[1])">
+        <xsl:value-of select="$name/surname[1]"/>
+      </xsl:when>
+      <xsl:otherwise>
+        
+        <xsl:value-of select="'No elements present'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:get-collab">
+    <xsl:param name="collab"/>
+    <xsl:for-each select="$collab/(*|text())">
+      <xsl:choose>
+        <xsl:when test="./name()='contrib-group'"/>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:function>
+  <xsl:function name="e:isbn-sum" as="xs:integer">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="string-length($s) = 10">
+        <xsl:variable name="d1" select="number(substring($s,1,1)) * 10"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 9"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1)) * 8"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 7"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1)) * 6"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 5"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1)) * 4"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1)) * 2"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 1"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10) mod 11"/>
+      </xsl:when>
+      <xsl:when test="string-length($s) = 13">
+        <xsl:variable name="d1" select="number(substring($s,1,1))"/>
+        <xsl:variable name="d2" select="number(substring($s,2,1)) * 3"/>
+        <xsl:variable name="d3" select="number(substring($s,3,1))"/>
+        <xsl:variable name="d4" select="number(substring($s,4,1)) * 3"/>
+        <xsl:variable name="d5" select="number(substring($s,5,1))"/>
+        <xsl:variable name="d6" select="number(substring($s,6,1)) * 3"/>
+        <xsl:variable name="d7" select="number(substring($s,7,1))"/>
+        <xsl:variable name="d8" select="number(substring($s,8,1)) * 3"/>
+        <xsl:variable name="d9" select="number(substring($s,9,1))"/>
+        <xsl:variable name="d10" select="number(substring($s,10,1)) * 3"/>
+        <xsl:variable name="d11" select="number(substring($s,11,1))"/>
+        <xsl:variable name="d12" select="number(substring($s,12,1)) * 3"/>
+        <xsl:variable name="d13" select="number(substring($s,13,1))"/>
+        <xsl:value-of select="number($d1 + $d2 + $d3 + $d4 + $d5 + $d6 + $d7 + $d8 + $d9 + $d10 + $d11 + $d12 + $d13) mod 10"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="number('1')"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:escape-for-regex" as="xs:string">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:sequence select="replace($arg,'(\.|\[|\]|\\|\||\-|\^|\$|\?|\*|\+|\{|\}|\(|\))','\\$1')"/>
+  </xsl:function>
+  <xsl:function name="e:get-ordinal" as="xs:string">
+    <xsl:param name="value" as="xs:integer?"/>
+    <xsl:if test="translate(string($value), '0123456789', '') = '' and number($value) &gt; 0">
+      <xsl:variable name="mod100" select="$value mod 100"/>
+      <xsl:variable name="mod10" select="$value mod 10"/>
+      <xsl:choose>
+        <xsl:when test="$mod100 = 11 or $mod100 = 12 or $mod100 = 13">
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 1">
+          <xsl:value-of select="concat($value,'st')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 2">
+          <xsl:value-of select="concat($value,'nd')"/>
+        </xsl:when>
+        <xsl:when test="$mod10 = 3">
+          <xsl:value-of select="concat($value,'rd')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat($value,'th')"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:function>
+  <let name="org-regex" value="'b\.\s?subtilis|bacillus\s?subtilis|d\.\s?melanogaster|drosophila\s?melanogaster|e\.\s?coli|escherichia\s?coli|s\.\s?pombe|schizosaccharomyces\s?pombe|s\.\s?cerevisiae|saccharomyces\s?cerevisiae|c\.\s?elegans|caenorhabditis\s?elegans|a\.\s?thaliana|arabidopsis\s?thaliana|m\.\s?thermophila|myceliophthora\s?thermophila|dictyostelium|p\.\s?falciparum|plasmodium\s?falciparum|s\.\s?enterica|salmonella\s?enterica|s\.\s?pyogenes|streptococcus\s?pyogenes|p\.\s?dumerilii|platynereis\s?dumerilii|p\.\s?cynocephalus|papio\s?cynocephalus|o\.\s?fasciatus|oncopeltus\s?fasciatus|n\.\s?crassa|neurospora\s?crassa|c\.\s?intestinalis|ciona\s?intestinalis|e\.\s?cuniculi|encephalitozoon\s?cuniculi|h\.\s?salinarum|halobacterium\s?salinarum|s\.\s?solfataricus|sulfolobus\s?solfataricus|s\.\s?mediterranea|schmidtea\s?mediterranea|s\.\s?rosetta|salpingoeca\s?rosetta|n\.\s?vectensis|nematostella\s?vectensis|s\.\s?aureus|staphylococcus\s?aureus|v\.\s?cholerae|vibrio\s?cholerae|t\.\s?thermophila|tetrahymena\s?thermophila|c\.\s?reinhardtii|chlamydomonas\s?reinhardtii|n\.\s?attenuata|nicotiana\s?attenuata|e\.\s?carotovora|erwinia\s?carotovora|e\.\s?faecalis|h\.\s?sapiens|homo\s?sapiens|c\.\s?trachomatis|chlamydia\s?trachomatis|enterococcus\s?faecalis|x\.\s?laevis|xenopus\s?laevis|x\.\s?tropicalis|xenopus\s?tropicalis|m\.\s?musculus|mus\s?musculus|d\.\s?immigrans|drosophila\s?immigrans|d\.\s?subobscura|drosophila\s?subobscura|d\.\s?affinis|drosophila\s?affinis|d\.\s?obscura|drosophila\s?obscura|f\.\s?tularensis|francisella\s?tularensis|p\.\s?plantaginis|podosphaera\s?plantaginis|p\.\s?lanceolata|plantago\s?lanceolata|m\.\s?trossulus|mytilus\s?trossulus|m\.\s?edulis|mytilus\s?edulis|m\.\s?chilensis|mytilus\s?chilensis|u\.\s?maydis|ustilago\s?maydis|p\.\s?knowlesi|plasmodium\s?knowlesi|p\.\s?aeruginosa|pseudomonas\s?aeruginosa|t\.\s?brucei|trypanosoma\s?brucei|caulobacter\s?crescentus|c\.\s?crescentus|d\.\s?rerio|danio\s?rerio|drosophila|xenopus'"/>
+  <let name="sec-title-regex" value="string-join(     for $x in tokenize($org-regex,'\|')     return concat('^',$x,'$')     ,'|')"/>
+  <xsl:function name="e:org-conform" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="matches($s,'b\.\s?subtilis')">
+        <xsl:value-of select="'B. subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'bacillus\s?subtilis')">
+        <xsl:value-of select="'Bacillus subtilis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?melanogaster')">
+        <xsl:value-of select="'D. melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?melanogaster')">
+        <xsl:value-of select="'Drosophila melanogaster'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?coli')">
+        <xsl:value-of select="'E. coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'escherichia\s?coli')">
+        <xsl:value-of select="'Escherichia coli'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pombe')">
+        <xsl:value-of select="'S. pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schizosaccharomyces\s?pombe')">
+        <xsl:value-of select="'Schizosaccharomyces pombe'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?cerevisiae')">
+        <xsl:value-of select="'S. cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'saccharomyces\s?cerevisiae')">
+        <xsl:value-of select="'Saccharomyces cerevisiae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?elegans')">
+        <xsl:value-of select="'C. elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caenorhabditis\s?elegans')">
+        <xsl:value-of select="'Caenorhabditis elegans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?thermophila')">
+        <xsl:value-of select="'M. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'myceliophthora\s?thermophila')">
+        <xsl:value-of select="'Myceliophthora thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'dictyostelium')">
+        <xsl:value-of select="'Dictyostelium'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?falciparum')">
+        <xsl:value-of select="'P. falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?falciparum')">
+        <xsl:value-of select="'Plasmodium falciparum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?enterica')">
+        <xsl:value-of select="'S. enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salmonella\s?enterica')">
+        <xsl:value-of select="'Salmonella enterica'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?pyogenes')">
+        <xsl:value-of select="'S. pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'streptococcus\s?pyogenes')">
+        <xsl:value-of select="'Streptococcus pyogenes'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?dumerilii')">
+        <xsl:value-of select="'P. dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'platynereis\s?dumerilii')">
+        <xsl:value-of select="'Platynereis dumerilii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?cynocephalus')">
+        <xsl:value-of select="'P. cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'papio\s?cynocephalus')">
+        <xsl:value-of select="'Papio cynocephalus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'o\.\s?fasciatus')">
+        <xsl:value-of select="'O. fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'oncopeltus\s?fasciatus')">
+        <xsl:value-of select="'Oncopeltus fasciatus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?crassa')">
+        <xsl:value-of select="'N. crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'neurospora\s?crassa')">
+        <xsl:value-of select="'Neurospora crassa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?intestinalis')">
+        <xsl:value-of select="'C. intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ciona\s?intestinalis')">
+        <xsl:value-of select="'Ciona intestinalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?cuniculi')">
+        <xsl:value-of select="'E. cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'encephalitozoon\s?cuniculi')">
+        <xsl:value-of select="'Encephalitozoon cuniculi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?salinarum')">
+        <xsl:value-of select="'H. salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'halobacterium\s?salinarum')">
+        <xsl:value-of select="'Halobacterium salinarum'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?solfataricus')">
+        <xsl:value-of select="'S. solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'sulfolobus\s?solfataricus')">
+        <xsl:value-of select="'Sulfolobus solfataricus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?mediterranea')">
+        <xsl:value-of select="'S. mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'schmidtea\s?mediterranea')">
+        <xsl:value-of select="'Schmidtea mediterranea'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?rosetta')">
+        <xsl:value-of select="'S. rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'salpingoeca\s?rosetta')">
+        <xsl:value-of select="'Salpingoeca rosetta'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?vectensis')">
+        <xsl:value-of select="'N. vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nematostella\s?vectensis')">
+        <xsl:value-of select="'Nematostella vectensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'s\.\s?aureus')">
+        <xsl:value-of select="'S. aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'staphylococcus\s?aureus')">
+        <xsl:value-of select="'Staphylococcus aureus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'a\.\s?thaliana')">
+        <xsl:value-of select="'A. thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'arabidopsis\s?thaliana')">
+        <xsl:value-of select="'Arabidopsis thaliana'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'v\.\s?cholerae')">
+        <xsl:value-of select="'V. cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'vibrio\s?cholerae')">
+        <xsl:value-of select="'Vibrio cholerae'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?thermophila')">
+        <xsl:value-of select="'T. thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'tetrahymena\s?thermophila')">
+        <xsl:value-of select="'Tetrahymena thermophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?reinhardtii')">
+        <xsl:value-of select="'C. reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydomonas\s?reinhardtii')">
+        <xsl:value-of select="'Chlamydomonas reinhardtii'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'n\.\s?attenuata')">
+        <xsl:value-of select="'N. attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'nicotiana\s?attenuata')">
+        <xsl:value-of select="'Nicotiana attenuata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?carotovora')">
+        <xsl:value-of select="'E. carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'erwinia\s?carotovora')">
+        <xsl:value-of select="'Erwinia carotovora'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'h\.\s?sapiens')">
+        <xsl:value-of select="'H. sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'homo\s?sapiens')">
+        <xsl:value-of select="'Homo sapiens'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'e\.\s?faecalis')">
+        <xsl:value-of select="'E. faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'enterococcus\s?faecalis')">
+        <xsl:value-of select="'Enterococcus faecalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?trachomatis')">
+        <xsl:value-of select="'C. trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'chlamydia\s?trachomatis')">
+        <xsl:value-of select="'Chlamydia trachomatis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?laevis')">
+        <xsl:value-of select="'X. laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?laevis')">
+        <xsl:value-of select="'Xenopus laevis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'x\.\s?tropicalis')">
+        <xsl:value-of select="'X. tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus\s?tropicalis')">
+        <xsl:value-of select="'Xenopus tropicalis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?musculus')">
+        <xsl:value-of select="'M. musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mus\s?musculus')">
+        <xsl:value-of select="'Mus musculus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?immigrans')">
+        <xsl:value-of select="'D. immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?immigrans')">
+        <xsl:value-of select="'Drosophila immigrans'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?subobscura')">
+        <xsl:value-of select="'D. subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?subobscura')">
+        <xsl:value-of select="'Drosophila subobscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?affinis')">
+        <xsl:value-of select="'D. affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?affinis')">
+        <xsl:value-of select="'Drosophila affinis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?obscura')">
+        <xsl:value-of select="'D. obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila\s?obscura')">
+        <xsl:value-of select="'Drosophila obscura'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'f\.\s?tularensis')">
+        <xsl:value-of select="'F. tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'francisella\s?tularensis')">
+        <xsl:value-of select="'Francisella tularensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?plantaginis')">
+        <xsl:value-of select="'P. plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'podosphaera\s?plantaginis')">
+        <xsl:value-of select="'Podosphaera plantaginis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?lanceolata')">
+        <xsl:value-of select="'P. lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plantago\s?lanceolata')">
+        <xsl:value-of select="'Plantago lanceolata'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?edulis')">
+        <xsl:value-of select="'M. edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?edulis')">
+        <xsl:value-of select="'Mytilus edulis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?chilensis')">
+        <xsl:value-of select="'M. chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?chilensis')">
+        <xsl:value-of select="'Mytilus chilensis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'m\.\s?trossulus')">
+        <xsl:value-of select="'M. trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'mytilus\s?trossulus')">
+        <xsl:value-of select="'Mytilus trossulus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'u\.\s?maydis')">
+        <xsl:value-of select="'U. maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'ustilago\s?maydis')">
+        <xsl:value-of select="'Ustilago maydis'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?knowlesi')">
+        <xsl:value-of select="'P. knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'plasmodium\s?knowlesi')">
+        <xsl:value-of select="'Plasmodium knowlesi'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'p\.\s?aeruginosa')">
+        <xsl:value-of select="'P. aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'pseudomonas\s?aeruginosa')">
+        <xsl:value-of select="'Pseudomonas aeruginosa'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'t\.\s?brucei')">
+        <xsl:value-of select="'T. brucei'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'trypanosoma\s?brucei')">
+        <xsl:value-of select="'Trypanosoma brucei'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'c\.\s?crescentus')">
+        <xsl:value-of select="'C. crescentus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'caulobacter\s?crescentus')">
+        <xsl:value-of select="'Caulobacter crescentus'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'d\.\s?rerio')">
+        <xsl:value-of select="'D. rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'danio\s?rerio')">
+        <xsl:value-of select="'Danio rerio'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'drosophila')">
+        <xsl:value-of select="'Drosophila'"/>
+      </xsl:when>
+      <xsl:when test="matches($s,'xenopus')">
+        <xsl:value-of select="'Xenopus'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'undefined'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:function name="e:code-check">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:element name="code">
+      <xsl:if test="contains($s,'github')">
+        <xsl:element name="match">
+        <xsl:value-of select="'github '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="contains($s,'gitlab')">
+        <xsl:element name="match">
+        <xsl:value-of select="'gitlab '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="contains($s,'codeplex')">
+        <xsl:element name="match">
+        <xsl:value-of select="'codeplex '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="contains($s,'sourceforge')">
+        <xsl:element name="match">
+        <xsl:value-of select="'sourceforge '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="contains($s,'bitbucket')">
+        <xsl:element name="match">
+        <xsl:value-of select="'bitbucket '"/>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="contains($s,'assembla ')">
+        <xsl:element name="match">
+        <xsl:value-of select="'assembla '"/>
+        </xsl:element>
+      </xsl:if>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-xrefs">
+    <xsl:param name="article"/>
+    <xsl:param name="object-id"/>
+    <xsl:param name="object-type"/>
+    <xsl:variable name="object-no" select="replace($object-id,'[^0-9]','')"/>
+    <xsl:element name="matches">
+      <xsl:for-each select="$article//xref[(@ref-type=$object-type) and not(ancestor::caption)]">
+        <xsl:variable name="rid-no" select="replace(./@rid,'[^0-9]','')"/>
+        <xsl:variable name="text-no" select="tokenize(normalize-space(replace(.,'[^0-9]',' ')),'\s')[last()]"/>
+        <xsl:choose>
+          <xsl:when test="./@rid = $object-id">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="contains(./@rid,'app')"/>
+          <xsl:when test="($rid-no lt $object-no) and (./following-sibling::text()[1] = '–') and (./following-sibling::*[1]/name()='xref') and (number(replace(replace(./following-sibling::xref[1]/@rid,'\-','.'),'[a-z]','')) gt number($object-no))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and contains(.,$object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'–'))">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:when test="($rid-no lt $object-no) and (contains(.,'Videos') or contains(.,'videos') and contains(.,'—')) and ($text-no gt $object-no)">
+            <xsl:element name="match">
+              <xsl:attribute name="sec-id">
+                <xsl:value-of select="./ancestor::sec[1]/@id"/>
+              </xsl:attribute>
+              <xsl:value-of select="self::*"/>
+            </xsl:element>
+          </xsl:when>
+          <xsl:otherwise/>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:get-iso-pub-date">
+    <xsl:param name="element"/>
+    <xsl:choose>
+      <xsl:when test="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]/month">
+        <xsl:variable name="pub-date" select="$element/ancestor-or-self::article//article-meta/pub-date[(@date-type='publication') or (@date-type='pub')]"/>
+        <xsl:value-of select="concat($pub-date/year,'-',$pub-date/month,'-',$pub-date/day)"/>
+      </xsl:when>
+      <xsl:otherwise/>
+    </xsl:choose>
+  </xsl:function>
+  <let name="latin-regex" value="'in\s+vitro|ex\s+vitro|in\s+vivo|ex\s+vivo|a\s+priori|a\s+posteriori|de\s+novo|in\s+utero|in\s+natura|in\s+situ|in\s+planta|rete\s+mirabile|nomen\s+novum| sensu |ad\s+libitum|in\s+ovo'"/>
+  <xsl:function name="e:get-latin-terms" as="element()">
+    <xsl:param name="article" as="element()"/>
+    <xsl:param name="regex" as="xs:string"/>
+    
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
+    
+    
+    <xsl:element name="result">
+      <xsl:choose>
+        <xsl:when test="matches($roman-text,$regex)">
+          <xsl:element name="list">
+            <xsl:attribute name="list-type">roman</xsl:attribute>
+            <xsl:for-each select="tokenize($regex,'\|')">
+              <xsl:variable name="display" select="replace(replace(.,'\\s\+',' '),'^ | $','')"/>
+              <xsl:element name="match">
+                <xsl:attribute name="count">
+                  <xsl:value-of select="count(tokenize($roman-text,.)) - 1"/>
+                </xsl:attribute>
+                <xsl:value-of select="$display"/>
+              </xsl:element>
+            </xsl:for-each>
+          </xsl:element>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:element name="list">
+            <xsl:attribute name="list-type">roman</xsl:attribute>
+          </xsl:element>
+        </xsl:otherwise>
+      </xsl:choose>
+      <xsl:choose>
+        <xsl:when test="matches($italic-text,$regex)">
+          <xsl:element name="list">
+            <xsl:attribute name="list-type">italic</xsl:attribute>
+            <xsl:for-each select="tokenize($regex,'\|')">
+              <xsl:variable name="display" select="replace(.,'\\s\+',' ')"/>
+              <xsl:element name="match">
+                <xsl:attribute name="count">
+                  <xsl:value-of select="count(tokenize($italic-text,.)) - 1"/>
+                </xsl:attribute>
+                <xsl:value-of select="$display"/>
+              </xsl:element>
+            </xsl:for-each>
+          </xsl:element>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:element name="list">
+            <xsl:attribute name="list-type">italic</xsl:attribute>
+          </xsl:element>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:element>
+  </xsl:function>
+  <xsl:function name="e:print-latin-terms" as="xs:string">
+    <xsl:param name="list" as="element()"/>
+    <xsl:value-of select="string-join(       for $term in $list//*:match[@count != '0']        return if (number($term/@count) gt 1) then concat($term/@count,' instances of ',$term)       else concat($term/@count,' instance of ',$term)       ,', ')"/>
+  </xsl:function>
+  <xsl:function name="e:line-count" as="xs:integer">
+    <xsl:param name="arg" as="xs:string?"/>
+    
+    <xsl:sequence select="count(tokenize($arg,'(\r\n?|\n\r?)'))"/>
+    
+  </xsl:function>
+  <pattern id="content-containers">
+    <rule context="mml:math" id="math-tests">
+      <let name="data" value="replace(normalize-space(.),'\s','')"/>
+      <let name="children" value="string-join(for $x in .//*[(local-name()!='mo') and (local-name()!='mn') and (normalize-space(.)!='')] return $x/local-name(),'')"/>
+      <report test="descendant::mml:mi[(.='') and preceding-sibling::*[1][(local-name() = 'mi') and matches(.,'[A-Za-z]')] and following-sibling::*[1][(local-name() = 'mi') and matches(.,'[A-Za-z]')]]" role="warning" id="math-test-19">Maths containing '<value-of select="."/>' has what looks like words or terms which need separating with a space. With it's current markup the space will not be preserved on the eLife website. Please add in the space(s) using the latext '\;' in the appropriate place(s), so that the space is preserved in the HTML.</report>
+    </rule>
+  </pattern>
+  <pattern id="root-pattern">
+    <rule context="root" id="root-rule">
+      <assert test="descendant::mml:math" role="error" id="math-tests-xspec-assert">mml:math must be present.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/test/tests/gen/math-tests/math-test-19/pass.xml
+++ b/test/tests/gen/math-tests/math-test-19/pass.xml
@@ -1,0 +1,11 @@
+<?oxygen SCHSchema="math-test-19.sch"?>
+<!--Context: mml:math
+Test: report    descendant::mml:mi[(.='') and preceding-sibling::*[1][(local-name() = 'mi') and matches(.,'[A-Za-z]')] and following-sibling::*[1][(local-name() = 'mi') and matches(.,'[A-Za-z]')]]
+Message: Maths containing '' has what looks like words or terms which need separating with a space. With it's current markup the space will not be preserved on the eLife website. Please add in the space(s) using the latext '\;' in the appropriate place(s), so that the space is preserved in the HTML. -->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <body>
+      <p><inline-formula><mml:math id="inf1"><mml:mstyle displaystyle="true" scriptlevel="0"><mml:mrow><mml:mfrac><mml:mrow><mml:mi>r</mml:mi><mml:mi>e</mml:mi><mml:mi>d</mml:mi><mml:mspace width="thickmathspace"/><mml:mi>b</mml:mi><mml:mi>l</mml:mi><mml:mi>o</mml:mi><mml:mi>o</mml:mi><mml:mi>d</mml:mi><mml:mspace width="thickmathspace"/><mml:mi>c</mml:mi><mml:mi>e</mml:mi><mml:mi>l</mml:mi><mml:mi>l</mml:mi><mml:mi>s</mml:mi><mml:mspace width="thickmathspace"/><mml:mo>∗</mml:mo><mml:mspace width="thickmathspace"/><mml:mi>m</mml:mi><mml:mi>e</mml:mi><mml:mi>a</mml:mi><mml:mi>n</mml:mi><mml:mspace width="thickmathspace"/><mml:mi>c</mml:mi><mml:mi>o</mml:mi><mml:mi>r</mml:mi><mml:mi>p</mml:mi><mml:mi>u</mml:mi><mml:mi>s</mml:mi><mml:mi>c</mml:mi><mml:mi>u</mml:mi><mml:mi>l</mml:mi><mml:mi>a</mml:mi><mml:mi>r</mml:mi><mml:mspace width="thickmathspace"/><mml:mi>v</mml:mi><mml:mi>o</mml:mi><mml:mi>l</mml:mi><mml:mi>u</mml:mi><mml:mi>m</mml:mi><mml:mi>e</mml:mi></mml:mrow><mml:mn>10</mml:mn></mml:mfrac></mml:mrow></mml:mstyle></mml:math></inline-formula></p>
+    </body>
+  </article>
+</root>

--- a/test/tests/gen/math-tests/math-test-2/math-test-2.sch
+++ b/test/tests/gen/math-tests/math-test-2/math-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/math-tests/math-test-3/math-test-3.sch
+++ b/test/tests/gen/math-tests/math-test-3/math-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/math-tests/math-test-4/math-test-4.sch
+++ b/test/tests/gen/math-tests/math-test-4/math-test-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/math-tests/math-test-5/math-test-5.sch
+++ b/test/tests/gen/math-tests/math-test-5/math-test-5.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/math-tests/math-test-6/math-test-6.sch
+++ b/test/tests/gen/math-tests/math-test-6/math-test-6.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/math-tests/math-test-7/math-test-7.sch
+++ b/test/tests/gen/math-tests/math-test-7/math-test-7.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/math-tests/math-test-8/math-test-8.sch
+++ b/test/tests/gen/math-tests/math-test-8/math-test-8.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/math-tests/math-test-9/math-test-9.sch
+++ b/test/tests/gen/math-tests/math-test-9/math-test-9.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/mathbackground-tests/final-mathbackground-test-1/final-mathbackground-test-1.sch
+++ b/test/tests/gen/mathbackground-tests/final-mathbackground-test-1/final-mathbackground-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/mathbackground-tests/final-mathbackground-test-2/final-mathbackground-test-2.sch
+++ b/test/tests/gen/mathbackground-tests/final-mathbackground-test-2/final-mathbackground-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/mathbackground-tests/pre-mathbackground-test-1/pre-mathbackground-test-1.sch
+++ b/test/tests/gen/mathbackground-tests/pre-mathbackground-test-1/pre-mathbackground-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/mathbackground-tests/pre-mathbackground-test-2/pre-mathbackground-test-2.sch
+++ b/test/tests/gen/mathbackground-tests/pre-mathbackground-test-2/pre-mathbackground-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/media-children/media-child-conformance/media-child-conformance.sch
+++ b/test/tests/gen/media-children/media-child-conformance/media-child-conformance.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/media-tests/media-test-1/media-test-1.sch
+++ b/test/tests/gen/media-tests/media-test-1/media-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/media-tests/media-test-10/media-test-10.sch
+++ b/test/tests/gen/media-tests/media-test-10/media-test-10.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/media-tests/media-test-11/media-test-11.sch
+++ b/test/tests/gen/media-tests/media-test-11/media-test-11.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/media-tests/media-test-2/media-test-2.sch
+++ b/test/tests/gen/media-tests/media-test-2/media-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/media-tests/media-test-3/media-test-3.sch
+++ b/test/tests/gen/media-tests/media-test-3/media-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/media-tests/media-test-4/media-test-4.sch
+++ b/test/tests/gen/media-tests/media-test-4/media-test-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/media-tests/media-test-5/media-test-5.sch
+++ b/test/tests/gen/media-tests/media-test-5/media-test-5.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/media-tests/media-test-6/media-test-6.sch
+++ b/test/tests/gen/media-tests/media-test-6/media-test-6.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/media-tests/media-test-7/media-test-7.sch
+++ b/test/tests/gen/media-tests/media-test-7/media-test-7.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/media-tests/media-test-8/media-test-8.sch
+++ b/test/tests/gen/media-tests/media-test-8/media-test-8.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/media-tests/media-test-9/media-test-9.sch
+++ b/test/tests/gen/media-tests/media-test-9/media-test-9.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/meta-value-child-tests/custom-meta-child-test-1/custom-meta-child-test-1.sch
+++ b/test/tests/gen/meta-value-child-tests/custom-meta-child-test-1/custom-meta-child-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/meta-value-tests/custom-meta-test-10/custom-meta-test-10.sch
+++ b/test/tests/gen/meta-value-tests/custom-meta-test-10/custom-meta-test-10.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/meta-value-tests/custom-meta-test-11/custom-meta-test-11.sch
+++ b/test/tests/gen/meta-value-tests/custom-meta-test-11/custom-meta-test-11.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/meta-value-tests/custom-meta-test-13/custom-meta-test-13.sch
+++ b/test/tests/gen/meta-value-tests/custom-meta-test-13/custom-meta-test-13.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/meta-value-tests/custom-meta-test-16/custom-meta-test-16.sch
+++ b/test/tests/gen/meta-value-tests/custom-meta-test-16/custom-meta-test-16.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/meta-value-tests/custom-meta-test-4/custom-meta-test-4.sch
+++ b/test/tests/gen/meta-value-tests/custom-meta-test-4/custom-meta-test-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/meta-value-tests/custom-meta-test-5/custom-meta-test-5.sch
+++ b/test/tests/gen/meta-value-tests/custom-meta-test-5/custom-meta-test-5.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/meta-value-tests/custom-meta-test-7/custom-meta-test-7.sch
+++ b/test/tests/gen/meta-value-tests/custom-meta-test-7/custom-meta-test-7.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/meta-value-tests/custom-meta-test-8/custom-meta-test-8.sch
+++ b/test/tests/gen/meta-value-tests/custom-meta-test-8/custom-meta-test-8.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/meta-value-tests/final-custom-meta-test-6/final-custom-meta-test-6.sch
+++ b/test/tests/gen/meta-value-tests/final-custom-meta-test-6/final-custom-meta-test-6.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/meta-value-tests/final-custom-meta-test-9/final-custom-meta-test-9.sch
+++ b/test/tests/gen/meta-value-tests/final-custom-meta-test-9/final-custom-meta-test-9.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/meta-value-tests/final-rep-study-custom-meta-test/final-rep-study-custom-meta-test.sch
+++ b/test/tests/gen/meta-value-tests/final-rep-study-custom-meta-test/final-rep-study-custom-meta-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/meta-value-tests/pre-custom-meta-test-6/pre-custom-meta-test-6.sch
+++ b/test/tests/gen/meta-value-tests/pre-custom-meta-test-6/pre-custom-meta-test-6.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/meta-value-tests/pre-custom-meta-test-9/pre-custom-meta-test-9.sch
+++ b/test/tests/gen/meta-value-tests/pre-custom-meta-test-9/pre-custom-meta-test-9.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/meta-value-tests/pre-rep-study-custom-meta-test/pre-rep-study-custom-meta-test.sch
+++ b/test/tests/gen/meta-value-tests/pre-rep-study-custom-meta-test/pre-rep-study-custom-meta-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/missing-ref-cited/missing-ref-in-text-test/missing-ref-in-text-test.sch
+++ b/test/tests/gen/missing-ref-cited/missing-ref-in-text-test/missing-ref-in-text-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/mml-math-ids/mml-math-id-test/mml-math-id-test.sch
+++ b/test/tests/gen/mml-math-ids/mml-math-id-test/mml-math-id-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/mml-math-ids/sub-mml-math-id-test/sub-mml-math-id-test.sch
+++ b/test/tests/gen/mml-math-ids/sub-mml-math-id-test/sub-mml-math-id-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/month-tests/month-conformity/month-conformity.sch
+++ b/test/tests/gen/month-tests/month-conformity/month-conformity.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/mtext-tests/mtext-test-1/mtext-test-1.sch
+++ b/test/tests/gen/mtext-tests/mtext-test-1/mtext-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/name-child-tests/disallowed-child-assert/disallowed-child-assert.sch
+++ b/test/tests/gen/name-child-tests/disallowed-child-assert/disallowed-child-assert.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/name-tests/given-names-test-1/given-names-test-1.sch
+++ b/test/tests/gen/name-tests/given-names-test-1/given-names-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/name-tests/given-names-test-2/given-names-test-2.sch
+++ b/test/tests/gen/name-tests/given-names-test-2/given-names-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/name-tests/surname-test-1/surname-test-1.sch
+++ b/test/tests/gen/name-tests/surname-test-1/surname-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/orcid-tests/final-orcid-test-3/final-orcid-test-3.sch
+++ b/test/tests/gen/orcid-tests/final-orcid-test-3/final-orcid-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/orcid-tests/orcid-test-1/orcid-test-1.sch
+++ b/test/tests/gen/orcid-tests/orcid-test-1/orcid-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/orcid-tests/orcid-test-2/orcid-test-2.sch
+++ b/test/tests/gen/orcid-tests/orcid-test-2/orcid-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/orcid-tests/pre-orcid-test-3/pre-orcid-test-3.sch
+++ b/test/tests/gen/orcid-tests/pre-orcid-test-3/pre-orcid-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/arabidopsissthaliana-ref-article-title-check/arabidopsissthaliana-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/arabidopsissthaliana-ref-article-title-check/arabidopsissthaliana-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/asthaliana-ref-article-title-check/asthaliana-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/asthaliana-ref-article-title-check/asthaliana-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/bacillusssubtilis-ref-article-title-check/bacillusssubtilis-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/bacillusssubtilis-ref-article-title-check/bacillusssubtilis-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/bssubtilis-ref-article-title-check/bssubtilis-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/bssubtilis-ref-article-title-check/bssubtilis-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/caenorhabditisselegans-ref-article-title-check/caenorhabditisselegans-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/caenorhabditisselegans-ref-article-title-check/caenorhabditisselegans-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/chlamydiatrachomatis-ref-article-title-check/chlamydiatrachomatis-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/chlamydiatrachomatis-ref-article-title-check/chlamydiatrachomatis-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/chlamydomonassreinhardtii-ref-article-title-check/chlamydomonassreinhardtii-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/chlamydomonassreinhardtii-ref-article-title-check/chlamydomonassreinhardtii-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/cionasintestinalis-ref-article-title-check/cionasintestinalis-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/cionasintestinalis-ref-article-title-check/cionasintestinalis-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/cselegans-ref-article-title-check/cselegans-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/cselegans-ref-article-title-check/cselegans-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/csintestinalis-ref-article-title-check/csintestinalis-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/csintestinalis-ref-article-title-check/csintestinalis-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/csreinhardtii-ref-article-title-check/csreinhardtii-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/csreinhardtii-ref-article-title-check/csreinhardtii-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/ctrachomatis-ref-article-title-check/ctrachomatis-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/ctrachomatis-ref-article-title-check/ctrachomatis-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/daffinis-ref-article-title-check/daffinis-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/daffinis-ref-article-title-check/daffinis-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/daniorerio-ref-article-title-check/daniorerio-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/daniorerio-ref-article-title-check/daniorerio-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/dictyostelium-ref-article-title-check/dictyostelium-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/dictyostelium-ref-article-title-check/dictyostelium-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/dimmigrans-ref-article-title-check/dimmigrans-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/dimmigrans-ref-article-title-check/dimmigrans-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/dobscura-ref-article-title-check/dobscura-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/dobscura-ref-article-title-check/dobscura-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/drerio-ref-article-title-check/drerio-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/drerio-ref-article-title-check/drerio-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/drosophila-ref-article-title-check/drosophila-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/drosophila-ref-article-title-check/drosophila-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/drosophilaaffinis-ref-article-title-check/drosophilaaffinis-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/drosophilaaffinis-ref-article-title-check/drosophilaaffinis-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/drosophilaimmigrans-ref-article-title-check/drosophilaimmigrans-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/drosophilaimmigrans-ref-article-title-check/drosophilaimmigrans-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/drosophilaobscura-ref-article-title-check/drosophilaobscura-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/drosophilaobscura-ref-article-title-check/drosophilaobscura-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/drosophilasmelanogaster-ref-article-title-check/drosophilasmelanogaster-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/drosophilasmelanogaster-ref-article-title-check/drosophilasmelanogaster-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/drosophilasubobscura-ref-article-title-check/drosophilasubobscura-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/drosophilasubobscura-ref-article-title-check/drosophilasubobscura-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/dsmelanogaster-ref-article-title-check/dsmelanogaster-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/dsmelanogaster-ref-article-title-check/dsmelanogaster-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/dsubobscura-ref-article-title-check/dsubobscura-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/dsubobscura-ref-article-title-check/dsubobscura-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/encephalitozoonscuniculi-ref-article-title-check/encephalitozoonscuniculi-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/encephalitozoonscuniculi-ref-article-title-check/encephalitozoonscuniculi-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/enterococcussfaecalis-ref-article-title-check/enterococcussfaecalis-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/enterococcussfaecalis-ref-article-title-check/enterococcussfaecalis-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/erwiniascarotovora-ref-article-title-check/erwiniascarotovora-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/erwiniascarotovora-ref-article-title-check/erwiniascarotovora-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/escarotovora-ref-article-title-check/escarotovora-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/escarotovora-ref-article-title-check/escarotovora-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/escherichiascoli-ref-article-title-check/escherichiascoli-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/escherichiascoli-ref-article-title-check/escherichiascoli-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/escoli-ref-article-title-check/escoli-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/escoli-ref-article-title-check/escoli-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/escuniculi-ref-article-title-check/escuniculi-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/escuniculi-ref-article-title-check/escuniculi-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/esfaecalis-ref-article-title-check/esfaecalis-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/esfaecalis-ref-article-title-check/esfaecalis-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/francisellatularensis-ref-article-title-check/francisellatularensis-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/francisellatularensis-ref-article-title-check/francisellatularensis-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/ftularensis-ref-article-title-check/ftularensis-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/ftularensis-ref-article-title-check/ftularensis-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/halobacteriumssalinarum-ref-article-title-check/halobacteriumssalinarum-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/halobacteriumssalinarum-ref-article-title-check/halobacteriumssalinarum-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/homosapiens-ref-article-title-check/homosapiens-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/homosapiens-ref-article-title-check/homosapiens-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/hsapiens-ref-article-title-check/hsapiens-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/hsapiens-ref-article-title-check/hsapiens-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/hssalinarum-ref-article-title-check/hssalinarum-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/hssalinarum-ref-article-title-check/hssalinarum-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/mchilensis-ref-article-title-check/mchilensis-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/mchilensis-ref-article-title-check/mchilensis-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/medulis-ref-article-title-check/medulis-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/medulis-ref-article-title-check/medulis-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/mmusculus-ref-article-title-check/mmusculus-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/mmusculus-ref-article-title-check/mmusculus-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/msthermophila-ref-article-title-check/msthermophila-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/msthermophila-ref-article-title-check/msthermophila-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/mtrossulus-ref-article-title-check/mtrossulus-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/mtrossulus-ref-article-title-check/mtrossulus-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/musmusculus-ref-article-title-check/musmusculus-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/musmusculus-ref-article-title-check/musmusculus-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/myceliophthorasthermophila-ref-article-title-check/myceliophthorasthermophila-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/myceliophthorasthermophila-ref-article-title-check/myceliophthorasthermophila-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/mytiluschilensis-ref-article-title-check/mytiluschilensis-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/mytiluschilensis-ref-article-title-check/mytiluschilensis-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/mytilusedulis-ref-article-title-check/mytilusedulis-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/mytilusedulis-ref-article-title-check/mytilusedulis-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/mytilustrossulus-ref-article-title-check/mytilustrossulus-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/mytilustrossulus-ref-article-title-check/mytilustrossulus-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/nematostellasvectensis-ref-article-title-check/nematostellasvectensis-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/nematostellasvectensis-ref-article-title-check/nematostellasvectensis-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/neurosporascrassa-ref-article-title-check/neurosporascrassa-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/neurosporascrassa-ref-article-title-check/neurosporascrassa-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/nicotianasattenuata-ref-article-title-check/nicotianasattenuata-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/nicotianasattenuata-ref-article-title-check/nicotianasattenuata-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/nsattenuata-ref-article-title-check/nsattenuata-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/nsattenuata-ref-article-title-check/nsattenuata-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/nscrassa-ref-article-title-check/nscrassa-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/nscrassa-ref-article-title-check/nscrassa-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/nsvectensis-ref-article-title-check/nsvectensis-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/nsvectensis-ref-article-title-check/nsvectensis-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/oncopeltussfasciatus-ref-article-title-check/oncopeltussfasciatus-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/oncopeltussfasciatus-ref-article-title-check/oncopeltussfasciatus-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/osfasciatus-ref-article-title-check/osfasciatus-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/osfasciatus-ref-article-title-check/osfasciatus-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/paeruginosa-ref-article-title-check/paeruginosa-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/paeruginosa-ref-article-title-check/paeruginosa-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/papioscynocephalus-ref-article-title-check/papioscynocephalus-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/papioscynocephalus-ref-article-title-check/papioscynocephalus-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/pknowlesi-ref-article-title-check/pknowlesi-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/pknowlesi-ref-article-title-check/pknowlesi-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/planceolata-ref-article-title-check/planceolata-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/planceolata-ref-article-title-check/planceolata-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/plantagolanceolata-ref-article-title-check/plantagolanceolata-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/plantagolanceolata-ref-article-title-check/plantagolanceolata-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/plasmodiumknowlesi-ref-article-title-check/plasmodiumknowlesi-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/plasmodiumknowlesi-ref-article-title-check/plasmodiumknowlesi-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/plasmodiumsfalciparum-ref-article-title-check/plasmodiumsfalciparum-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/plasmodiumsfalciparum-ref-article-title-check/plasmodiumsfalciparum-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/platynereissdumerilii-ref-article-title-check/platynereissdumerilii-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/platynereissdumerilii-ref-article-title-check/platynereissdumerilii-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/podosphaeraplantaginis-ref-article-title-check/podosphaeraplantaginis-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/podosphaeraplantaginis-ref-article-title-check/podosphaeraplantaginis-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/pplantaginis-ref-article-title-check/pplantaginis-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/pplantaginis-ref-article-title-check/pplantaginis-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/pscynocephalus-ref-article-title-check/pscynocephalus-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/pscynocephalus-ref-article-title-check/pscynocephalus-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/psdumerilii-ref-article-title-check/psdumerilii-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/psdumerilii-ref-article-title-check/psdumerilii-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/pseudomonasaeruginosa-ref-article-title-check/pseudomonasaeruginosa-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/pseudomonasaeruginosa-ref-article-title-check/pseudomonasaeruginosa-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/psfalciparum-ref-article-title-check/psfalciparum-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/psfalciparum-ref-article-title-check/psfalciparum-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/saccharomycesscerevisiae-ref-article-title-check/saccharomycesscerevisiae-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/saccharomycesscerevisiae-ref-article-title-check/saccharomycesscerevisiae-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/salmonellasenterica-ref-article-title-check/salmonellasenterica-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/salmonellasenterica-ref-article-title-check/salmonellasenterica-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/salpingoecasrosetta-ref-article-title-check/salpingoecasrosetta-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/salpingoecasrosetta-ref-article-title-check/salpingoecasrosetta-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/schizosaccharomycesspombe-ref-article-title-check/schizosaccharomycesspombe-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/schizosaccharomycesspombe-ref-article-title-check/schizosaccharomycesspombe-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/schmidteasmediterranea-ref-article-title-check/schmidteasmediterranea-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/schmidteasmediterranea-ref-article-title-check/schmidteasmediterranea-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/ssaureus-ref-article-title-check/ssaureus-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/ssaureus-ref-article-title-check/ssaureus-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/sscerevisiae-ref-article-title-check/sscerevisiae-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/sscerevisiae-ref-article-title-check/sscerevisiae-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/ssenterica-ref-article-title-check/ssenterica-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/ssenterica-ref-article-title-check/ssenterica-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/ssmediterranea-ref-article-title-check/ssmediterranea-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/ssmediterranea-ref-article-title-check/ssmediterranea-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/sspombe-ref-article-title-check/sspombe-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/sspombe-ref-article-title-check/sspombe-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/sspyogenes-ref-article-title-check/sspyogenes-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/sspyogenes-ref-article-title-check/sspyogenes-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/ssrosetta-ref-article-title-check/ssrosetta-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/ssrosetta-ref-article-title-check/ssrosetta-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/sssolfataricus-ref-article-title-check/sssolfataricus-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/sssolfataricus-ref-article-title-check/sssolfataricus-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/staphylococcussaureus-ref-article-title-check/staphylococcussaureus-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/staphylococcussaureus-ref-article-title-check/staphylococcussaureus-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/streptococcusspyogenes-ref-article-title-check/streptococcusspyogenes-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/streptococcusspyogenes-ref-article-title-check/streptococcusspyogenes-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/sulfolobusssolfataricus-ref-article-title-check/sulfolobusssolfataricus-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/sulfolobusssolfataricus-ref-article-title-check/sulfolobusssolfataricus-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/tbrucei-ref-article-title-check/tbrucei-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/tbrucei-ref-article-title-check/tbrucei-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/tetrahymenasthermophila-ref-article-title-check/tetrahymenasthermophila-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/tetrahymenasthermophila-ref-article-title-check/tetrahymenasthermophila-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/trypanosomabrucei-ref-article-title-check/trypanosomabrucei-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/trypanosomabrucei-ref-article-title-check/trypanosomabrucei-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/tsthermophila-ref-article-title-check/tsthermophila-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/tsthermophila-ref-article-title-check/tsthermophila-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/umaydis-ref-article-title-check/umaydis-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/umaydis-ref-article-title-check/umaydis-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/ustilagomaydis-ref-article-title-check/ustilagomaydis-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/ustilagomaydis-ref-article-title-check/ustilagomaydis-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/vibrioscholerae-ref-article-title-check/vibrioscholerae-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/vibrioscholerae-ref-article-title-check/vibrioscholerae-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/vscholerae-ref-article-title-check/vscholerae-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/vscholerae-ref-article-title-check/vscholerae-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/xenopus-ref-article-title-check/xenopus-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/xenopus-ref-article-title-check/xenopus-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/xenopuslaevis-ref-article-title-check/xenopuslaevis-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/xenopuslaevis-ref-article-title-check/xenopuslaevis-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/xenopustropicalis-ref-article-title-check/xenopustropicalis-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/xenopustropicalis-ref-article-title-check/xenopustropicalis-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/xlaevis-ref-article-title-check/xlaevis-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/xlaevis-ref-article-title-check/xlaevis-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-ref-article-book-title/xtropicalis-ref-article-title-check/xtropicalis-ref-article-title-check.sch
+++ b/test/tests/gen/org-ref-article-book-title/xtropicalis-ref-article-title-check/xtropicalis-ref-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/arabidopsissthaliana-article-title-check/arabidopsissthaliana-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/arabidopsissthaliana-article-title-check/arabidopsissthaliana-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/asthaliana-article-title-check/asthaliana-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/asthaliana-article-title-check/asthaliana-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/bacillusssubtilis-article-title-check/bacillusssubtilis-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/bacillusssubtilis-article-title-check/bacillusssubtilis-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/bssubtilis-article-title-check/bssubtilis-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/bssubtilis-article-title-check/bssubtilis-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/caenorhabditisselegans-article-title-check/caenorhabditisselegans-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/caenorhabditisselegans-article-title-check/caenorhabditisselegans-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/chlamydiatrachomatis-article-title-check/chlamydiatrachomatis-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/chlamydiatrachomatis-article-title-check/chlamydiatrachomatis-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/chlamydomonassreinhardtii-article-title-check/chlamydomonassreinhardtii-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/chlamydomonassreinhardtii-article-title-check/chlamydomonassreinhardtii-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/cionasintestinalis-article-title-check/cionasintestinalis-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/cionasintestinalis-article-title-check/cionasintestinalis-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/cselegans-article-title-check/cselegans-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/cselegans-article-title-check/cselegans-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/csintestinalis-article-title-check/csintestinalis-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/csintestinalis-article-title-check/csintestinalis-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/csreinhardtii-article-title-check/csreinhardtii-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/csreinhardtii-article-title-check/csreinhardtii-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/ctrachomatis-article-title-check/ctrachomatis-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/ctrachomatis-article-title-check/ctrachomatis-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/daffinis-article-title-check/daffinis-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/daffinis-article-title-check/daffinis-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/daniorerio-article-title-check/daniorerio-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/daniorerio-article-title-check/daniorerio-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/dictyostelium-article-title-check/dictyostelium-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/dictyostelium-article-title-check/dictyostelium-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/dimmigrans-article-title-check/dimmigrans-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/dimmigrans-article-title-check/dimmigrans-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/dobscura-article-title-check/dobscura-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/dobscura-article-title-check/dobscura-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/drerio-article-title-check/drerio-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/drerio-article-title-check/drerio-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/drosophila-article-title-check/drosophila-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/drosophila-article-title-check/drosophila-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/drosophilaaffinis-article-title-check/drosophilaaffinis-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/drosophilaaffinis-article-title-check/drosophilaaffinis-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/drosophilaimmigrans-article-title-check/drosophilaimmigrans-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/drosophilaimmigrans-article-title-check/drosophilaimmigrans-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/drosophilaobscura-article-title-check/drosophilaobscura-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/drosophilaobscura-article-title-check/drosophilaobscura-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/drosophilasmelanogaster-article-title-check/drosophilasmelanogaster-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/drosophilasmelanogaster-article-title-check/drosophilasmelanogaster-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/drosophilasubobscura-article-title-check/drosophilasubobscura-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/drosophilasubobscura-article-title-check/drosophilasubobscura-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/dsmelanogaster-article-title-check/dsmelanogaster-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/dsmelanogaster-article-title-check/dsmelanogaster-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/dsubobscura-article-title-check/dsubobscura-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/dsubobscura-article-title-check/dsubobscura-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/encephalitozoonscuniculi-article-title-check/encephalitozoonscuniculi-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/encephalitozoonscuniculi-article-title-check/encephalitozoonscuniculi-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/enterococcussfaecalis-article-title-check/enterococcussfaecalis-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/enterococcussfaecalis-article-title-check/enterococcussfaecalis-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/erwiniascarotovora-article-title-check/erwiniascarotovora-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/erwiniascarotovora-article-title-check/erwiniascarotovora-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/escarotovora-article-title-check/escarotovora-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/escarotovora-article-title-check/escarotovora-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/escherichiascoli-article-title-check/escherichiascoli-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/escherichiascoli-article-title-check/escherichiascoli-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/escoli-article-title-check/escoli-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/escoli-article-title-check/escoli-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/escuniculi-article-title-check/escuniculi-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/escuniculi-article-title-check/escuniculi-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/esfaecalis-article-title-check/esfaecalis-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/esfaecalis-article-title-check/esfaecalis-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/francisellatularensis-article-title-check/francisellatularensis-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/francisellatularensis-article-title-check/francisellatularensis-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/ftularensis-article-title-check/ftularensis-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/ftularensis-article-title-check/ftularensis-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/halobacteriumssalinarum-article-title-check/halobacteriumssalinarum-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/halobacteriumssalinarum-article-title-check/halobacteriumssalinarum-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/homosapiens-article-title-check/homosapiens-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/homosapiens-article-title-check/homosapiens-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/hsapiens-article-title-check/hsapiens-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/hsapiens-article-title-check/hsapiens-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/hssalinarum-article-title-check/hssalinarum-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/hssalinarum-article-title-check/hssalinarum-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/mchilensis-article-title-check/mchilensis-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/mchilensis-article-title-check/mchilensis-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/medulis-article-title-check/medulis-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/medulis-article-title-check/medulis-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/mmusculus-article-title-check/mmusculus-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/mmusculus-article-title-check/mmusculus-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/msthermophila-article-title-check/msthermophila-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/msthermophila-article-title-check/msthermophila-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/mtrossulus-article-title-check/mtrossulus-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/mtrossulus-article-title-check/mtrossulus-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/musmusculus-article-title-check/musmusculus-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/musmusculus-article-title-check/musmusculus-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/myceliophthorasthermophila-article-title-check/myceliophthorasthermophila-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/myceliophthorasthermophila-article-title-check/myceliophthorasthermophila-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/mytiluschilensis-article-title-check/mytiluschilensis-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/mytiluschilensis-article-title-check/mytiluschilensis-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/mytilusedulis-article-title-check/mytilusedulis-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/mytilusedulis-article-title-check/mytilusedulis-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/mytilustrossulus-article-title-check/mytilustrossulus-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/mytilustrossulus-article-title-check/mytilustrossulus-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/nematostellasvectensis-article-title-check/nematostellasvectensis-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/nematostellasvectensis-article-title-check/nematostellasvectensis-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/neurosporascrassa-article-title-check/neurosporascrassa-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/neurosporascrassa-article-title-check/neurosporascrassa-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/nicotianasattenuata-article-title-check/nicotianasattenuata-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/nicotianasattenuata-article-title-check/nicotianasattenuata-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/nsattenuata-article-title-check/nsattenuata-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/nsattenuata-article-title-check/nsattenuata-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/nscrassa-article-title-check/nscrassa-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/nscrassa-article-title-check/nscrassa-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/nsvectensis-article-title-check/nsvectensis-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/nsvectensis-article-title-check/nsvectensis-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/oncopeltussfasciatus-article-title-check/oncopeltussfasciatus-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/oncopeltussfasciatus-article-title-check/oncopeltussfasciatus-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/osfasciatus-article-title-check/osfasciatus-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/osfasciatus-article-title-check/osfasciatus-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/paeruginosa-article-title-check/paeruginosa-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/paeruginosa-article-title-check/paeruginosa-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/papioscynocephalus-article-title-check/papioscynocephalus-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/papioscynocephalus-article-title-check/papioscynocephalus-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/pknowlesi-article-title-check/pknowlesi-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/pknowlesi-article-title-check/pknowlesi-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/planceolata-article-title-check/planceolata-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/planceolata-article-title-check/planceolata-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/plantagolanceolata-article-title-check/plantagolanceolata-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/plantagolanceolata-article-title-check/plantagolanceolata-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/plasmodiumknowlesi-article-title-check/plasmodiumknowlesi-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/plasmodiumknowlesi-article-title-check/plasmodiumknowlesi-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/plasmodiumsfalciparum-article-title-check/plasmodiumsfalciparum-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/plasmodiumsfalciparum-article-title-check/plasmodiumsfalciparum-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/platynereissdumerilii-article-title-check/platynereissdumerilii-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/platynereissdumerilii-article-title-check/platynereissdumerilii-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/podosphaeraplantaginis-article-title-check/podosphaeraplantaginis-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/podosphaeraplantaginis-article-title-check/podosphaeraplantaginis-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/pplantaginis-article-title-check/pplantaginis-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/pplantaginis-article-title-check/pplantaginis-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/pscynocephalus-article-title-check/pscynocephalus-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/pscynocephalus-article-title-check/pscynocephalus-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/psdumerilii-article-title-check/psdumerilii-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/psdumerilii-article-title-check/psdumerilii-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/pseudomonasaeruginosa-article-title-check/pseudomonasaeruginosa-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/pseudomonasaeruginosa-article-title-check/pseudomonasaeruginosa-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/psfalciparum-article-title-check/psfalciparum-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/psfalciparum-article-title-check/psfalciparum-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/saccharomycesscerevisiae-article-title-check/saccharomycesscerevisiae-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/saccharomycesscerevisiae-article-title-check/saccharomycesscerevisiae-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/salmonellasenterica-article-title-check/salmonellasenterica-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/salmonellasenterica-article-title-check/salmonellasenterica-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/salpingoecasrosetta-article-title-check/salpingoecasrosetta-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/salpingoecasrosetta-article-title-check/salpingoecasrosetta-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/schizosaccharomycesspombe-article-title-check/schizosaccharomycesspombe-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/schizosaccharomycesspombe-article-title-check/schizosaccharomycesspombe-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/schmidteasmediterranea-article-title-check/schmidteasmediterranea-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/schmidteasmediterranea-article-title-check/schmidteasmediterranea-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/ssaureus-article-title-check/ssaureus-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/ssaureus-article-title-check/ssaureus-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/sscerevisiae-article-title-check/sscerevisiae-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/sscerevisiae-article-title-check/sscerevisiae-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/ssenterica-article-title-check/ssenterica-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/ssenterica-article-title-check/ssenterica-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/ssmediterranea-article-title-check/ssmediterranea-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/ssmediterranea-article-title-check/ssmediterranea-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/sspombe-article-title-check/sspombe-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/sspombe-article-title-check/sspombe-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/sspyogenes-article-title-check/sspyogenes-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/sspyogenes-article-title-check/sspyogenes-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/ssrosetta-article-title-check/ssrosetta-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/ssrosetta-article-title-check/ssrosetta-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/sssolfataricus-article-title-check/sssolfataricus-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/sssolfataricus-article-title-check/sssolfataricus-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/staphylococcussaureus-article-title-check/staphylococcussaureus-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/staphylococcussaureus-article-title-check/staphylococcussaureus-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/streptococcusspyogenes-article-title-check/streptococcusspyogenes-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/streptococcusspyogenes-article-title-check/streptococcusspyogenes-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/sulfolobusssolfataricus-article-title-check/sulfolobusssolfataricus-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/sulfolobusssolfataricus-article-title-check/sulfolobusssolfataricus-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/tbrucei-article-title-check/tbrucei-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/tbrucei-article-title-check/tbrucei-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/tetrahymenasthermophila-article-title-check/tetrahymenasthermophila-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/tetrahymenasthermophila-article-title-check/tetrahymenasthermophila-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/trypanosomabrucei-article-title-check/trypanosomabrucei-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/trypanosomabrucei-article-title-check/trypanosomabrucei-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/tsthermophila-article-title-check/tsthermophila-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/tsthermophila-article-title-check/tsthermophila-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/umaydis-article-title-check/umaydis-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/umaydis-article-title-check/umaydis-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/ustilagomaydis-article-title-check/ustilagomaydis-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/ustilagomaydis-article-title-check/ustilagomaydis-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/vibrioscholerae-article-title-check/vibrioscholerae-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/vibrioscholerae-article-title-check/vibrioscholerae-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/vscholerae-article-title-check/vscholerae-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/vscholerae-article-title-check/vscholerae-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/xenopus-article-title-check/xenopus-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/xenopus-article-title-check/xenopus-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/xenopuslaevis-article-title-check/xenopuslaevis-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/xenopuslaevis-article-title-check/xenopuslaevis-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/xenopustropicalis-article-title-check/xenopustropicalis-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/xenopustropicalis-article-title-check/xenopustropicalis-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/xlaevis-article-title-check/xlaevis-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/xlaevis-article-title-check/xlaevis-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/org-title-kwd/xtropicalis-article-title-check/xtropicalis-article-title-check.sch
+++ b/test/tests/gen/org-title-kwd/xtropicalis-article-title-check/xtropicalis-article-title-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/p-child-tests/allowed-p-test/allowed-p-test.sch
+++ b/test/tests/gen/p-child-tests/allowed-p-test/allowed-p-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/p-punctuation/p-bracket-test/p-bracket-test.sch
+++ b/test/tests/gen/p-punctuation/p-bracket-test/p-bracket-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/p-punctuation/p-punctuation-test/p-punctuation-test.sch
+++ b/test/tests/gen/p-punctuation/p-punctuation-test/p-punctuation-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/p-tests/p-test-2/p-test-2.sch
+++ b/test/tests/gen/p-tests/p-test-2/p-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/p-tests/p-test-3/p-test-3.sch
+++ b/test/tests/gen/p-tests/p-test-3/p-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/p-tests/p-test-5/p-test-5.sch
+++ b/test/tests/gen/p-tests/p-test-5/p-test-5.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/p-tests/p-test-6/p-test-6.sch
+++ b/test/tests/gen/p-tests/p-test-6/p-test-6.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/p-tests/p-test-7/p-test-7.sch
+++ b/test/tests/gen/p-tests/p-test-7/p-test-7.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/page-conformity/online-journal-w-page/online-journal-w-page.sch
+++ b/test/tests/gen/page-conformity/online-journal-w-page/online-journal-w-page.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/par-name-tests/par-name-test-1/par-name-test-1.sch
+++ b/test/tests/gen/par-name-tests/par-name-test-1/par-name-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/permissions-2/fig-permissions-test-12/fig-permissions-test-12.sch
+++ b/test/tests/gen/permissions-2/fig-permissions-test-12/fig-permissions-test-12.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/permissions-2/fig-permissions-test-13/fig-permissions-test-13.sch
+++ b/test/tests/gen/permissions-2/fig-permissions-test-13/fig-permissions-test-13.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/preprint-title-tests/arxiv-test/arxiv-test.sch
+++ b/test/tests/gen/preprint-title-tests/arxiv-test/arxiv-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/preprint-title-tests/biorxiv-test-2/biorxiv-test-2.sch
+++ b/test/tests/gen/preprint-title-tests/biorxiv-test-2/biorxiv-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/preprint-title-tests/biorxiv-test/biorxiv-test.sch
+++ b/test/tests/gen/preprint-title-tests/biorxiv-test/biorxiv-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/preprint-title-tests/chemrxiv-test/chemrxiv-test.sch
+++ b/test/tests/gen/preprint-title-tests/chemrxiv-test/chemrxiv-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/preprint-title-tests/medrxiv-test/medrxiv-test.sch
+++ b/test/tests/gen/preprint-title-tests/medrxiv-test/medrxiv-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/preprint-title-tests/not-rxiv-test/not-rxiv-test.sch
+++ b/test/tests/gen/preprint-title-tests/not-rxiv-test/not-rxiv-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/preprint-title-tests/paleorxiv-test/paleorxiv-test.sch
+++ b/test/tests/gen/preprint-title-tests/paleorxiv-test/paleorxiv-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/preprint-title-tests/peerjpreprints-test/peerjpreprints-test.sch
+++ b/test/tests/gen/preprint-title-tests/peerjpreprints-test/peerjpreprints-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/preprint-title-tests/preprint-handbook-presence/preprint-handbook-presence.sch
+++ b/test/tests/gen/preprint-title-tests/preprint-handbook-presence/preprint-handbook-presence.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/preprint-title-tests/preprint-replacement-character-presence/preprint-replacement-character-presence.sch
+++ b/test/tests/gen/preprint-title-tests/preprint-replacement-character-presence/preprint-replacement-character-presence.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/preprint-title-tests/psyarxiv-test/psyarxiv-test.sch
+++ b/test/tests/gen/preprint-title-tests/psyarxiv-test/psyarxiv-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/pub-date-tests-1/final-pub-date-test-1/final-pub-date-test-1.sch
+++ b/test/tests/gen/pub-date-tests-1/final-pub-date-test-1/final-pub-date-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/pub-date-tests-1/final-pub-date-test-2/final-pub-date-test-2.sch
+++ b/test/tests/gen/pub-date-tests-1/final-pub-date-test-2/final-pub-date-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/pub-date-tests-1/pre-pub-date-test-1/pre-pub-date-test-1.sch
+++ b/test/tests/gen/pub-date-tests-1/pre-pub-date-test-1/pre-pub-date-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/pub-date-tests-1/pre-pub-date-test-2/pre-pub-date-test-2.sch
+++ b/test/tests/gen/pub-date-tests-1/pre-pub-date-test-2/pre-pub-date-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/pub-date-tests-1/pub-date-test-3/pub-date-test-3.sch
+++ b/test/tests/gen/pub-date-tests-1/pub-date-test-3/pub-date-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/pub-date-tests-2/pub-date-test-4/pub-date-test-4.sch
+++ b/test/tests/gen/pub-date-tests-2/pub-date-test-4/pub-date-test-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/pub-date-tests-2/pub-date-test-5/pub-date-test-5.sch
+++ b/test/tests/gen/pub-date-tests-2/pub-date-test-5/pub-date-test-5.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/pub-date-tests-2/pub-date-test-6/pub-date-test-6.sch
+++ b/test/tests/gen/pub-date-tests-2/pub-date-test-6/pub-date-test-6.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/pub-id-tests/final-pub-id-test-1/final-pub-id-test-1.sch
+++ b/test/tests/gen/pub-id-tests/final-pub-id-test-1/final-pub-id-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/pub-id-tests/final-pub-id-test-2/final-pub-id-test-2.sch
+++ b/test/tests/gen/pub-id-tests/final-pub-id-test-2/final-pub-id-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/pub-id-tests/pre-pub-id-test-1/pre-pub-id-test-1.sch
+++ b/test/tests/gen/pub-id-tests/pre-pub-id-test-1/pre-pub-id-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/pub-id-tests/pre-pub-id-test-2/pre-pub-id-test-2.sch
+++ b/test/tests/gen/pub-id-tests/pre-pub-id-test-2/pre-pub-id-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/pub-id-tests/pub-id-doi-test-1/pub-id-doi-test-1.sch
+++ b/test/tests/gen/pub-id-tests/pub-id-doi-test-1/pub-id-doi-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/pub-id-tests/pub-id-doi-test-2/pub-id-doi-test-2.sch
+++ b/test/tests/gen/pub-id-tests/pub-id-doi-test-2/pub-id-doi-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/pub-id-tests/pub-id-test-3/pub-id-test-3.sch
+++ b/test/tests/gen/pub-id-tests/pub-id-test-3/pub-id-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/pub-id-tests/pub-id-test-4/pub-id-test-4.sch
+++ b/test/tests/gen/pub-id-tests/pub-id-test-4/pub-id-test-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/publisher-name-tests/pub-name-newspaper/pub-name-newspaper.sch
+++ b/test/tests/gen/publisher-name-tests/pub-name-newspaper/pub-name-newspaper.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/publisher-name-tests/pub-name-replacement-character-presence/pub-name-replacement-character-presence.sch
+++ b/test/tests/gen/publisher-name-tests/pub-name-replacement-character-presence/pub-name-replacement-character-presence.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/publisher-name-tests/publisher-name-colon/publisher-name-colon.sch
+++ b/test/tests/gen/publisher-name-tests/publisher-name-colon/publisher-name-colon.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/publisher-name-tests/publisher-name-inc/publisher-name-inc.sch
+++ b/test/tests/gen/publisher-name-tests/publisher-name-inc/publisher-name-inc.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/pubmed-link-2/final-pmid-spacing-table/final-pmid-spacing-table.sch
+++ b/test/tests/gen/pubmed-link-2/final-pmid-spacing-table/final-pmid-spacing-table.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/pubmed-link-2/pre-pmid-spacing-table/pre-pmid-spacing-table.sch
+++ b/test/tests/gen/pubmed-link-2/pre-pmid-spacing-table/pre-pmid-spacing-table.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/pubmed-link/pmc-presence/pmc-presence.sch
+++ b/test/tests/gen/pubmed-link/pmc-presence/pmc-presence.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/pubmed-link/pubmed-presence/pubmed-presence.sch
+++ b/test/tests/gen/pubmed-link/pubmed-presence/pubmed-presence.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ra-body-tests/ra-sec-test-1/ra-sec-test-1.sch
+++ b/test/tests/gen/ra-body-tests/ra-sec-test-1/ra-sec-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ra-body-tests/ra-sec-test-2/ra-sec-test-2.sch
+++ b/test/tests/gen/ra-body-tests/ra-sec-test-2/ra-sec-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ra-body-tests/ra-sec-test-3/ra-sec-test-3.sch
+++ b/test/tests/gen/ra-body-tests/ra-sec-test-3/ra-sec-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ra-body-tests/ra-sec-test-4/ra-sec-test-4.sch
+++ b/test/tests/gen/ra-body-tests/ra-sec-test-4/ra-sec-test-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ref-article-title-tests/a-title-replacement-character-presence/a-title-replacement-character-presence.sch
+++ b/test/tests/gen/ref-article-title-tests/a-title-replacement-character-presence/a-title-replacement-character-presence.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ref-article-title-tests/article-title-child-1/article-title-child-1.sch
+++ b/test/tests/gen/ref-article-title-tests/article-title-child-1/article-title-child-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ref-article-title-tests/article-title-correction-check/article-title-correction-check.sch
+++ b/test/tests/gen/ref-article-title-tests/article-title-correction-check/article-title-correction-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ref-article-title-tests/article-title-fullstop-check-1/article-title-fullstop-check-1.sch
+++ b/test/tests/gen/ref-article-title-tests/article-title-fullstop-check-1/article-title-fullstop-check-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ref-article-title-tests/article-title-fullstop-check-2/article-title-fullstop-check-2.sch
+++ b/test/tests/gen/ref-article-title-tests/article-title-fullstop-check-2/article-title-fullstop-check-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ref-article-title-tests/article-title-fullstop-check-3/article-title-fullstop-check-3.sch
+++ b/test/tests/gen/ref-article-title-tests/article-title-fullstop-check-3/article-title-fullstop-check-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ref-article-title-tests/article-title-journal-check/article-title-journal-check.sch
+++ b/test/tests/gen/ref-article-title-tests/article-title-journal-check/article-title-journal-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ref-book-source-tests/report-book-source-test/report-book-source-test.sch
+++ b/test/tests/gen/ref-book-source-tests/report-book-source-test/report-book-source-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ref-chapter-title-tests/report-chapter-title-test/report-chapter-title-test.sch
+++ b/test/tests/gen/ref-chapter-title-tests/report-chapter-title-test/report-chapter-title-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ref-given-names/ref-given-names-test-1/ref-given-names-test-1.sch
+++ b/test/tests/gen/ref-given-names/ref-given-names-test-1/ref-given-names-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ref-link-mandate/final-ref-link-presence/final-ref-link-presence.sch
+++ b/test/tests/gen/ref-link-mandate/final-ref-link-presence/final-ref-link-presence.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ref-link-mandate/pre-ref-link-presence/pre-ref-link-presence.sch
+++ b/test/tests/gen/ref-link-mandate/pre-ref-link-presence/pre-ref-link-presence.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ref-list-title-tests/ref-list-distinct-1/ref-list-distinct-1.sch
+++ b/test/tests/gen/ref-list-title-tests/ref-list-distinct-1/ref-list-distinct-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ref-list-title-tests/ref-list-title-test/ref-list-title-test.sch
+++ b/test/tests/gen/ref-list-title-tests/ref-list-title-test/ref-list-title-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ref-name-tests/all-caps-surname/all-caps-surname.sch
+++ b/test/tests/gen/ref-name-tests/all-caps-surname/all-caps-surname.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ref-name-tests/author-test-1/author-test-1.sch
+++ b/test/tests/gen/ref-name-tests/author-test-1/author-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ref-name-tests/author-test-2/author-test-2.sch
+++ b/test/tests/gen/ref-name-tests/author-test-2/author-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ref-name-tests/author-test-3/author-test-3.sch
+++ b/test/tests/gen/ref-name-tests/author-test-3/author-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ref-name-tests/given-names-count-2/given-names-count-2.sch
+++ b/test/tests/gen/ref-name-tests/given-names-count-2/given-names-count-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ref-name-tests/given-names-count/given-names-count.sch
+++ b/test/tests/gen/ref-name-tests/given-names-count/given-names-count.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ref-name-tests/surname-count/surname-count.sch
+++ b/test/tests/gen/ref-name-tests/surname-count/surname-count.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ref-name-tests/surname-ellipsis-check/surname-ellipsis-check.sch
+++ b/test/tests/gen/ref-name-tests/surname-ellipsis-check/surname-ellipsis-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ref-name-tests/surname-number-check/surname-number-check.sch
+++ b/test/tests/gen/ref-name-tests/surname-number-check/surname-number-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ref-xref-conformance/final-ref-xref-test-1/final-ref-xref-test-1.sch
+++ b/test/tests/gen/ref-xref-conformance/final-ref-xref-test-1/final-ref-xref-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ref-xref-conformance/final-ref-xref-test-4/final-ref-xref-test-4.sch
+++ b/test/tests/gen/ref-xref-conformance/final-ref-xref-test-4/final-ref-xref-test-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ref-xref-conformance/pre-ref-xref-test-1/pre-ref-xref-test-1.sch
+++ b/test/tests/gen/ref-xref-conformance/pre-ref-xref-test-1/pre-ref-xref-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ref-xref-conformance/pre-ref-xref-test-4/pre-ref-xref-test-4.sch
+++ b/test/tests/gen/ref-xref-conformance/pre-ref-xref-test-4/pre-ref-xref-test-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ref-xref-conformance/ref-xref-test-10/ref-xref-test-10.sch
+++ b/test/tests/gen/ref-xref-conformance/ref-xref-test-10/ref-xref-test-10.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ref-xref-conformance/ref-xref-test-11/ref-xref-test-11.sch
+++ b/test/tests/gen/ref-xref-conformance/ref-xref-test-11/ref-xref-test-11.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ref-xref-conformance/ref-xref-test-12/ref-xref-test-12.sch
+++ b/test/tests/gen/ref-xref-conformance/ref-xref-test-12/ref-xref-test-12.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ref-xref-conformance/ref-xref-test-13/ref-xref-test-13.sch
+++ b/test/tests/gen/ref-xref-conformance/ref-xref-test-13/ref-xref-test-13.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ref-xref-conformance/ref-xref-test-14/ref-xref-test-14.sch
+++ b/test/tests/gen/ref-xref-conformance/ref-xref-test-14/ref-xref-test-14.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ref-xref-conformance/ref-xref-test-15/ref-xref-test-15.sch
+++ b/test/tests/gen/ref-xref-conformance/ref-xref-test-15/ref-xref-test-15.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ref-xref-conformance/ref-xref-test-16/ref-xref-test-16.sch
+++ b/test/tests/gen/ref-xref-conformance/ref-xref-test-16/ref-xref-test-16.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ref-xref-conformance/ref-xref-test-17/ref-xref-test-17.sch
+++ b/test/tests/gen/ref-xref-conformance/ref-xref-test-17/ref-xref-test-17.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ref-xref-conformance/ref-xref-test-18/ref-xref-test-18.sch
+++ b/test/tests/gen/ref-xref-conformance/ref-xref-test-18/ref-xref-test-18.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ref-xref-conformance/ref-xref-test-19/ref-xref-test-19.sch
+++ b/test/tests/gen/ref-xref-conformance/ref-xref-test-19/ref-xref-test-19.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ref-xref-conformance/ref-xref-test-2/ref-xref-test-2.sch
+++ b/test/tests/gen/ref-xref-conformance/ref-xref-test-2/ref-xref-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ref-xref-conformance/ref-xref-test-20/ref-xref-test-20.sch
+++ b/test/tests/gen/ref-xref-conformance/ref-xref-test-20/ref-xref-test-20.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ref-xref-conformance/ref-xref-test-21/ref-xref-test-21.sch
+++ b/test/tests/gen/ref-xref-conformance/ref-xref-test-21/ref-xref-test-21.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ref-xref-conformance/ref-xref-test-22/ref-xref-test-22.sch
+++ b/test/tests/gen/ref-xref-conformance/ref-xref-test-22/ref-xref-test-22.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ref-xref-conformance/ref-xref-test-26/ref-xref-test-26.sch
+++ b/test/tests/gen/ref-xref-conformance/ref-xref-test-26/ref-xref-test-26.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ref-xref-conformance/ref-xref-test-27/ref-xref-test-27.sch
+++ b/test/tests/gen/ref-xref-conformance/ref-xref-test-27/ref-xref-test-27.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ref-xref-conformance/ref-xref-test-28/ref-xref-test-28.sch
+++ b/test/tests/gen/ref-xref-conformance/ref-xref-test-28/ref-xref-test-28.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ref-xref-conformance/ref-xref-test-29/ref-xref-test-29.sch
+++ b/test/tests/gen/ref-xref-conformance/ref-xref-test-29/ref-xref-test-29.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ref-xref-conformance/ref-xref-test-3/ref-xref-test-3.sch
+++ b/test/tests/gen/ref-xref-conformance/ref-xref-test-3/ref-xref-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ref-xref-conformance/ref-xref-test-5/ref-xref-test-5.sch
+++ b/test/tests/gen/ref-xref-conformance/ref-xref-test-5/ref-xref-test-5.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ref-xref-conformance/ref-xref-test-7/ref-xref-test-7.sch
+++ b/test/tests/gen/ref-xref-conformance/ref-xref-test-7/ref-xref-test-7.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ref-xref-formatting/ref-xref-child-test/ref-xref-child-test.sch
+++ b/test/tests/gen/ref-xref-formatting/ref-xref-child-test/ref-xref-child-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ref-xref-formatting/ref-xref-italic-child-test/ref-xref-italic-child-test.sch
+++ b/test/tests/gen/ref-xref-formatting/ref-xref-italic-child-test/ref-xref-italic-child-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ref-xref-formatting/ref-xref-parent-test/ref-xref-parent-test.sch
+++ b/test/tests/gen/ref-xref-formatting/ref-xref-parent-test/ref-xref-parent-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ref/err-elem-cit-high-1/err-elem-cit-high-1.sch
+++ b/test/tests/gen/ref/err-elem-cit-high-1/err-elem-cit-high-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ref/err-elem-cit-high-2-2/err-elem-cit-high-2-2.sch
+++ b/test/tests/gen/ref/err-elem-cit-high-2-2/err-elem-cit-high-2-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ref/err-elem-cit-high-3-1/err-elem-cit-high-3-1.sch
+++ b/test/tests/gen/ref/err-elem-cit-high-3-1/err-elem-cit-high-3-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ref/err-elem-cit-high-3-2/err-elem-cit-high-3-2.sch
+++ b/test/tests/gen/ref/err-elem-cit-high-3-2/err-elem-cit-high-3-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ref/err-elem-cit-high-3-3/err-elem-cit-high-3-3.sch
+++ b/test/tests/gen/ref/err-elem-cit-high-3-3/err-elem-cit-high-3-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/related-articles-conformance/related-articles-test-10/related-articles-test-10.sch
+++ b/test/tests/gen/related-articles-conformance/related-articles-test-10/related-articles-test-10.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/related-articles-conformance/related-articles-test-11/related-articles-test-11.sch
+++ b/test/tests/gen/related-articles-conformance/related-articles-test-11/related-articles-test-11.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/related-articles-conformance/related-articles-test-3/related-articles-test-3.sch
+++ b/test/tests/gen/related-articles-conformance/related-articles-test-3/related-articles-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/related-articles-conformance/related-articles-test-4/related-articles-test-4.sch
+++ b/test/tests/gen/related-articles-conformance/related-articles-test-4/related-articles-test-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/related-articles-conformance/related-articles-test-5/related-articles-test-5.sch
+++ b/test/tests/gen/related-articles-conformance/related-articles-test-5/related-articles-test-5.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/related-articles-conformance/related-articles-test-6/related-articles-test-6.sch
+++ b/test/tests/gen/related-articles-conformance/related-articles-test-6/related-articles-test-6.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/related-articles-ids/related-articles-test-7/related-articles-test-7.sch
+++ b/test/tests/gen/related-articles-ids/related-articles-test-7/related-articles-test-7.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/related-object-tests/related-object-ancetsor/related-object-ancetsor.sch
+++ b/test/tests/gen/related-object-tests/related-object-ancetsor/related-object-ancetsor.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/rep-fig-ids/resp-fig-id-test/resp-fig-id-test.sch
+++ b/test/tests/gen/rep-fig-ids/resp-fig-id-test/resp-fig-id-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/rep-fig-sup-ids/resp-fig-sup-id-test/resp-fig-sup-id-test.sch
+++ b/test/tests/gen/rep-fig-sup-ids/resp-fig-sup-id-test/resp-fig-sup-id-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/rep-fig-tests/reply-fig-test-2/reply-fig-test-2.sch
+++ b/test/tests/gen/rep-fig-tests/reply-fig-test-2/reply-fig-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/rep-fig-tests/resp-fig-test-2/resp-fig-test-2.sch
+++ b/test/tests/gen/rep-fig-tests/resp-fig-test-2/resp-fig-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/reply-body-tests/reply-body-test-1/reply-body-test-1.sch
+++ b/test/tests/gen/reply-body-tests/reply-body-test-1/reply-body-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/reply-body-tests/reply-body-test-2/reply-body-test-2.sch
+++ b/test/tests/gen/reply-body-tests/reply-body-test-2/reply-body-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/reply-disp-quote-tests/reply-disp-quote-test-1/reply-disp-quote-test-1.sch
+++ b/test/tests/gen/reply-disp-quote-tests/reply-disp-quote-test-1/reply-disp-quote-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/reply-front-tests/reply-front-test-1/reply-front-test-1.sch
+++ b/test/tests/gen/reply-front-tests/reply-front-test-1/reply-front-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/reply-missing-disp-quote-tests-2/reply-missing-disp-quote-test-2/reply-missing-disp-quote-test-2.sch
+++ b/test/tests/gen/reply-missing-disp-quote-tests-2/reply-missing-disp-quote-test-2/reply-missing-disp-quote-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/reply-missing-disp-quote-tests/reply-missing-disp-quote-test-1/reply-missing-disp-quote-test-1.sch
+++ b/test/tests/gen/reply-missing-disp-quote-tests/reply-missing-disp-quote-test-1/reply-missing-disp-quote-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/reply-missing-table-tests/reply-missing-table-test/reply-missing-table-test.sch
+++ b/test/tests/gen/reply-missing-table-tests/reply-missing-table-test/reply-missing-table-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/reply-title-tests/reply-title-test/reply-title-test.sch
+++ b/test/tests/gen/reply-title-tests/reply-title-test/reply-title-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/res-data-sec/sec-test-3/sec-test-3.sch
+++ b/test/tests/gen/res-data-sec/sec-test-3/sec-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/res-ethics-sec/sec-test-4/sec-test-4.sch
+++ b/test/tests/gen/res-ethics-sec/sec-test-4/sec-test-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/research-advance-test/related-articles-test-1/related-articles-test-1.sch
+++ b/test/tests/gen/research-advance-test/related-articles-test-1/related-articles-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/research-article-ra-test/related-articles-test-12/related-articles-test-12.sch
+++ b/test/tests/gen/research-article-ra-test/related-articles-test-12/related-articles-test-12.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/research-article/final-test-r-article-d-letter-feat/final-test-r-article-d-letter-feat.sch
+++ b/test/tests/gen/research-article/final-test-r-article-d-letter-feat/final-test-r-article-d-letter-feat.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/research-article/final-test-r-article-d-letter/final-test-r-article-d-letter.sch
+++ b/test/tests/gen/research-article/final-test-r-article-d-letter/final-test-r-article-d-letter.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/research-article/pre-test-r-article-d-letter/pre-test-r-article-d-letter.sch
+++ b/test/tests/gen/research-article/pre-test-r-article-d-letter/pre-test-r-article-d-letter.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/research-article/test-r-article-a-reply/test-r-article-a-reply.sch
+++ b/test/tests/gen/research-article/test-r-article-a-reply/test-r-article-a-reply.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/resp-table-wrap-ids/resp-table-wrap-id-test/resp-table-wrap-id-test.sch
+++ b/test/tests/gen/resp-table-wrap-ids/resp-table-wrap-id-test/resp-table-wrap-id-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/retraction-test/related-articles-test-9/related-articles-test-9.sch
+++ b/test/tests/gen/retraction-test/related-articles-test-9/related-articles-test-9.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/retraction-tests/retr-COI-presence/retr-COI-presence.sch
+++ b/test/tests/gen/retraction-tests/retr-COI-presence/retr-COI-presence.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/retraction-tests/retr-SE-BRE/retr-SE-BRE.sch
+++ b/test/tests/gen/retraction-tests/retr-SE-BRE/retr-SE-BRE.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/retraction-tests/retr-abstract-presence/retr-abstract-presence.sch
+++ b/test/tests/gen/retraction-tests/retr-abstract-presence/retr-abstract-presence.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/retraction-tests/retr-aff-presence/retr-aff-presence.sch
+++ b/test/tests/gen/retraction-tests/retr-aff-presence/retr-aff-presence.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/retraction-tests/retr-back/retr-back.sch
+++ b/test/tests/gen/retraction-tests/retr-back/retr-back.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/retraction-tests/retr-impact-statement/retr-impact-statement.sch
+++ b/test/tests/gen/retraction-tests/retr-impact-statement/retr-impact-statement.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/retraction-tests/retr-self-uri-presence/retr-self-uri-presence.sch
+++ b/test/tests/gen/retraction-tests/retr-self-uri-presence/retr-self-uri-presence.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ro-kwd-group-tests/kwd-group-title/kwd-group-title.sch
+++ b/test/tests/gen/ro-kwd-group-tests/kwd-group-title/kwd-group-title.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ro-kwd-group-tests/ro-kwd-presence-test/ro-kwd-presence-test.sch
+++ b/test/tests/gen/ro-kwd-group-tests/ro-kwd-presence-test/ro-kwd-presence-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ro-kwd-tests/kwd-child-test/kwd-child-test.sch
+++ b/test/tests/gen/ro-kwd-tests/kwd-child-test/kwd-child-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/ro-kwd-tests/kwd-upper-case/kwd-upper-case.sch
+++ b/test/tests/gen/ro-kwd-tests/kwd-upper-case/kwd-upper-case.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/rrid-link/final-rrid-spacing/final-rrid-spacing.sch
+++ b/test/tests/gen/rrid-link/final-rrid-spacing/final-rrid-spacing.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/rrid-link/pre-rrid-spacing/pre-rrid-spacing.sch
+++ b/test/tests/gen/rrid-link/pre-rrid-spacing/pre-rrid-spacing.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/rrid-org-code/cell-spacing-test/cell-spacing-test.sch
+++ b/test/tests/gen/rrid-org-code/cell-spacing-test/cell-spacing-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/rrid-org-code/code-test/code-test.sch
+++ b/test/tests/gen/rrid-org-code/code-test/code-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/rrid-org-code/diabetes-1-test/diabetes-1-test.sch
+++ b/test/tests/gen/rrid-org-code/diabetes-1-test/diabetes-1-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/rrid-org-code/diabetes-2-test/diabetes-2-test.sch
+++ b/test/tests/gen/rrid-org-code/diabetes-2-test/diabetes-2-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/rrid-org-code/equal-spacing-test/equal-spacing-test.sch
+++ b/test/tests/gen/rrid-org-code/equal-spacing-test/equal-spacing-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/rrid-org-code/final-missing-url-test/final-missing-url-test.sch
+++ b/test/tests/gen/rrid-org-code/final-missing-url-test/final-missing-url-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/rrid-org-code/org-test/org-test.sch
+++ b/test/tests/gen/rrid-org-code/org-test/org-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/rrid-org-code/ring-diacritic-symbol-test/ring-diacritic-symbol-test.sch
+++ b/test/tests/gen/rrid-org-code/ring-diacritic-symbol-test/ring-diacritic-symbol-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/rrid-org-code/rrid-test/rrid-test.sch
+++ b/test/tests/gen/rrid-org-code/rrid-test/rrid-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/rrid-org-code/unlinked-url/unlinked-url.sch
+++ b/test/tests/gen/rrid-org-code/unlinked-url/unlinked-url.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/rrid-org-code/year-style-test/year-style-test.sch
+++ b/test/tests/gen/rrid-org-code/year-style-test/year-style-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/sec-tests/sec-test-1/sec-test-1.sch
+++ b/test/tests/gen/sec-tests/sec-test-1/sec-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/sec-tests/sec-test-2/sec-test-2.sch
+++ b/test/tests/gen/sec-tests/sec-test-2/sec-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/sec-tests/sec-test-5/sec-test-5.sch
+++ b/test/tests/gen/sec-tests/sec-test-5/sec-test-5.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/sec-title-conformity/sec-title-abbr-check/sec-title-abbr-check.sch
+++ b/test/tests/gen/sec-title-conformity/sec-title-abbr-check/sec-title-abbr-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/sec-title-conformity/sec-title-appendix-check-2/sec-title-appendix-check-2.sch
+++ b/test/tests/gen/sec-title-conformity/sec-title-appendix-check-2/sec-title-appendix-check-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/sec-title-conformity/sec-title-appendix-check/sec-title-appendix-check.sch
+++ b/test/tests/gen/sec-title-conformity/sec-title-appendix-check/sec-title-appendix-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/sec-title-conformity/sec-title-bold/sec-title-bold.sch
+++ b/test/tests/gen/sec-title-conformity/sec-title-bold/sec-title-bold.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/sec-title-conformity/sec-title-content-mandate/sec-title-content-mandate.sch
+++ b/test/tests/gen/sec-title-conformity/sec-title-content-mandate/sec-title-content-mandate.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/sec-title-conformity/sec-title-dimension/sec-title-dimension.sch
+++ b/test/tests/gen/sec-title-conformity/sec-title-dimension/sec-title-dimension.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/sec-title-conformity/sec-title-dna/sec-title-dna.sch
+++ b/test/tests/gen/sec-title-conformity/sec-title-dna/sec-title-dna.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/sec-title-conformity/sec-title-full-stop/sec-title-full-stop.sch
+++ b/test/tests/gen/sec-title-conformity/sec-title-full-stop/sec-title-full-stop.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/sec-title-conformity/sec-title-hiv/sec-title-hiv.sch
+++ b/test/tests/gen/sec-title-conformity/sec-title-hiv/sec-title-hiv.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/sec-title-conformity/sec-title-italic/sec-title-italic.sch
+++ b/test/tests/gen/sec-title-conformity/sec-title-italic/sec-title-italic.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/sec-title-conformity/sec-title-list-check/sec-title-list-check.sch
+++ b/test/tests/gen/sec-title-conformity/sec-title-list-check/sec-title-list-check.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/sec-title-conformity/sec-title-rna/sec-title-rna.sch
+++ b/test/tests/gen/sec-title-conformity/sec-title-rna/sec-title-rna.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/sec-title-conformity/sec-title-underline/sec-title-underline.sch
+++ b/test/tests/gen/sec-title-conformity/sec-title-underline/sec-title-underline.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/sec-title-tests/sec-type-title-test/sec-type-title-test.sch
+++ b/test/tests/gen/sec-title-tests/sec-type-title-test/sec-type-title-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/section-title-tests/section-title-test-1/section-title-test-1.sch
+++ b/test/tests/gen/section-title-tests/section-title-test-1/section-title-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/software-ref-tests/R-test-1/R-test-1.sch
+++ b/test/tests/gen/software-ref-tests/R-test-1/R-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/software-ref-tests/R-test-2/R-test-2.sch
+++ b/test/tests/gen/software-ref-tests/R-test-2/R-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/software-ref-tests/R-test-3/R-test-3.sch
+++ b/test/tests/gen/software-ref-tests/R-test-3/R-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/software-ref-tests/R-test-4/R-test-4.sch
+++ b/test/tests/gen/software-ref-tests/R-test-4/R-test-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/software-ref-tests/R-test-5/R-test-5.sch
+++ b/test/tests/gen/software-ref-tests/R-test-5/R-test-5.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/software-ref-tests/R-test-6/R-test-6.sch
+++ b/test/tests/gen/software-ref-tests/R-test-6/R-test-6.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/software-ref-tests/R-test-7/R-test-7.sch
+++ b/test/tests/gen/software-ref-tests/R-test-7/R-test-7.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/software-ref-tests/ref-software-test-1/ref-software-test-1.sch
+++ b/test/tests/gen/software-ref-tests/ref-software-test-1/ref-software-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/software-ref-tests/ref-software-test-2/ref-software-test-2.sch
+++ b/test/tests/gen/software-ref-tests/ref-software-test-2/ref-software-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/software-ref-tests/ref-software-test-3/ref-software-test-3.sch
+++ b/test/tests/gen/software-ref-tests/ref-software-test-3/ref-software-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/software-ref-tests/ref-software-test-4/ref-software-test-4.sch
+++ b/test/tests/gen/software-ref-tests/ref-software-test-4/ref-software-test-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/software-ref-tests/ref-software-test-5/ref-software-test-5.sch
+++ b/test/tests/gen/software-ref-tests/ref-software-test-5/ref-software-test-5.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/software-ref-tests/ref-software-test-6/ref-software-test-6.sch
+++ b/test/tests/gen/software-ref-tests/ref-software-test-6/ref-software-test-6.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/software-ref-tests/software-replacement-character-presence/software-replacement-character-presence.sch
+++ b/test/tests/gen/software-ref-tests/software-replacement-character-presence/software-replacement-character-presence.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/source-data-specific-tests/fig-code-test-1/fig-code-test-1.sch
+++ b/test/tests/gen/source-data-specific-tests/fig-code-test-1/fig-code-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/source-data-specific-tests/fig-data-test-1/fig-data-test-1.sch
+++ b/test/tests/gen/source-data-specific-tests/fig-data-test-1/fig-data-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/strike-tests/final-strike-flag/final-strike-flag.sch
+++ b/test/tests/gen/strike-tests/final-strike-flag/final-strike-flag.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/sub-article-ext-link-tests/paper-pile-test/paper-pile-test.sch
+++ b/test/tests/gen/sub-article-ext-link-tests/paper-pile-test/paper-pile-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/suffix-tests/suffix-assert/suffix-assert.sch
+++ b/test/tests/gen/suffix-tests/suffix-assert/suffix-assert.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/suffix-tests/suffix-child-test/suffix-child-test.sch
+++ b/test/tests/gen/suffix-tests/suffix-child-test/suffix-child-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/supp-file-xref-conformance/supp-file-xref-conformity-1/supp-file-xref-conformity-1.sch
+++ b/test/tests/gen/supp-file-xref-conformance/supp-file-xref-conformity-1/supp-file-xref-conformity-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/supp-file-xref-conformance/supp-file-xref-conformity-2/supp-file-xref-conformity-2.sch
+++ b/test/tests/gen/supp-file-xref-conformance/supp-file-xref-conformity-2/supp-file-xref-conformity-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/supp-file-xref-conformance/supp-file-xref-conformity-3/supp-file-xref-conformity-3.sch
+++ b/test/tests/gen/supp-file-xref-conformance/supp-file-xref-conformity-3/supp-file-xref-conformity-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/supp-file-xref-conformance/supp-file-xref-conformity-4/supp-file-xref-conformity-4.sch
+++ b/test/tests/gen/supp-file-xref-conformance/supp-file-xref-conformity-4/supp-file-xref-conformity-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/supp-file-xref-conformance/supp-file-xref-conformity-5/supp-file-xref-conformity-5.sch
+++ b/test/tests/gen/supp-file-xref-conformance/supp-file-xref-conformity-5/supp-file-xref-conformity-5.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/supp-file-xref-conformance/supp-file-xref-test-1/supp-file-xref-test-1.sch
+++ b/test/tests/gen/supp-file-xref-conformance/supp-file-xref-test-1/supp-file-xref-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/supp-file-xref-conformance/supp-xref-test-2/supp-xref-test-2.sch
+++ b/test/tests/gen/supp-file-xref-conformance/supp-xref-test-2/supp-xref-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/supp-file-xref-conformance/supp-xref-test-3/supp-xref-test-3.sch
+++ b/test/tests/gen/supp-file-xref-conformance/supp-xref-test-3/supp-xref-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/supp-file-xref-conformance/supp-xref-test-4/supp-xref-test-4.sch
+++ b/test/tests/gen/supp-file-xref-conformance/supp-xref-test-4/supp-xref-test-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/supp-file-xref-conformance/supp-xref-test-5/supp-xref-test-5.sch
+++ b/test/tests/gen/supp-file-xref-conformance/supp-xref-test-5/supp-xref-test-5.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/supp-file-xref-conformance/supp-xref-test-6/supp-xref-test-6.sch
+++ b/test/tests/gen/supp-file-xref-conformance/supp-xref-test-6/supp-xref-test-6.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/supplementary-material-children/supplementary-material-child-conformance/supplementary-material-child-conformance.sch
+++ b/test/tests/gen/supplementary-material-children/supplementary-material-child-conformance/supplementary-material-child-conformance.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/supplementary-material-tests/final-supplementary-material-test-3/final-supplementary-material-test-3.sch
+++ b/test/tests/gen/supplementary-material-tests/final-supplementary-material-test-3/final-supplementary-material-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/supplementary-material-tests/final-supplementary-material-test-5/final-supplementary-material-test-5.sch
+++ b/test/tests/gen/supplementary-material-tests/final-supplementary-material-test-5/final-supplementary-material-test-5.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/supplementary-material-tests/pre-supplementary-material-test-3/pre-supplementary-material-test-3.sch
+++ b/test/tests/gen/supplementary-material-tests/pre-supplementary-material-test-3/pre-supplementary-material-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/supplementary-material-tests/pre-supplementary-material-test-5/pre-supplementary-material-test-5.sch
+++ b/test/tests/gen/supplementary-material-tests/pre-supplementary-material-test-5/pre-supplementary-material-test-5.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/supplementary-material-tests/source-code-test-1/source-code-test-1.sch
+++ b/test/tests/gen/supplementary-material-tests/source-code-test-1/source-code-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/supplementary-material-tests/source-code-test-2/source-code-test-2.sch
+++ b/test/tests/gen/supplementary-material-tests/source-code-test-2/source-code-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/supplementary-material-tests/supplementary-material-test-1/supplementary-material-test-1.sch
+++ b/test/tests/gen/supplementary-material-tests/supplementary-material-test-1/supplementary-material-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/supplementary-material-tests/supplementary-material-test-10/supplementary-material-test-10.sch
+++ b/test/tests/gen/supplementary-material-tests/supplementary-material-test-10/supplementary-material-test-10.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/supplementary-material-tests/supplementary-material-test-11/supplementary-material-test-11.sch
+++ b/test/tests/gen/supplementary-material-tests/supplementary-material-test-11/supplementary-material-test-11.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/supplementary-material-tests/supplementary-material-test-2/supplementary-material-test-2.sch
+++ b/test/tests/gen/supplementary-material-tests/supplementary-material-test-2/supplementary-material-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/supplementary-material-tests/supplementary-material-test-6/supplementary-material-test-6.sch
+++ b/test/tests/gen/supplementary-material-tests/supplementary-material-test-6/supplementary-material-test-6.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/supplementary-material-tests/supplementary-material-test-7/supplementary-material-test-7.sch
+++ b/test/tests/gen/supplementary-material-tests/supplementary-material-test-7/supplementary-material-test-7.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/supplementary-material-tests/supplementary-material-test-8/supplementary-material-test-8.sch
+++ b/test/tests/gen/supplementary-material-tests/supplementary-material-test-8/supplementary-material-test-8.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/supplementary-material-tests/supplementary-material-test-9/supplementary-material-test-9.sch
+++ b/test/tests/gen/supplementary-material-tests/supplementary-material-test-9/supplementary-material-test-9.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/supplementary-material-title-tests/supplementary-material-title-test-1/supplementary-material-title-test-1.sch
+++ b/test/tests/gen/supplementary-material-title-tests/supplementary-material-title-test-1/supplementary-material-title-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/supplementary-material-title-tests/supplementary-material-title-test-2/supplementary-material-title-test-2.sch
+++ b/test/tests/gen/supplementary-material-title-tests/supplementary-material-title-test-2/supplementary-material-title-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/supplementary-material-title-tests/supplementary-material-title-test-3/supplementary-material-title-test-3.sch
+++ b/test/tests/gen/supplementary-material-title-tests/supplementary-material-title-test-3/supplementary-material-title-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/supplementary-material-title-tests/supplementary-material-title-test-4/supplementary-material-title-test-4.sch
+++ b/test/tests/gen/supplementary-material-title-tests/supplementary-material-title-test-4/supplementary-material-title-test-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/supplementary-material-title-tests/supplementary-material-title-test-5/supplementary-material-title-test-5.sch
+++ b/test/tests/gen/supplementary-material-title-tests/supplementary-material-title-test-5/supplementary-material-title-test-5.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/supplementary-material-title-tests/supplementary-material-title-test-6/supplementary-material-title-test-6.sch
+++ b/test/tests/gen/supplementary-material-title-tests/supplementary-material-title-test-6/supplementary-material-title-test-6.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/supplementary-material-title-tests/supplementary-material-title-test-7/supplementary-material-title-test-7.sch
+++ b/test/tests/gen/supplementary-material-title-tests/supplementary-material-title-test-7/supplementary-material-title-test-7.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/supplementary-material-title-tests/supplementary-material-title-test-8/supplementary-material-title-test-8.sch
+++ b/test/tests/gen/supplementary-material-title-tests/supplementary-material-title-test-8/supplementary-material-title-test-8.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/surname-tests/surname-test-2/surname-test-2.sch
+++ b/test/tests/gen/surname-tests/surname-test-2/surname-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/surname-tests/surname-test-3/surname-test-3.sch
+++ b/test/tests/gen/surname-tests/surname-test-3/surname-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/surname-tests/surname-test-4/surname-test-4.sch
+++ b/test/tests/gen/surname-tests/surname-test-4/surname-test-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/surname-tests/surname-test-5/surname-test-5.sch
+++ b/test/tests/gen/surname-tests/surname-test-5/surname-test-5.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/surname-tests/surname-test-6/surname-test-6.sch
+++ b/test/tests/gen/surname-tests/surname-test-6/surname-test-6.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/surname-tests/surname-test-7/surname-test-7.sch
+++ b/test/tests/gen/surname-tests/surname-test-7/surname-test-7.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/surname-tests/surname-test-8/surname-test-8.sch
+++ b/test/tests/gen/surname-tests/surname-test-8/surname-test-8.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/surname-tests/surname-test-9/surname-test-9.sch
+++ b/test/tests/gen/surname-tests/surname-test-9/surname-test-9.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/table-cell-tests/table-cell-1/table-cell-1.sch
+++ b/test/tests/gen/table-cell-tests/table-cell-1/table-cell-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/table-fn-label-tests/table-fn-label-test-1/table-fn-label-test-1.sch
+++ b/test/tests/gen/table-fn-label-tests/table-fn-label-test-1/table-fn-label-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/table-source-code-tests/table-code-test-2/table-code-test-2.sch
+++ b/test/tests/gen/table-source-code-tests/table-code-test-2/table-code-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/table-source-data-tests/table-data-test-2/table-data-test-2.sch
+++ b/test/tests/gen/table-source-data-tests/table-data-test-2/table-data-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/table-tests/table-test-1/table-test-1.sch
+++ b/test/tests/gen/table-tests/table-test-1/table-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/table-tests/table-test-2/table-test-2.sch
+++ b/test/tests/gen/table-tests/table-test-2/table-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/table-tests/table-test-3/table-test-3.sch
+++ b/test/tests/gen/table-tests/table-test-3/table-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/table-title-tests-2/table-title-test-2/table-title-test-2.sch
+++ b/test/tests/gen/table-title-tests-2/table-title-test-2/table-title-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/table-title-tests-2/table-title-test-3/table-title-test-3.sch
+++ b/test/tests/gen/table-title-tests-2/table-title-test-3/table-title-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/table-title-tests-2/table-title-test-4/table-title-test-4.sch
+++ b/test/tests/gen/table-title-tests-2/table-title-test-4/table-title-test-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/table-title-tests-2/table-title-test-5/table-title-test-5.sch
+++ b/test/tests/gen/table-title-tests-2/table-title-test-5/table-title-test-5.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/table-title-tests-2/table-title-test-6/table-title-test-6.sch
+++ b/test/tests/gen/table-title-tests-2/table-title-test-6/table-title-test-6.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/table-title-tests/final-table-title-test-1/final-table-title-test-1.sch
+++ b/test/tests/gen/table-title-tests/final-table-title-test-1/final-table-title-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/table-title-tests/pre-table-title-test-1/pre-table-title-test-1.sch
+++ b/test/tests/gen/table-title-tests/pre-table-title-test-1/pre-table-title-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/table-wrap-children/table-wrap-child-conformance/table-wrap-child-conformance.sch
+++ b/test/tests/gen/table-wrap-children/table-wrap-child-conformance/table-wrap-child-conformance.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/table-wrap-ids/table-wrap-id-test/table-wrap-id-test.sch
+++ b/test/tests/gen/table-wrap-ids/table-wrap-id-test/table-wrap-id-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/table-wrap-tests/feat-table-wrap-cite-1/feat-table-wrap-cite-1.sch
+++ b/test/tests/gen/table-wrap-tests/feat-table-wrap-cite-1/feat-table-wrap-cite-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/table-wrap-tests/final-table-wrap-cite-1/final-table-wrap-cite-1.sch
+++ b/test/tests/gen/table-wrap-tests/final-table-wrap-cite-1/final-table-wrap-cite-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/table-wrap-tests/kr-table-not-tagged-2/kr-table-not-tagged-2.sch
+++ b/test/tests/gen/table-wrap-tests/kr-table-not-tagged-2/kr-table-not-tagged-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/table-wrap-tests/kr-table-not-tagged/kr-table-not-tagged.sch
+++ b/test/tests/gen/table-wrap-tests/kr-table-not-tagged/kr-table-not-tagged.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/table-wrap-tests/kr-table-wrap-test-1/kr-table-wrap-test-1.sch
+++ b/test/tests/gen/table-wrap-tests/kr-table-wrap-test-1/kr-table-wrap-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/table-wrap-tests/pre-table-wrap-cite-1/pre-table-wrap-cite-1.sch
+++ b/test/tests/gen/table-wrap-tests/pre-table-wrap-cite-1/pre-table-wrap-cite-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/table-wrap-tests/table-wrap-test-1/table-wrap-test-1.sch
+++ b/test/tests/gen/table-wrap-tests/table-wrap-test-1/table-wrap-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/table-wrap-tests/table-wrap-test-2/table-wrap-test-2.sch
+++ b/test/tests/gen/table-wrap-tests/table-wrap-test-2/table-wrap-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/table-wrap-tests/table-wrap-test-3/table-wrap-test-3.sch
+++ b/test/tests/gen/table-wrap-tests/table-wrap-test-3/table-wrap-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/table-wrap-tests/table-wrap-test-4/table-wrap-test-4.sch
+++ b/test/tests/gen/table-wrap-tests/table-wrap-test-4/table-wrap-test-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/table-xref-conformance/table-xref-conformity-1/table-xref-conformity-1.sch
+++ b/test/tests/gen/table-xref-conformance/table-xref-conformity-1/table-xref-conformity-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/table-xref-conformance/table-xref-conformity-2/table-xref-conformity-2.sch
+++ b/test/tests/gen/table-xref-conformance/table-xref-conformity-2/table-xref-conformity-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/table-xref-conformance/table-xref-conformity-3/table-xref-conformity-3.sch
+++ b/test/tests/gen/table-xref-conformance/table-xref-conformity-3/table-xref-conformity-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/table-xref-conformance/table-xref-conformity-4/table-xref-conformity-4.sch
+++ b/test/tests/gen/table-xref-conformance/table-xref-conformity-4/table-xref-conformity-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/table-xref-conformance/table-xref-test-1/table-xref-test-1.sch
+++ b/test/tests/gen/table-xref-conformance/table-xref-test-1/table-xref-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/table-xref-conformance/table-xref-test-2/table-xref-test-2.sch
+++ b/test/tests/gen/table-xref-conformance/table-xref-test-2/table-xref-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/table-xref-conformance/table-xref-test-3/table-xref-test-3.sch
+++ b/test/tests/gen/table-xref-conformance/table-xref-test-3/table-xref-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/table-xref-conformance/table-xref-test-4/table-xref-test-4.sch
+++ b/test/tests/gen/table-xref-conformance/table-xref-test-4/table-xref-test-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/table-xref-conformance/table-xref-test-5/table-xref-test-5.sch
+++ b/test/tests/gen/table-xref-conformance/table-xref-test-5/table-xref-test-5.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/table-xref-conformance/table-xref-test-6/table-xref-test-6.sch
+++ b/test/tests/gen/table-xref-conformance/table-xref-test-6/table-xref-test-6.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/tbody-tests/tbody-test-1/tbody-test-1.sch
+++ b/test/tests/gen/tbody-tests/tbody-test-1/tbody-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/td-child-tests/td-child-test/td-child-test.sch
+++ b/test/tests/gen/td-child-tests/td-child-test/td-child-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/test-article-categories/disp-subj-test/disp-subj-test.sch
+++ b/test/tests/gen/test-article-categories/disp-subj-test/disp-subj-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/test-article-categories/disp-subj-test2/disp-subj-test2.sch
+++ b/test/tests/gen/test-article-categories/disp-subj-test2/disp-subj-test2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/test-article-categories/head-subj-distinct-test/head-subj-distinct-test.sch
+++ b/test/tests/gen/test-article-categories/head-subj-distinct-test/head-subj-distinct-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/test-article-categories/head-subj-test1/head-subj-test1.sch
+++ b/test/tests/gen/test-article-categories/head-subj-test1/head-subj-test1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/test-article-categories/head-subj-test2/head-subj-test2.sch
+++ b/test/tests/gen/test-article-categories/head-subj-test2/head-subj-test2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/test-article-categories/head-subj-test3/head-subj-test3.sch
+++ b/test/tests/gen/test-article-categories/head-subj-test3/head-subj-test3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/test-article-metadata/test-abstracts/test-abstracts.sch
+++ b/test/tests/gen/test-article-metadata/test-abstracts/test-abstracts.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/test-article-metadata/test-article-doi-1/test-article-doi-1.sch
+++ b/test/tests/gen/test-article-metadata/test-article-doi-1/test-article-doi-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/test-article-metadata/test-article-doi-2/test-article-doi-2.sch
+++ b/test/tests/gen/test-article-metadata/test-article-doi-2/test-article-doi-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/test-article-metadata/test-article-id/test-article-id.sch
+++ b/test/tests/gen/test-article-metadata/test-article-id/test-article-id.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/test-article-metadata/test-article-presence/test-article-presence.sch
+++ b/test/tests/gen/test-article-metadata/test-article-presence/test-article-presence.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/test-article-metadata/test-auth-kwd-group-presence-1/test-auth-kwd-group-presence-1.sch
+++ b/test/tests/gen/test-article-metadata/test-auth-kwd-group-presence-1/test-auth-kwd-group-presence-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/test-article-metadata/test-auth-kwd-group-presence-2/test-auth-kwd-group-presence-2.sch
+++ b/test/tests/gen/test-article-metadata/test-auth-kwd-group-presence-2/test-auth-kwd-group-presence-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/test-article-metadata/test-custom-meta-group-presence/test-custom-meta-group-presence.sch
+++ b/test/tests/gen/test-article-metadata/test-custom-meta-group-presence/test-custom-meta-group-presence.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/test-article-metadata/test-elocation-presence/test-elocation-presence.sch
+++ b/test/tests/gen/test-article-metadata/test-elocation-presence/test-elocation-presence.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/test-article-metadata/test-epub-date/test-epub-date.sch
+++ b/test/tests/gen/test-article-metadata/test-epub-date/test-epub-date.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/test-article-metadata/test-funding-group-presence/test-funding-group-presence.sch
+++ b/test/tests/gen/test-article-metadata/test-funding-group-presence/test-funding-group-presence.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/test-article-metadata/test-history-presence/test-history-presence.sch
+++ b/test/tests/gen/test-article-metadata/test-history-presence/test-history-presence.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/test-article-metadata/test-no-digest/test-no-digest.sch
+++ b/test/tests/gen/test-article-metadata/test-no-digest/test-no-digest.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/test-article-metadata/test-permissions-presence/test-permissions-presence.sch
+++ b/test/tests/gen/test-article-metadata/test-permissions-presence/test-permissions-presence.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/test-article-metadata/test-pub-collection-presence/test-pub-collection-presence.sch
+++ b/test/tests/gen/test-article-metadata/test-pub-collection-presence/test-pub-collection-presence.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/test-article-metadata/test-ro-kwd-group-presence-1/test-ro-kwd-group-presence-1.sch
+++ b/test/tests/gen/test-article-metadata/test-ro-kwd-group-presence-1/test-ro-kwd-group-presence-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/test-article-metadata/test-ro-kwd-group-presence-2/test-ro-kwd-group-presence-2.sch
+++ b/test/tests/gen/test-article-metadata/test-ro-kwd-group-presence-2/test-ro-kwd-group-presence-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/test-article-metadata/test-self-uri-att/test-self-uri-att.sch
+++ b/test/tests/gen/test-article-metadata/test-self-uri-att/test-self-uri-att.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/test-article-metadata/test-self-uri-pdf-1/test-self-uri-pdf-1.sch
+++ b/test/tests/gen/test-article-metadata/test-self-uri-pdf-1/test-self-uri-pdf-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/test-article-metadata/test-self-uri-pdf-2/test-self-uri-pdf-2.sch
+++ b/test/tests/gen/test-article-metadata/test-self-uri-pdf-2/test-self-uri-pdf-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/test-article-metadata/test-self-uri-presence/test-self-uri-presence.sch
+++ b/test/tests/gen/test-article-metadata/test-self-uri-presence/test-self-uri-presence.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/test-article-metadata/test-title-group-presence/test-title-group-presence.sch
+++ b/test/tests/gen/test-article-metadata/test-title-group-presence/test-title-group-presence.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/test-article-metadata/test-volume-contents/test-volume-contents.sch
+++ b/test/tests/gen/test-article-metadata/test-volume-contents/test-volume-contents.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/test-article-metadata/test-volume-presence/test-volume-presence.sch
+++ b/test/tests/gen/test-article-metadata/test-volume-presence/test-volume-presence.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/test-contrib-group/contrib-presence-test/contrib-presence-test.sch
+++ b/test/tests/gen/test-contrib-group/contrib-presence-test/contrib-presence-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/test-contrib-group/equal-count-test/equal-count-test.sch
+++ b/test/tests/gen/test-contrib-group/equal-count-test/equal-count-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/test-editor-contrib-group/editor-conformance-1/editor-conformance-1.sch
+++ b/test/tests/gen/test-editor-contrib-group/editor-conformance-1/editor-conformance-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/test-editor-contrib-group/editor-conformance-2/editor-conformance-2.sch
+++ b/test/tests/gen/test-editor-contrib-group/editor-conformance-2/editor-conformance-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/test-editors-contrib/editor-conformance-3/editor-conformance-3.sch
+++ b/test/tests/gen/test-editors-contrib/editor-conformance-3/editor-conformance-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/test-editors-contrib/editor-conformance-4/editor-conformance-4.sch
+++ b/test/tests/gen/test-editors-contrib/editor-conformance-4/editor-conformance-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/test-front/test-front-ameta/test-front-ameta.sch
+++ b/test/tests/gen/test-front/test-front-ameta/test-front-ameta.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/test-front/test-front-jmeta/test-front-jmeta.sch
+++ b/test/tests/gen/test-front/test-front-jmeta/test-front-jmeta.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/test-journal-meta/test-journal-nlm/test-journal-nlm.sch
+++ b/test/tests/gen/test-journal-meta/test-journal-nlm/test-journal-nlm.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/test-journal-meta/test-journal-pubid-1/test-journal-pubid-1.sch
+++ b/test/tests/gen/test-journal-meta/test-journal-pubid-1/test-journal-pubid-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/test-journal-meta/test-journal-pubid-2/test-journal-pubid-2.sch
+++ b/test/tests/gen/test-journal-meta/test-journal-pubid-2/test-journal-pubid-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/test-journal-meta/test-journal-pubid-3/test-journal-pubid-3.sch
+++ b/test/tests/gen/test-journal-meta/test-journal-pubid-3/test-journal-pubid-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/test-journal-meta/test-journal-pubid-4/test-journal-pubid-4.sch
+++ b/test/tests/gen/test-journal-meta/test-journal-pubid-4/test-journal-pubid-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/test-research-article-metadata/test-contrib-group-presence-1/test-contrib-group-presence-1.sch
+++ b/test/tests/gen/test-research-article-metadata/test-contrib-group-presence-1/test-contrib-group-presence-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/test-research-article-metadata/test-contrib-group-presence-2/test-contrib-group-presence-2.sch
+++ b/test/tests/gen/test-research-article-metadata/test-contrib-group-presence-2/test-contrib-group-presence-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/test-title-group/article-title-test-1/article-title-test-1.sch
+++ b/test/tests/gen/test-title-group/article-title-test-1/article-title-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/test-title-group/article-title-test-10/article-title-test-10.sch
+++ b/test/tests/gen/test-title-group/article-title-test-10/article-title-test-10.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/test-title-group/article-title-test-11/article-title-test-11.sch
+++ b/test/tests/gen/test-title-group/article-title-test-11/article-title-test-11.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/test-title-group/article-title-test-12/article-title-test-12.sch
+++ b/test/tests/gen/test-title-group/article-title-test-12/article-title-test-12.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/test-title-group/article-title-test-2/article-title-test-2.sch
+++ b/test/tests/gen/test-title-group/article-title-test-2/article-title-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/test-title-group/article-title-test-3/article-title-test-3.sch
+++ b/test/tests/gen/test-title-group/article-title-test-3/article-title-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/test-title-group/article-title-test-4/article-title-test-4.sch
+++ b/test/tests/gen/test-title-group/article-title-test-4/article-title-test-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/test-title-group/article-title-test-5/article-title-test-5.sch
+++ b/test/tests/gen/test-title-group/article-title-test-5/article-title-test-5.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/test-title-group/article-title-test-6/article-title-test-6.sch
+++ b/test/tests/gen/test-title-group/article-title-test-6/article-title-test-6.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/test-title-group/article-title-test-7/article-title-test-7.sch
+++ b/test/tests/gen/test-title-group/article-title-test-7/article-title-test-7.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/test-title-group/article-title-test-8/article-title-test-8.sch
+++ b/test/tests/gen/test-title-group/article-title-test-8/article-title-test-8.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/test-title-group/article-title-test-9/article-title-test-9.sch
+++ b/test/tests/gen/test-title-group/article-title-test-9/article-title-test-9.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/th-child-tests/th-child-test-1/th-child-test-1.sch
+++ b/test/tests/gen/th-child-tests/th-child-test-1/th-child-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/th-child-tests/th-child-test-2/th-child-test-2.sch
+++ b/test/tests/gen/th-child-tests/th-child-test-2/th-child-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/th-tests/th-row-test/th-row-test.sch
+++ b/test/tests/gen/th-tests/th-row-test/th-row-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/thead-tests/thead-test-1/thead-test-1.sch
+++ b/test/tests/gen/thead-tests/thead-test-1/thead-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/title-bold-tests/title-all-bold-test-1/title-all-bold-test-1.sch
+++ b/test/tests/gen/title-bold-tests/title-all-bold-test-1/title-all-bold-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/top-level-sec-tests/sec-conformity/sec-conformity.sch
+++ b/test/tests/gen/top-level-sec-tests/sec-conformity/sec-conformity.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/tr-tests/tr-test-1/tr-test-1.sch
+++ b/test/tests/gen/tr-tests/tr-test-1/tr-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/tr-tests/tr-test-2/tr-test-2.sch
+++ b/test/tests/gen/tr-tests/tr-test-2/tr-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/tr-tests/tr-test-3/tr-test-3.sch
+++ b/test/tests/gen/tr-tests/tr-test-3/tr-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unallowed-symbol-tests-sup/copyright-symbol-sup/copyright-symbol-sup.sch
+++ b/test/tests/gen/unallowed-symbol-tests-sup/copyright-symbol-sup/copyright-symbol-sup.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unallowed-symbol-tests-sup/degree-symbol-sup/degree-symbol-sup.sch
+++ b/test/tests/gen/unallowed-symbol-tests-sup/degree-symbol-sup/degree-symbol-sup.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unallowed-symbol-tests-sup/reg-trademark-symbol-sup/reg-trademark-symbol-sup.sch
+++ b/test/tests/gen/unallowed-symbol-tests-sup/reg-trademark-symbol-sup/reg-trademark-symbol-sup.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unallowed-symbol-tests-sup/ring-diacritic-symbol-sup/ring-diacritic-symbol-sup.sch
+++ b/test/tests/gen/unallowed-symbol-tests-sup/ring-diacritic-symbol-sup/ring-diacritic-symbol-sup.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unallowed-symbol-tests-sup/ring-op-symbol-sup/ring-op-symbol-sup.sch
+++ b/test/tests/gen/unallowed-symbol-tests-sup/ring-op-symbol-sup/ring-op-symbol-sup.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unallowed-symbol-tests-sup/trademark-symbol-1-sup/trademark-symbol-1-sup.sch
+++ b/test/tests/gen/unallowed-symbol-tests-sup/trademark-symbol-1-sup/trademark-symbol-1-sup.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unallowed-symbol-tests-sup/trademark-symbol-2-sup/trademark-symbol-2-sup.sch
+++ b/test/tests/gen/unallowed-symbol-tests-sup/trademark-symbol-2-sup/trademark-symbol-2-sup.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unallowed-symbol-tests-sup/white-circle-symbol-sup/white-circle-symbol-sup.sch
+++ b/test/tests/gen/unallowed-symbol-tests-sup/white-circle-symbol-sup/white-circle-symbol-sup.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unallowed-symbol-tests/Inc-presence/Inc-presence.sch
+++ b/test/tests/gen/unallowed-symbol-tests/Inc-presence/Inc-presence.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unallowed-symbol-tests/andand-presence/andand-presence.sch
+++ b/test/tests/gen/unallowed-symbol-tests/andand-presence/andand-presence.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unallowed-symbol-tests/broken-unicode-presence/broken-unicode-presence.sch
+++ b/test/tests/gen/unallowed-symbol-tests/broken-unicode-presence/broken-unicode-presence.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unallowed-symbol-tests/copyright-symbol/copyright-symbol.sch
+++ b/test/tests/gen/unallowed-symbol-tests/copyright-symbol/copyright-symbol.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unallowed-symbol-tests/empty-parentheses-presence/empty-parentheses-presence.sch
+++ b/test/tests/gen/unallowed-symbol-tests/empty-parentheses-presence/empty-parentheses-presence.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unallowed-symbol-tests/extra-full-stop-presence/extra-full-stop-presence.sch
+++ b/test/tests/gen/unallowed-symbol-tests/extra-full-stop-presence/extra-full-stop-presence.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unallowed-symbol-tests/extra-space-presence/extra-space-presence.sch
+++ b/test/tests/gen/unallowed-symbol-tests/extra-space-presence/extra-space-presence.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unallowed-symbol-tests/figurefigure-presence/figurefigure-presence.sch
+++ b/test/tests/gen/unallowed-symbol-tests/figurefigure-presence/figurefigure-presence.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unallowed-symbol-tests/inverterted-question-presence/inverterted-question-presence.sch
+++ b/test/tests/gen/unallowed-symbol-tests/inverterted-question-presence/inverterted-question-presence.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unallowed-symbol-tests/junk-character-presence/junk-character-presence.sch
+++ b/test/tests/gen/unallowed-symbol-tests/junk-character-presence/junk-character-presence.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unallowed-symbol-tests/operating-system-command-presence/operating-system-command-presence.sch
+++ b/test/tests/gen/unallowed-symbol-tests/operating-system-command-presence/operating-system-command-presence.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unallowed-symbol-tests/plus-minus-presence/plus-minus-presence.sch
+++ b/test/tests/gen/unallowed-symbol-tests/plus-minus-presence/plus-minus-presence.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unallowed-symbol-tests/ref-presence/ref-presence.sch
+++ b/test/tests/gen/unallowed-symbol-tests/ref-presence/ref-presence.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unallowed-symbol-tests/refs-presence/refs-presence.sch
+++ b/test/tests/gen/unallowed-symbol-tests/refs-presence/refs-presence.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unallowed-symbol-tests/reg-trademark-symbol/reg-trademark-symbol.sch
+++ b/test/tests/gen/unallowed-symbol-tests/reg-trademark-symbol/reg-trademark-symbol.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unallowed-symbol-tests/replacement-character-presence/replacement-character-presence.sch
+++ b/test/tests/gen/unallowed-symbol-tests/replacement-character-presence/replacement-character-presence.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unallowed-symbol-tests/supplement-table-presence/supplement-table-presence.sch
+++ b/test/tests/gen/unallowed-symbol-tests/supplement-table-presence/supplement-table-presence.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unallowed-symbol-tests/supplementalfigure-presence/supplementalfigure-presence.sch
+++ b/test/tests/gen/unallowed-symbol-tests/supplementalfigure-presence/supplementalfigure-presence.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unallowed-symbol-tests/supplementalfile-presence/supplementalfile-presence.sch
+++ b/test/tests/gen/unallowed-symbol-tests/supplementalfile-presence/supplementalfile-presence.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unallowed-symbol-tests/supplementaryfigure-presence/supplementaryfigure-presence.sch
+++ b/test/tests/gen/unallowed-symbol-tests/supplementaryfigure-presence/supplementaryfigure-presence.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unallowed-symbol-tests/trademark-symbol/trademark-symbol.sch
+++ b/test/tests/gen/unallowed-symbol-tests/trademark-symbol/trademark-symbol.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/underline-tests/underline-test-1/underline-test-1.sch
+++ b/test/tests/gen/underline-tests/underline-test-1/underline-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-1/unicode-test-1.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-1/unicode-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-10/unicode-test-10.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-10/unicode-test-10.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-11/unicode-test-11.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-11/unicode-test-11.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-13/unicode-test-13.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-13/unicode-test-13.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-14/unicode-test-14.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-14/unicode-test-14.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-15/unicode-test-15.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-15/unicode-test-15.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-16/unicode-test-16.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-16/unicode-test-16.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-17/unicode-test-17.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-17/unicode-test-17.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-18/unicode-test-18.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-18/unicode-test-18.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-19/unicode-test-19.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-19/unicode-test-19.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-2/unicode-test-2.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-2/unicode-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-21/unicode-test-21.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-21/unicode-test-21.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-22/unicode-test-22.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-22/unicode-test-22.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-23/unicode-test-23.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-23/unicode-test-23.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-24/unicode-test-24.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-24/unicode-test-24.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-25/unicode-test-25.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-25/unicode-test-25.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-26/unicode-test-26.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-26/unicode-test-26.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-27/unicode-test-27.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-27/unicode-test-27.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-28/unicode-test-28.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-28/unicode-test-28.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-29/unicode-test-29.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-29/unicode-test-29.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-3/unicode-test-3.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-3/unicode-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-30/unicode-test-30.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-30/unicode-test-30.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-31/unicode-test-31.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-31/unicode-test-31.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-32/unicode-test-32.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-32/unicode-test-32.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-33/unicode-test-33.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-33/unicode-test-33.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-34/unicode-test-34.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-34/unicode-test-34.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-35/unicode-test-35.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-35/unicode-test-35.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-36/unicode-test-36.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-36/unicode-test-36.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-37/unicode-test-37.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-37/unicode-test-37.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-38/unicode-test-38.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-38/unicode-test-38.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-39/unicode-test-39.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-39/unicode-test-39.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-4/unicode-test-4.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-4/unicode-test-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-40/unicode-test-40.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-40/unicode-test-40.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-41/unicode-test-41.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-41/unicode-test-41.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-42/unicode-test-42.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-42/unicode-test-42.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-43/unicode-test-43.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-43/unicode-test-43.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-44/unicode-test-44.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-44/unicode-test-44.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-45/unicode-test-45.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-45/unicode-test-45.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-46/unicode-test-46.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-46/unicode-test-46.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-47/unicode-test-47.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-47/unicode-test-47.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-48/unicode-test-48.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-48/unicode-test-48.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-49/unicode-test-49.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-49/unicode-test-49.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-5/unicode-test-5.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-5/unicode-test-5.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-50/unicode-test-50.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-50/unicode-test-50.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-51/unicode-test-51.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-51/unicode-test-51.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-52/unicode-test-52.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-52/unicode-test-52.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-53/unicode-test-53.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-53/unicode-test-53.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-54/unicode-test-54.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-54/unicode-test-54.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-55/unicode-test-55.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-55/unicode-test-55.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-56/unicode-test-56.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-56/unicode-test-56.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-57/unicode-test-57.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-57/unicode-test-57.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-58/unicode-test-58.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-58/unicode-test-58.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-59/unicode-test-59.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-59/unicode-test-59.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-6/unicode-test-6.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-6/unicode-test-6.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-60/unicode-test-60.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-60/unicode-test-60.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-61/unicode-test-61.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-61/unicode-test-61.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-62/unicode-test-62.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-62/unicode-test-62.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-63/unicode-test-63.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-63/unicode-test-63.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-64/unicode-test-64.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-64/unicode-test-64.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-65/unicode-test-65.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-65/unicode-test-65.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-66/unicode-test-66.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-66/unicode-test-66.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-67/unicode-test-67.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-67/unicode-test-67.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-68/unicode-test-68.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-68/unicode-test-68.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-69/unicode-test-69.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-69/unicode-test-69.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-7/unicode-test-7.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-7/unicode-test-7.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-70/unicode-test-70.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-70/unicode-test-70.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-71/unicode-test-71.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-71/unicode-test-71.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-72/unicode-test-72.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-72/unicode-test-72.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-73/unicode-test-73.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-73/unicode-test-73.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-74/unicode-test-74.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-74/unicode-test-74.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-75/unicode-test-75.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-75/unicode-test-75.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-76/unicode-test-76.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-76/unicode-test-76.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-77/unicode-test-77.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-77/unicode-test-77.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-78/unicode-test-78.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-78/unicode-test-78.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-79/unicode-test-79.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-79/unicode-test-79.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-8/unicode-test-8.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-8/unicode-test-8.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-80/unicode-test-80.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-80/unicode-test-80.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-81/unicode-test-81.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-81/unicode-test-81.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-82/unicode-test-82.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-82/unicode-test-82.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-83/unicode-test-83.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-83/unicode-test-83.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-84/unicode-test-84.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-84/unicode-test-84.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-85/unicode-test-85.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-85/unicode-test-85.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-86/unicode-test-86.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-86/unicode-test-86.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-87/unicode-test-87.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-87/unicode-test-87.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-88/unicode-test-88.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-88/unicode-test-88.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-89/unicode-test-89.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-89/unicode-test-89.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-9/unicode-test-9.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-9/unicode-test-9.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-90/unicode-test-90.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-90/unicode-test-90.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-91/unicode-test-91.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-91/unicode-test-91.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-92/unicode-test-92.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-92/unicode-test-92.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unicode-tests/unicode-test-93/unicode-test-93.sch
+++ b/test/tests/gen/unicode-tests/unicode-test-93/unicode-test-93.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unlinked-object-cite/text-v-object-cite-test/text-v-object-cite-test.sch
+++ b/test/tests/gen/unlinked-object-cite/text-v-object-cite-test/text-v-object-cite-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/unlinked-ref-cite/text-v-cite-test/text-v-cite-test.sch
+++ b/test/tests/gen/unlinked-ref-cite/text-v-cite-test/text-v-cite-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/vid-source-code-tests/vid-code-test-2/vid-code-test-2.sch
+++ b/test/tests/gen/vid-source-code-tests/vid-code-test-2/vid-code-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/vid-source-data-tests/vid-data-test-2/vid-data-test-2.sch
+++ b/test/tests/gen/vid-source-data-tests/vid-data-test-2/vid-data-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/vid-xref-conformance/vid-xref-conformity-1/vid-xref-conformity-1.sch
+++ b/test/tests/gen/vid-xref-conformance/vid-xref-conformity-1/vid-xref-conformity-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/vid-xref-conformance/vid-xref-conformity-2/vid-xref-conformity-2.sch
+++ b/test/tests/gen/vid-xref-conformance/vid-xref-conformity-2/vid-xref-conformity-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/vid-xref-conformance/vid-xref-test-10/vid-xref-test-10.sch
+++ b/test/tests/gen/vid-xref-conformance/vid-xref-test-10/vid-xref-test-10.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/vid-xref-conformance/vid-xref-test-11/vid-xref-test-11.sch
+++ b/test/tests/gen/vid-xref-conformance/vid-xref-test-11/vid-xref-test-11.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/vid-xref-conformance/vid-xref-test-2/vid-xref-test-2.sch
+++ b/test/tests/gen/vid-xref-conformance/vid-xref-test-2/vid-xref-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/vid-xref-conformance/vid-xref-test-3/vid-xref-test-3.sch
+++ b/test/tests/gen/vid-xref-conformance/vid-xref-test-3/vid-xref-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/vid-xref-conformance/vid-xref-test-4/vid-xref-test-4.sch
+++ b/test/tests/gen/vid-xref-conformance/vid-xref-test-4/vid-xref-test-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/vid-xref-conformance/vid-xref-test-5/vid-xref-test-5.sch
+++ b/test/tests/gen/vid-xref-conformance/vid-xref-test-5/vid-xref-test-5.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/vid-xref-conformance/vid-xref-test-6/vid-xref-test-6.sch
+++ b/test/tests/gen/vid-xref-conformance/vid-xref-test-6/vid-xref-test-6.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/vid-xref-conformance/vid-xref-test-7/vid-xref-test-7.sch
+++ b/test/tests/gen/vid-xref-conformance/vid-xref-test-7/vid-xref-test-7.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/vid-xref-conformance/vid-xref-test-8/vid-xref-test-8.sch
+++ b/test/tests/gen/vid-xref-conformance/vid-xref-test-8/vid-xref-test-8.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/vid-xref-conformance/vid-xref-test-9/vid-xref-test-9.sch
+++ b/test/tests/gen/vid-xref-conformance/vid-xref-test-9/vid-xref-test-9.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/video-ids/video-id-test/video-id-test.sch
+++ b/test/tests/gen/video-ids/video-id-test/video-id-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/video-parent-conformance/video-parent-test/video-parent-test.sch
+++ b/test/tests/gen/video-parent-conformance/video-parent-test/video-parent-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/video-sup-ids/video-sup-id-test-1/video-sup-id-test-1.sch
+++ b/test/tests/gen/video-sup-ids/video-sup-id-test-1/video-sup-id-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/video-sup-ids/video-sup-id-test-2/video-sup-id-test-2.sch
+++ b/test/tests/gen/video-sup-ids/video-sup-id-test-2/video-sup-id-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/video-test/final-video-title/final-video-title.sch
+++ b/test/tests/gen/video-test/final-video-title/final-video-title.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/video-test/pre-video-title/pre-video-title.sch
+++ b/test/tests/gen/video-test/pre-video-title/pre-video-title.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/video-title-tests/video-title-test-1/video-title-test-1.sch
+++ b/test/tests/gen/video-title-tests/video-title-test-1/video-title-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/video-title-tests/video-title-test-2/video-title-test-2.sch
+++ b/test/tests/gen/video-title-tests/video-title-test-2/video-title-test-2.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/video-title-tests/video-title-test-3/video-title-test-3.sch
+++ b/test/tests/gen/video-title-tests/video-title-test-3/video-title-test-3.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/video-title-tests/video-title-test-4/video-title-test-4.sch
+++ b/test/tests/gen/video-title-tests/video-title-test-4/video-title-test-4.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/video-title-tests/video-title-test-7/video-title-test-7.sch
+++ b/test/tests/gen/video-title-tests/video-title-test-7/video-title-test-7.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/video-title-tests/video-title-test-8/video-title-test-8.sch
+++ b/test/tests/gen/video-title-tests/video-title-test-8/video-title-test-8.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/volume-test/volume-test-1/volume-test-1.sch
+++ b/test/tests/gen/volume-test/volume-test-1/volume-test-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/website-tests/arxiv-web-test/arxiv-web-test.sch
+++ b/test/tests/gen/website-tests/arxiv-web-test/arxiv-web-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/website-tests/biorxiv-web-test/biorxiv-web-test.sch
+++ b/test/tests/gen/website-tests/biorxiv-web-test/biorxiv-web-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/website-tests/chemrxiv-web-test/chemrxiv-web-test.sch
+++ b/test/tests/gen/website-tests/chemrxiv-web-test/chemrxiv-web-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/website-tests/github-web-test/github-web-test.sch
+++ b/test/tests/gen/website-tests/github-web-test/github-web-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/website-tests/paleorxiv-web-test/paleorxiv-web-test.sch
+++ b/test/tests/gen/website-tests/paleorxiv-web-test/paleorxiv-web-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/website-tests/peerj-preprints-web-test/peerj-preprints-web-test.sch
+++ b/test/tests/gen/website-tests/peerj-preprints-web-test/peerj-preprints-web-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/website-tests/psyarxiv-web-test/psyarxiv-web-test.sch
+++ b/test/tests/gen/website-tests/psyarxiv-web-test/psyarxiv-web-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/website-tests/webreplacement-character-presence/webreplacement-character-presence.sch
+++ b/test/tests/gen/website-tests/webreplacement-character-presence/webreplacement-character-presence.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/xref-formatting/xref-child-test/xref-child-test.sch
+++ b/test/tests/gen/xref-formatting/xref-child-test/xref-child-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/xref-formatting/xref-parent-test/xref-parent-test.sch
+++ b/test/tests/gen/xref-formatting/xref-parent-test/xref-parent-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/xref-target-tests/aff-xref-target-test/aff-xref-target-test.sch
+++ b/test/tests/gen/xref-target-tests/aff-xref-target-test/aff-xref-target-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/xref-target-tests/app-xref-target-test/app-xref-target-test.sch
+++ b/test/tests/gen/xref-target-tests/app-xref-target-test/app-xref-target-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/xref-target-tests/bibr-xref-target-test/bibr-xref-target-test.sch
+++ b/test/tests/gen/xref-target-tests/bibr-xref-target-test/bibr-xref-target-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/xref-target-tests/box-xref-target-test/box-xref-target-test.sch
+++ b/test/tests/gen/xref-target-tests/box-xref-target-test/box-xref-target-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/xref-target-tests/decision-letter-xref-target-test/decision-letter-xref-target-test.sch
+++ b/test/tests/gen/xref-target-tests/decision-letter-xref-target-test/decision-letter-xref-target-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/xref-target-tests/disp-formula-xref-target-test/disp-formula-xref-target-test.sch
+++ b/test/tests/gen/xref-target-tests/disp-formula-xref-target-test/disp-formula-xref-target-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/xref-target-tests/fig-xref-target-test/fig-xref-target-test.sch
+++ b/test/tests/gen/xref-target-tests/fig-xref-target-test/fig-xref-target-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/xref-target-tests/fn-xref-target-test/fn-xref-target-test.sch
+++ b/test/tests/gen/xref-target-tests/fn-xref-target-test/fn-xref-target-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/xref-target-tests/other-xref-target-test/other-xref-target-test.sch
+++ b/test/tests/gen/xref-target-tests/other-xref-target-test/other-xref-target-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/xref-target-tests/sec-xref-target-test/sec-xref-target-test.sch
+++ b/test/tests/gen/xref-target-tests/sec-xref-target-test/sec-xref-target-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/xref-target-tests/supplementary-material-xref-target-test/supplementary-material-xref-target-test.sch
+++ b/test/tests/gen/xref-target-tests/supplementary-material-xref-target-test/supplementary-material-xref-target-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/xref-target-tests/table-fn-xref-target-test/table-fn-xref-target-test.sch
+++ b/test/tests/gen/xref-target-tests/table-fn-xref-target-test/table-fn-xref-target-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/xref-target-tests/table-xref-target-test/table-xref-target-test.sch
+++ b/test/tests/gen/xref-target-tests/table-xref-target-test/table-xref-target-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/xref-target-tests/vid-xref-target-test/vid-xref-target-test.sch
+++ b/test/tests/gen/xref-target-tests/vid-xref-target-test/vid-xref-target-test.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/xref-target-tests/xref-ref-type-conformance/xref-ref-type-conformance.sch
+++ b/test/tests/gen/xref-target-tests/xref-ref-type-conformance/xref-ref-type-conformance.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/xref-target-tests/xref-target-conformance/xref-target-conformance.sch
+++ b/test/tests/gen/xref-target-tests/xref-target-conformance/xref-target-conformance.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/xref/err-xref-high-2-1/err-xref-high-2-1.sch
+++ b/test/tests/gen/xref/err-xref-high-2-1/err-xref-high-2-1.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/year-article-meta-tests/year-article-meta-conformity/year-article-meta-conformity.sch
+++ b/test/tests/gen/year-article-meta-tests/year-article-meta-conformity/year-article-meta-conformity.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/year-element-citation-tests/final-year-element-citation-conformity/final-year-element-citation-conformity.sch
+++ b/test/tests/gen/year-element-citation-tests/final-year-element-citation-conformity/final-year-element-citation-conformity.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/tests/gen/year-element-citation-tests/pre-year-element-citation-conformity/pre-year-element-citation-conformity.sch
+++ b/test/tests/gen/year-element-citation-tests/pre-year-element-citation-conformity/pre-year-element-citation-conformity.sch
@@ -794,8 +794,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">

--- a/test/xspec/schematron.sch
+++ b/test/xspec/schematron.sch
@@ -831,8 +831,8 @@
     <xsl:param name="article" as="element()"/>
     <xsl:param name="regex" as="xs:string"/>
     
-    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor::sec[@sec-type='additional-information']) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),''))"/>
-    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic,''))"/>
+    <xsl:variable name="roman-text" select="lower-case(       string-join(for $x in $article/*[local-name() = 'body' or local-name() = 'back']//*       return       if ($x/ancestor-or-self::sec[@sec-type='additional-information']) then ()       else if ($x/ancestor-or-self::ref-list) then ()       else if ($x/local-name() = 'italic') then ()       else $x/text(),' '))"/>
+    <xsl:variable name="italic-text" select="lower-case(string-join($article//*:italic[not(ancestor::ref-list) and not(ancestor::sec[@sec-type='additional-information'])],' '))"/>
     
     
     <xsl:element name="result">
@@ -2399,6 +2399,8 @@
       <report test="child::mml:msqrt and matches($data,'^±\d+%$|^+\d+%$|^-\d+%$|^\d+%$|^±\d+$|^+\d+$|^-\d+$')" role="warning" id="math-test-17">mml:math only contains number(s) and square root symbol(s) '<value-of select="."/>', which is likely unnecessary. Should this be captured as normal text instead? Such as <value-of select="concat('√',.)"/>?</report>
       
       <report test="ancestor::abstract" role="warning" id="math-test-18">abstract contains MathML (<value-of select="."/>). Is this necessary? MathML in abstracts may not render downstream, so if it can be represented using normal text/unicode, then please do so instead.</report>
+      
+      <report test="descendant::mml:mi[(.='') and preceding-sibling::*[1][(local-name() = 'mi') and matches(.,'[A-Za-z]')] and following-sibling::*[1][(local-name() = 'mi') and matches(.,'[A-Za-z]')]]" role="warning" id="math-test-19">Maths containing '<value-of select="."/>' has what looks like words or terms which need separating with a space. With it's current markup the space will not be preserved on the eLife website. Please add in the space(s) using the latext '\;' in the appropriate place(s), so that the space is preserved in the HTML.</report>
     </rule>
   </pattern>
   <pattern id="disp-formula-child-tests-pattern">
@@ -7258,7 +7260,7 @@
       
       <report test="($italic-count != 0) and ($roman-count gt $italic-count)" role="warning" id="latin-italic-info">Latin terms are not consistenly either roman or italic. There are <value-of select="$roman-count"/> roman terms which is more common, and <value-of select="$italic-count"/> italic term(s). The following terms should be unitalicised: <value-of select="e:print-latin-terms($latin-terms//*:list[@list-type='italic'])"/>.</report>
       
-      <report test="($roman-count != 0) and ($italic-count gt $roman-count)" role="warning" id="latin-roman-info">Latin terms are not consistenly either roman or italic. There are <value-of select="$italic-count"/> italic terms which is more common, and <value-of select="$roman-count"/> roman term(s). The following terms should be unitalicised: <value-of select="e:print-latin-terms($latin-terms//*:list[@list-type='italic'])"/>.</report>
+      <report test="($roman-count != 0) and ($italic-count gt $roman-count)" role="warning" id="latin-roman-info">Latin terms are not consistenly either roman or italic. There are <value-of select="$italic-count"/> italic terms which is more common, and <value-of select="$roman-count"/> roman term(s). The following terms should be italicised: <value-of select="e:print-latin-terms($latin-terms//*:list[@list-type='roman'])"/>.</report>
       
       <report test="($roman-count != 0) and ($italic-count = $roman-count)" role="warning" id="latin-conformance-info">Latin terms are not consistenly either roman or italic. There are an equal number of italic (<value-of select="$italic-count"/>) and roman (<value-of select="$roman-count"/>) terms. The following terms are italicised: <value-of select="e:print-latin-terms($latin-terms//*:list[@list-type='italic'])"/>. The following terms are unitalicised: <value-of select="e:print-latin-terms($latin-terms//*:list[@list-type='roman'])"/>.</report>
     </rule>

--- a/test/xspec/schematron.xspec
+++ b/test/xspec/schematron.xspec
@@ -4151,6 +4151,16 @@
         <x:expect-report id="math-test-18" role="warning"/>
         <x:expect-not-assert id="math-tests-xspec-assert" role="error"/>
       </x:scenario>
+      <x:scenario label="math-test-19-pass">
+        <x:context href="../tests/gen/math-tests/math-test-19/pass.xml"/>
+        <x:expect-not-report id="math-test-19" role="warning"/>
+        <x:expect-not-assert id="math-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="math-test-19-fail">
+        <x:context href="../tests/gen/math-tests/math-test-19/fail.xml"/>
+        <x:expect-report id="math-test-19" role="warning"/>
+        <x:expect-not-assert id="math-tests-xspec-assert" role="error"/>
+      </x:scenario>
     </x:scenario>
     <x:scenario label="disp-formula-child-tests">
       <x:scenario label="disp-formula-child-test-1-pass">


### PR DESCRIPTION
- Check for preserving space in html `math-test-19`.
- Ignore `ref-list` in latin term consistency checks
- Fix for `e:print-latin-terms` function