### PR TITLE
fix: ignore http/https in orcid duplicate check

### DIFF
--- a/src/final-JATS-schematron.sch
+++ b/src/final-JATS-schematron.sch
@@ -1168,7 +1168,7 @@
     <rule context="article/front/article-meta/contrib-group[1]" id="auth-contrib-group">
       <let name="names" value="for $name in contrib[@contrib-type='author']/name[1] return e:get-name($name)"/>
       <let name="indistinct-names" value="for $name in distinct-values($names) return $name[count($names[. = $name]) gt 1]"/>
-      <let name="orcids" value="contrib[@contrib-type='author']/contrib-id[@contrib-id-type='orcid']"/>
+      <let name="orcids" value="for $x in contrib[@contrib-type='author']/contrib-id[@contrib-id-type='orcid'] return substring-after($x,'orcid.org/')"/>
       <let name="indistinct-orcids" value="for $orcid in distinct-values($orcids) return $orcid[count($orcids[. = $orcid]) gt 1]"/>
       
       <assert test="contrib[@contrib-type='author' and @corresp='yes']" role="error" id="corresp-presence-test">[corresp-presence-test] There must be at least one corresponding author (a contrib[@contrib-type='author' and @corresp='yes'] in the first contrib-group).</assert>
@@ -1215,7 +1215,7 @@
     <rule context="article//article-meta/contrib-group[1]/contrib[@contrib-type='author']/collab/contrib-group" id="collab-tests">
       <let name="names" value="for $name in contrib[@contrib-type='author']/name[1] return e:get-name($name)"/>
       <let name="indistinct-names" value="for $name in distinct-values($names) return $name[count($names[. = $name]) gt 1]"/>
-      <let name="orcids" value="contrib[@contrib-type='author']/contrib-id[@contrib-id-type='orcid']"/>
+      <let name="orcids" value="for $x in contrib[@contrib-type='author']/contrib-id[@contrib-id-type='orcid'] return substring-after($x,'orcid.org/')"/>
       <let name="indistinct-orcids" value="for $orcid in distinct-values($orcids) return $orcid[count($orcids[. = $orcid]) gt 1]"/>
       
       <assert test="empty($indistinct-names)" role="warning" id="duplicate-member-test">[duplicate-member-test] There is more than one member of the group author <value-of select="e:get-collab(parent::collab)"/> with the following name(s) - <value-of select="if (count($indistinct-names) gt 1) then concat(string-join($indistinct-names[position() != last()],', '),' and ',$indistinct-names[last()]) else $indistinct-names"/> - which is very likely incorrect.</assert>

--- a/src/final-JATS-schematron.xsl
+++ b/src/final-JATS-schematron.xsl
@@ -6012,7 +6012,7 @@
    <xsl:template match="article/front/article-meta/contrib-group[1]" priority="1000" mode="M58">
       <xsl:variable name="names" select="for $name in contrib[@contrib-type='author']/name[1] return e:get-name($name)"/>
       <xsl:variable name="indistinct-names" select="for $name in distinct-values($names) return $name[count($names[. = $name]) gt 1]"/>
-      <xsl:variable name="orcids" select="contrib[@contrib-type='author']/contrib-id[@contrib-id-type='orcid']"/>
+      <xsl:variable name="orcids" select="for $x in contrib[@contrib-type='author']/contrib-id[@contrib-id-type='orcid'] return substring-after($x,'orcid.org/')"/>
       <xsl:variable name="indistinct-orcids" select="for $orcid in distinct-values($orcids) return $orcid[count($orcids[. = $orcid]) gt 1]"/>
 
 		    <!--ASSERT error-->
@@ -6223,7 +6223,7 @@
    <xsl:template match="article//article-meta/contrib-group[1]/contrib[@contrib-type='author']/collab/contrib-group" priority="1000" mode="M63">
       <xsl:variable name="names" select="for $name in contrib[@contrib-type='author']/name[1] return e:get-name($name)"/>
       <xsl:variable name="indistinct-names" select="for $name in distinct-values($names) return $name[count($names[. = $name]) gt 1]"/>
-      <xsl:variable name="orcids" select="contrib[@contrib-type='author']/contrib-id[@contrib-id-type='orcid']"/>
+      <xsl:variable name="orcids" select="for $x in contrib[@contrib-type='author']/contrib-id[@contrib-id-type='orcid'] return substring-after($x,'orcid.org/')"/>
       <xsl:variable name="indistinct-orcids" select="for $orcid in distinct-values($orcids) return $orcid[count($orcids[. = $orcid]) gt 1]"/>
 
 		    <!--ASSERT warning-->

--- a/src/final-package-JATS-schematron.sch
+++ b/src/final-package-JATS-schematron.sch
@@ -1176,7 +1176,7 @@
     <rule context="article/front/article-meta/contrib-group[1]" id="auth-contrib-group">
       <let name="names" value="for $name in contrib[@contrib-type='author']/name[1] return e:get-name($name)"/>
       <let name="indistinct-names" value="for $name in distinct-values($names) return $name[count($names[. = $name]) gt 1]"/>
-      <let name="orcids" value="contrib[@contrib-type='author']/contrib-id[@contrib-id-type='orcid']"/>
+      <let name="orcids" value="for $x in contrib[@contrib-type='author']/contrib-id[@contrib-id-type='orcid'] return substring-after($x,'orcid.org/')"/>
       <let name="indistinct-orcids" value="for $orcid in distinct-values($orcids) return $orcid[count($orcids[. = $orcid]) gt 1]"/>
       
       <assert test="contrib[@contrib-type='author' and @corresp='yes']" role="error" id="corresp-presence-test">There must be at least one corresponding author (a contrib[@contrib-type='author' and @corresp='yes'] in the first contrib-group).</assert>
@@ -1227,7 +1227,7 @@
     <rule context="article//article-meta/contrib-group[1]/contrib[@contrib-type='author']/collab/contrib-group" id="collab-tests">
       <let name="names" value="for $name in contrib[@contrib-type='author']/name[1] return e:get-name($name)"/>
       <let name="indistinct-names" value="for $name in distinct-values($names) return $name[count($names[. = $name]) gt 1]"/>
-      <let name="orcids" value="contrib[@contrib-type='author']/contrib-id[@contrib-id-type='orcid']"/>
+      <let name="orcids" value="for $x in contrib[@contrib-type='author']/contrib-id[@contrib-id-type='orcid'] return substring-after($x,'orcid.org/')"/>
       <let name="indistinct-orcids" value="for $orcid in distinct-values($orcids) return $orcid[count($orcids[. = $orcid]) gt 1]"/>
       
       <assert test="empty($indistinct-names)" role="warning" id="duplicate-member-test">There is more than one member of the group author <value-of select="e:get-collab(parent::collab)"/> with the following name(s) - <value-of select="if (count($indistinct-names) gt 1) then concat(string-join($indistinct-names[position() != last()],', '),' and ',$indistinct-names[last()]) else $indistinct-names"/> - which is very likely incorrect.</assert>

--- a/src/pre-JATS-schematron.sch
+++ b/src/pre-JATS-schematron.sch
@@ -1113,7 +1113,7 @@
     <rule context="article/front/article-meta/contrib-group[1]" id="auth-contrib-group">
       <let name="names" value="for $name in contrib[@contrib-type='author']/name[1] return e:get-name($name)"/>
       <let name="indistinct-names" value="for $name in distinct-values($names) return $name[count($names[. = $name]) gt 1]"/>
-      <let name="orcids" value="contrib[@contrib-type='author']/contrib-id[@contrib-id-type='orcid']"/>
+      <let name="orcids" value="for $x in contrib[@contrib-type='author']/contrib-id[@contrib-id-type='orcid'] return substring-after($x,'orcid.org/')"/>
       <let name="indistinct-orcids" value="for $orcid in distinct-values($orcids) return $orcid[count($orcids[. = $orcid]) gt 1]"/>
       
       <assert test="contrib[@contrib-type='author' and @corresp='yes']" role="error" id="corresp-presence-test">[corresp-presence-test] There must be at least one corresponding author (a contrib[@contrib-type='author' and @corresp='yes'] in the first contrib-group).</assert>
@@ -1160,7 +1160,7 @@
     <rule context="article//article-meta/contrib-group[1]/contrib[@contrib-type='author']/collab/contrib-group" id="collab-tests">
       <let name="names" value="for $name in contrib[@contrib-type='author']/name[1] return e:get-name($name)"/>
       <let name="indistinct-names" value="for $name in distinct-values($names) return $name[count($names[. = $name]) gt 1]"/>
-      <let name="orcids" value="contrib[@contrib-type='author']/contrib-id[@contrib-id-type='orcid']"/>
+      <let name="orcids" value="for $x in contrib[@contrib-type='author']/contrib-id[@contrib-id-type='orcid'] return substring-after($x,'orcid.org/')"/>
       <let name="indistinct-orcids" value="for $orcid in distinct-values($orcids) return $orcid[count($orcids[. = $orcid]) gt 1]"/>
       
       <assert test="empty($indistinct-names)" role="warning" id="duplicate-member-test">[duplicate-member-test] There is more than one member of the group author <value-of select="e:get-collab(parent::collab)"/> with the following name(s) - <value-of select="if (count($indistinct-names) gt 1) then concat(string-join($indistinct-names[position() != last()],', '),' and ',$indistinct-names[last()]) else $indistinct-names"/> - which is very likely incorrect.</assert>

--- a/src/pre-JATS-schematron.xsl
+++ b/src/pre-JATS-schematron.xsl
@@ -5933,7 +5933,7 @@
    <xsl:template match="article/front/article-meta/contrib-group[1]" priority="1000" mode="M56">
       <xsl:variable name="names" select="for $name in contrib[@contrib-type='author']/name[1] return e:get-name($name)"/>
       <xsl:variable name="indistinct-names" select="for $name in distinct-values($names) return $name[count($names[. = $name]) gt 1]"/>
-      <xsl:variable name="orcids" select="contrib[@contrib-type='author']/contrib-id[@contrib-id-type='orcid']"/>
+      <xsl:variable name="orcids" select="for $x in contrib[@contrib-type='author']/contrib-id[@contrib-id-type='orcid'] return substring-after($x,'orcid.org/')"/>
       <xsl:variable name="indistinct-orcids" select="for $orcid in distinct-values($orcids) return $orcid[count($orcids[. = $orcid]) gt 1]"/>
 
 		    <!--ASSERT error-->
@@ -6144,7 +6144,7 @@
    <xsl:template match="article//article-meta/contrib-group[1]/contrib[@contrib-type='author']/collab/contrib-group" priority="1000" mode="M61">
       <xsl:variable name="names" select="for $name in contrib[@contrib-type='author']/name[1] return e:get-name($name)"/>
       <xsl:variable name="indistinct-names" select="for $name in distinct-values($names) return $name[count($names[. = $name]) gt 1]"/>
-      <xsl:variable name="orcids" select="contrib[@contrib-type='author']/contrib-id[@contrib-id-type='orcid']"/>
+      <xsl:variable name="orcids" select="for $x in contrib[@contrib-type='author']/contrib-id[@contrib-id-type='orcid'] return substring-after($x,'orcid.org/')"/>
       <xsl:variable name="indistinct-orcids" select="for $orcid in distinct-values($orcids) return $orcid[count($orcids[. = $orcid]) gt 1]"/>
 
 		    <!--ASSERT warning-->

--- a/src/schematron.sch
+++ b/src/schematron.sch
@@ -1349,7 +1349,7 @@
     <rule context="article/front/article-meta/contrib-group[1]" id="auth-contrib-group">
       <let name="names" value="for $name in contrib[@contrib-type='author']/name[1] return e:get-name($name)"/>
       <let name="indistinct-names" value="for $name in distinct-values($names) return $name[count($names[. = $name]) gt 1]"/>
-      <let name="orcids" value="contrib[@contrib-type='author']/contrib-id[@contrib-id-type='orcid']"/>
+      <let name="orcids" value="for $x in contrib[@contrib-type='author']/contrib-id[@contrib-id-type='orcid'] return substring-after($x,'orcid.org/')"/>
       <let name="indistinct-orcids" value="for $orcid in distinct-values($orcids) return $orcid[count($orcids[. = $orcid]) gt 1]"/>
       
       <assert test="contrib[@contrib-type='author' and @corresp='yes']" 
@@ -1410,7 +1410,7 @@
       id="collab-tests">
       <let name="names" value="for $name in contrib[@contrib-type='author']/name[1] return e:get-name($name)"/>
       <let name="indistinct-names" value="for $name in distinct-values($names) return $name[count($names[. = $name]) gt 1]"/>
-      <let name="orcids" value="contrib[@contrib-type='author']/contrib-id[@contrib-id-type='orcid']"/>
+      <let name="orcids" value="for $x in contrib[@contrib-type='author']/contrib-id[@contrib-id-type='orcid'] return substring-after($x,'orcid.org/')"/>
       <let name="indistinct-orcids" value="for $orcid in distinct-values($orcids) return $orcid[count($orcids[. = $orcid]) gt 1]"/>
       
       <assert test="empty($indistinct-names)" 

--- a/test/xspec/schematron.sch
+++ b/test/xspec/schematron.sch
@@ -1170,7 +1170,7 @@
     <rule context="article/front/article-meta/contrib-group[1]" id="auth-contrib-group">
       <let name="names" value="for $name in contrib[@contrib-type='author']/name[1] return e:get-name($name)"/>
       <let name="indistinct-names" value="for $name in distinct-values($names) return $name[count($names[. = $name]) gt 1]"/>
-      <let name="orcids" value="contrib[@contrib-type='author']/contrib-id[@contrib-id-type='orcid']"/>
+      <let name="orcids" value="for $x in contrib[@contrib-type='author']/contrib-id[@contrib-id-type='orcid'] return substring-after($x,'orcid.org/')"/>
       <let name="indistinct-orcids" value="for $orcid in distinct-values($orcids) return $orcid[count($orcids[. = $orcid]) gt 1]"/>
       
       <assert test="contrib[@contrib-type='author' and @corresp='yes']" role="error" id="corresp-presence-test">There must be at least one corresponding author (a contrib[@contrib-type='author' and @corresp='yes'] in the first contrib-group).</assert>
@@ -1221,7 +1221,7 @@
     <rule context="article//article-meta/contrib-group[1]/contrib[@contrib-type='author']/collab/contrib-group" id="collab-tests">
       <let name="names" value="for $name in contrib[@contrib-type='author']/name[1] return e:get-name($name)"/>
       <let name="indistinct-names" value="for $name in distinct-values($names) return $name[count($names[. = $name]) gt 1]"/>
-      <let name="orcids" value="contrib[@contrib-type='author']/contrib-id[@contrib-id-type='orcid']"/>
+      <let name="orcids" value="for $x in contrib[@contrib-type='author']/contrib-id[@contrib-id-type='orcid'] return substring-after($x,'orcid.org/')"/>
       <let name="indistinct-orcids" value="for $orcid in distinct-values($orcids) return $orcid[count($orcids[. = $orcid]) gt 1]"/>
       
       <assert test="empty($indistinct-names)" role="warning" id="duplicate-member-test">There is more than one member of the group author <value-of select="e:get-collab(parent::collab)"/> with the following name(s) - <value-of select="if (count($indistinct-names) gt 1) then concat(string-join($indistinct-names[position() != last()],', '),' and ',$indistinct-names[last()]) else $indistinct-names"/> - which is very likely incorrect.</assert>


### PR DESCRIPTION
- Use 16 digit orcid instead of full url for `duplicate-member-orcid-test` and `duplicate-orcid-test` thereby ignoring http/https.