### PR TITLE
fix: minor fixes

### DIFF
--- a/src/final-JATS-schematron.sch
+++ b/src/final-JATS-schematron.sch
@@ -1993,7 +1993,7 @@
       
       <report test="(@ref-type='supplementary-material') and ($target/local-name() != 'supplementary-material')" role="error" id="supplementary-material-xref-target-test">[supplementary-material-xref-target-test] xref with @ref-type='<value-of select="@ref-type"/>' points to <value-of select="$target/local-name()"/>. This is not correct.</report>
       
-      <report test="(@ref-type='other') and ($target/local-name() != 'award-group') and ($target/local-name() != 'element-citation')" role="error" id="other-xref-target-test">[other-xref-target-test] xref with @ref-type='<value-of select="@ref-type"/>' points to <value-of select="$target/local-name()"/>. This is not correct.</report>
+      <report test="(@ref-type='other') and not($target/local-name() = 'award-group')" role="error" id="other-xref-target-test">[other-xref-target-test] xref with @ref-type='<value-of select="@ref-type"/>' points to <value-of select="$target/local-name()"/>. This is not correct.</report>
       
       <report test="(@ref-type='table') and ($target/local-name() != 'table-wrap') and ($target/local-name() != 'table')" role="error" id="table-xref-target-test">[table-xref-target-test] xref with @ref-type='<value-of select="@ref-type"/>' points to <value-of select="$target/local-name()"/>. This is not correct.</report>
       
@@ -3105,7 +3105,7 @@
       
       <report test="matches(.,'^\([A-Za-z]|^[A-Za-z]\)')" role="warning" id="supplementary-material-title-test-1">[supplementary-material-title-test-1] '<value-of select="$label"/>' appears to have a title which is the beginning of a caption. Is this correct?</report>
       
-      <assert test="matches(.,'\.$')" role="error" id="supplementary-material-title-test-2">[supplementary-material-title-test-2] title for <value-of select="$label"/> must end with a full stop.</assert>
+      <assert test="matches(.,'[\.\?]$')" role="error" id="supplementary-material-title-test-2">[supplementary-material-title-test-2] title for <value-of select="$label"/> must end with a full stop.</assert>
       
       <report test="matches(.,' vs\.$')" role="warning" id="supplementary-material-title-test-3">[supplementary-material-title-test-3] title for <value-of select="$label"/> ends with 'vs.', which indicates that the title sentence may be split across title and caption.</report>
       

--- a/src/final-JATS-schematron.xsl
+++ b/src/final-JATS-schematron.xsl
@@ -9930,8 +9930,8 @@
       </xsl:if>
 
 		    <!--REPORT error-->
-      <xsl:if test="(@ref-type='other') and ($target/local-name() != 'award-group') and ($target/local-name() != 'element-citation')">
-         <svrl:successful-report xmlns:svrl="http://purl.oclc.org/dsdl/svrl" test="(@ref-type='other') and ($target/local-name() != 'award-group') and ($target/local-name() != 'element-citation')">
+      <xsl:if test="(@ref-type='other') and not($target/local-name() = 'award-group')">
+         <svrl:successful-report xmlns:svrl="http://purl.oclc.org/dsdl/svrl" test="(@ref-type='other') and not($target/local-name() = 'award-group')">
             <xsl:attribute name="id">other-xref-target-test</xsl:attribute>
             <xsl:attribute name="role">error</xsl:attribute>
             <xsl:attribute name="location">
@@ -15282,9 +15282,9 @@
 
 		    <!--ASSERT error-->
       <xsl:choose>
-         <xsl:when test="matches(.,'\.$')"/>
+         <xsl:when test="matches(.,'[\.\?]$')"/>
          <xsl:otherwise>
-            <svrl:failed-assert xmlns:svrl="http://purl.oclc.org/dsdl/svrl" test="matches(.,'\.$')">
+            <svrl:failed-assert xmlns:svrl="http://purl.oclc.org/dsdl/svrl" test="matches(.,'[\.\?]$')">
                <xsl:attribute name="id">supplementary-material-title-test-2</xsl:attribute>
                <xsl:attribute name="role">error</xsl:attribute>
                <xsl:attribute name="location">

--- a/src/final-package-JATS-schematron.sch
+++ b/src/final-package-JATS-schematron.sch
@@ -2037,7 +2037,7 @@
       
       <report test="(@ref-type='supplementary-material') and ($target/local-name() != 'supplementary-material')" role="error" id="supplementary-material-xref-target-test">xref with @ref-type='<value-of select="@ref-type"/>' points to <value-of select="$target/local-name()"/>. This is not correct.</report>
       
-      <report test="(@ref-type='other') and ($target/local-name() != 'award-group') and ($target/local-name() != 'element-citation')" role="error" id="other-xref-target-test">xref with @ref-type='<value-of select="@ref-type"/>' points to <value-of select="$target/local-name()"/>. This is not correct.</report>
+      <report test="(@ref-type='other') and not($target/local-name() = 'award-group')" role="error" id="other-xref-target-test">xref with @ref-type='<value-of select="@ref-type"/>' points to <value-of select="$target/local-name()"/>. This is not correct.</report>
       
       <report test="(@ref-type='table') and ($target/local-name() != 'table-wrap') and ($target/local-name() != 'table')" role="error" id="table-xref-target-test">xref with @ref-type='<value-of select="@ref-type"/>' points to <value-of select="$target/local-name()"/>. This is not correct.</report>
       
@@ -3212,7 +3212,7 @@
       
       <report test="matches(.,'^\([A-Za-z]|^[A-Za-z]\)')" role="warning" id="supplementary-material-title-test-1">'<value-of select="$label"/>' appears to have a title which is the beginning of a caption. Is this correct?</report>
       
-      <assert test="matches(.,'\.$')" role="error" id="supplementary-material-title-test-2">title for <value-of select="$label"/> must end with a full stop.</assert>
+      <assert test="matches(.,'[\.\?]$')" role="error" id="supplementary-material-title-test-2">title for <value-of select="$label"/> must end with a full stop.</assert>
       
       <report test="matches(.,' vs\.$')" role="warning" id="supplementary-material-title-test-3">title for <value-of select="$label"/> ends with 'vs.', which indicates that the title sentence may be split across title and caption.</report>
       

--- a/src/pre-JATS-schematron.sch
+++ b/src/pre-JATS-schematron.sch
@@ -1936,7 +1936,7 @@
       
       <report test="(@ref-type='supplementary-material') and ($target/local-name() != 'supplementary-material')" role="error" id="supplementary-material-xref-target-test">[supplementary-material-xref-target-test] xref with @ref-type='<value-of select="@ref-type"/>' points to <value-of select="$target/local-name()"/>. This is not correct.</report>
       
-      <report test="(@ref-type='other') and ($target/local-name() != 'award-group') and ($target/local-name() != 'element-citation')" role="error" id="other-xref-target-test">[other-xref-target-test] xref with @ref-type='<value-of select="@ref-type"/>' points to <value-of select="$target/local-name()"/>. This is not correct.</report>
+      <report test="(@ref-type='other') and not($target/local-name() = 'award-group')" role="error" id="other-xref-target-test">[other-xref-target-test] xref with @ref-type='<value-of select="@ref-type"/>' points to <value-of select="$target/local-name()"/>. This is not correct.</report>
       
       <report test="(@ref-type='table') and ($target/local-name() != 'table-wrap') and ($target/local-name() != 'table')" role="error" id="table-xref-target-test">[table-xref-target-test] xref with @ref-type='<value-of select="@ref-type"/>' points to <value-of select="$target/local-name()"/>. This is not correct.</report>
       
@@ -3048,7 +3048,7 @@
       
       <report test="matches(.,'^\([A-Za-z]|^[A-Za-z]\)')" role="warning" id="supplementary-material-title-test-1">[supplementary-material-title-test-1] '<value-of select="$label"/>' appears to have a title which is the beginning of a caption. Is this correct?</report>
       
-      <assert test="matches(.,'\.$')" role="error" id="supplementary-material-title-test-2">[supplementary-material-title-test-2] title for <value-of select="$label"/> must end with a full stop.</assert>
+      <assert test="matches(.,'[\.\?]$')" role="error" id="supplementary-material-title-test-2">[supplementary-material-title-test-2] title for <value-of select="$label"/> must end with a full stop.</assert>
       
       <report test="matches(.,' vs\.$')" role="warning" id="supplementary-material-title-test-3">[supplementary-material-title-test-3] title for <value-of select="$label"/> ends with 'vs.', which indicates that the title sentence may be split across title and caption.</report>
       

--- a/src/pre-JATS-schematron.xsl
+++ b/src/pre-JATS-schematron.xsl
@@ -9851,8 +9851,8 @@
       </xsl:if>
 
 		    <!--REPORT error-->
-      <xsl:if test="(@ref-type='other') and ($target/local-name() != 'award-group') and ($target/local-name() != 'element-citation')">
-         <svrl:successful-report xmlns:svrl="http://purl.oclc.org/dsdl/svrl" test="(@ref-type='other') and ($target/local-name() != 'award-group') and ($target/local-name() != 'element-citation')">
+      <xsl:if test="(@ref-type='other') and not($target/local-name() = 'award-group')">
+         <svrl:successful-report xmlns:svrl="http://purl.oclc.org/dsdl/svrl" test="(@ref-type='other') and not($target/local-name() = 'award-group')">
             <xsl:attribute name="id">other-xref-target-test</xsl:attribute>
             <xsl:attribute name="role">error</xsl:attribute>
             <xsl:attribute name="location">
@@ -15208,9 +15208,9 @@
 
 		    <!--ASSERT error-->
       <xsl:choose>
-         <xsl:when test="matches(.,'\.$')"/>
+         <xsl:when test="matches(.,'[\.\?]$')"/>
          <xsl:otherwise>
-            <svrl:failed-assert xmlns:svrl="http://purl.oclc.org/dsdl/svrl" test="matches(.,'\.$')">
+            <svrl:failed-assert xmlns:svrl="http://purl.oclc.org/dsdl/svrl" test="matches(.,'[\.\?]$')">
                <xsl:attribute name="id">supplementary-material-title-test-2</xsl:attribute>
                <xsl:attribute name="role">error</xsl:attribute>
                <xsl:attribute name="location">

--- a/src/schematron.sch
+++ b/src/schematron.sch
@@ -2618,7 +2618,7 @@ else self::*/local-name() = $allowed-p-blocks"
         role="error" 
         id="supplementary-material-xref-target-test">xref with @ref-type='<value-of select="@ref-type"/>' points to <value-of select="$target/local-name()"/>. This is not correct.</report>
       
-      <report test="(@ref-type='other') and ($target/local-name() != 'award-group') and ($target/local-name() != 'element-citation')" 
+      <report test="(@ref-type='other') and not($target/local-name() = 'award-group')" 
         role="error" 
         id="other-xref-target-test">xref with @ref-type='<value-of select="@ref-type"/>' points to <value-of select="$target/local-name()"/>. This is not correct.</report>
       
@@ -4428,7 +4428,7 @@ else self::*/local-name() = $allowed-p-blocks"
         role="warning" 
         id="supplementary-material-title-test-1">'<value-of select="$label"/>' appears to have a title which is the beginning of a caption. Is this correct?</report>
       
-      <assert test="matches(.,'\.$')" 
+      <assert test="matches(.,'[\.\?]$')" 
         role="error" 
         id="supplementary-material-title-test-2">title for <value-of select="$label"/> must end with a full stop.</assert>
       

--- a/test/tests/gen/supplementary-material-title-tests/supplementary-material-title-test-2/fail.xml
+++ b/test/tests/gen/supplementary-material-title-tests/supplementary-material-title-test-2/fail.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="supplementary-material-title-test-2.sch"?>
 <!--Context: supplementary-material/caption/title
-Test: assert    matches(.,'\.$')
+Test: assert    matches(.,'[\.\?]$')
 Message: title for  must end with a full stop. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>

--- a/test/tests/gen/supplementary-material-title-tests/supplementary-material-title-test-2/pass.xml
+++ b/test/tests/gen/supplementary-material-title-tests/supplementary-material-title-test-2/pass.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="supplementary-material-title-test-2.sch"?>
 <!--Context: supplementary-material/caption/title
-Test: assert    matches(.,'\.$')
+Test: assert    matches(.,'[\.\?]$')
 Message: title for  must end with a full stop. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>

--- a/test/tests/gen/supplementary-material-title-tests/supplementary-material-title-test-2/supplementary-material-title-test-2.sch
+++ b/test/tests/gen/supplementary-material-title-tests/supplementary-material-title-test-2/supplementary-material-title-test-2.sch
@@ -889,7 +889,7 @@
     <rule context="supplementary-material/caption/title" id="supplementary-material-title-tests">
       <let name="label" value="parent::caption/preceding-sibling::label[1]"/>
       <let name="sentence-count" value="count(tokenize(replace(replace(lower-case(.),$org-regex,''),'[\s ]$',''),'\. '))"/>
-      <assert test="matches(.,'\.$')" role="error" id="supplementary-material-title-test-2">title for <value-of select="$label"/> must end with a full stop.</assert>
+      <assert test="matches(.,'[\.\?]$')" role="error" id="supplementary-material-title-test-2">title for <value-of select="$label"/> must end with a full stop.</assert>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/xref-target-tests/other-xref-target-test/fail.xml
+++ b/test/tests/gen/xref-target-tests/other-xref-target-test/fail.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="other-xref-target-test.sch"?>
 <!--Context: xref
-Test: report    (@ref-type='other') and ($target/local-name() != 'award-group') and ($target/local-name() != 'element-citation')
+Test: report    (@ref-type='other') and not($target/local-name() = 'award-group')
 Message: xref with @ref-type='' points to . This is not correct. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>

--- a/test/tests/gen/xref-target-tests/other-xref-target-test/other-xref-target-test.sch
+++ b/test/tests/gen/xref-target-tests/other-xref-target-test/other-xref-target-test.sch
@@ -889,7 +889,7 @@
     <rule context="xref" id="xref-target-tests">
       <let name="rid" value="tokenize(@rid,' ')[1]"/>
       <let name="target" value="self::*/ancestor::article//*[@id = $rid]"/>
-      <report test="(@ref-type='other') and ($target/local-name() != 'award-group') and ($target/local-name() != 'element-citation')" role="error" id="other-xref-target-test">xref with @ref-type='<value-of select="@ref-type"/>' points to <value-of select="$target/local-name()"/>. This is not correct.</report>
+      <report test="(@ref-type='other') and not($target/local-name() = 'award-group')" role="error" id="other-xref-target-test">xref with @ref-type='<value-of select="@ref-type"/>' points to <value-of select="$target/local-name()"/>. This is not correct.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/xref-target-tests/other-xref-target-test/pass.xml
+++ b/test/tests/gen/xref-target-tests/other-xref-target-test/pass.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="other-xref-target-test.sch"?>
 <!--Context: xref
-Test: report    (@ref-type='other') and ($target/local-name() != 'award-group') and ($target/local-name() != 'element-citation')
+Test: report    (@ref-type='other') and not($target/local-name() = 'award-group')
 Message: xref with @ref-type='' points to . This is not correct. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>

--- a/test/xspec/schematron.sch
+++ b/test/xspec/schematron.sch
@@ -2032,7 +2032,7 @@
       
       <report test="(@ref-type='supplementary-material') and ($target/local-name() != 'supplementary-material')" role="error" id="supplementary-material-xref-target-test">xref with @ref-type='<value-of select="@ref-type"/>' points to <value-of select="$target/local-name()"/>. This is not correct.</report>
       
-      <report test="(@ref-type='other') and ($target/local-name() != 'award-group') and ($target/local-name() != 'element-citation')" role="error" id="other-xref-target-test">xref with @ref-type='<value-of select="@ref-type"/>' points to <value-of select="$target/local-name()"/>. This is not correct.</report>
+      <report test="(@ref-type='other') and not($target/local-name() = 'award-group')" role="error" id="other-xref-target-test">xref with @ref-type='<value-of select="@ref-type"/>' points to <value-of select="$target/local-name()"/>. This is not correct.</report>
       
       <report test="(@ref-type='table') and ($target/local-name() != 'table-wrap') and ($target/local-name() != 'table')" role="error" id="table-xref-target-test">xref with @ref-type='<value-of select="@ref-type"/>' points to <value-of select="$target/local-name()"/>. This is not correct.</report>
       
@@ -3220,7 +3220,7 @@
       
       <report test="matches(.,'^\([A-Za-z]|^[A-Za-z]\)')" role="warning" id="supplementary-material-title-test-1">'<value-of select="$label"/>' appears to have a title which is the beginning of a caption. Is this correct?</report>
       
-      <assert test="matches(.,'\.$')" role="error" id="supplementary-material-title-test-2">title for <value-of select="$label"/> must end with a full stop.</assert>
+      <assert test="matches(.,'[\.\?]$')" role="error" id="supplementary-material-title-test-2">title for <value-of select="$label"/> must end with a full stop.</assert>
       
       <report test="matches(.,' vs\.$')" role="warning" id="supplementary-material-title-test-3">title for <value-of select="$label"/> ends with 'vs.', which indicates that the title sentence may be split across title and caption.</report>
       


### PR DESCRIPTION
- Permit question mark and full stop for `supplementary-material-title-test-2`.
- No longer permit `element-citation` as a target of `<xref ref-type="other">` in `other-xref-target-test`.