### PR TITLE
downgrade supp-file-xref-conformity-4

### DIFF
--- a/src/final-JATS-schematron.sch
+++ b/src/final-JATS-schematron.sch
@@ -5541,7 +5541,7 @@
       
       <report test="contains($rid,'supp') and not(matches(.,'[Ss]upplementary file')) and ($pre-text != ' and ') and ($pre-text != '–') and ($pre-text != ', ')" role="warning" id="supp-file-xref-conformity-3">[supp-file-xref-conformity-3] <value-of select="."/> - citation points to a supplementary file, but does not include the string 'Supplementary file', which is very unusual.</report>
       
-      <assert test="contains(.,$last-rid-no)" role="error" id="supp-file-xref-conformity-4">[supp-file-xref-conformity-4] <value-of select="."/> - It looks like the citation content does not match what it directs to.</assert>
+      <assert test="contains(.,$last-rid-no)" role="warning" id="supp-file-xref-conformity-4">[supp-file-xref-conformity-4] <value-of select="."/> - It looks like the citation content does not match what it directs to. The only case where this can be ignored is if this points to an audio file.</assert>
       
       <assert test="$last-text-no = $last-rid-no" role="warning" id="supp-file-xref-conformity-5">[supp-file-xref-conformity-5] <value-of select="."/> - It looks like the citation content does not match what it directs to. Check that it is correct.</assert>
       

--- a/src/final-JATS-schematron.xsl
+++ b/src/final-JATS-schematron.xsl
@@ -26298,19 +26298,19 @@
          </svrl:successful-report>
       </xsl:if>
 
-		    <!--ASSERT error-->
+		    <!--ASSERT warning-->
       <xsl:choose>
          <xsl:when test="contains(.,$last-rid-no)"/>
          <xsl:otherwise>
             <svrl:failed-assert xmlns:svrl="http://purl.oclc.org/dsdl/svrl" test="contains(.,$last-rid-no)">
                <xsl:attribute name="id">supp-file-xref-conformity-4</xsl:attribute>
-               <xsl:attribute name="role">error</xsl:attribute>
+               <xsl:attribute name="role">warning</xsl:attribute>
                <xsl:attribute name="location">
                   <xsl:apply-templates select="." mode="schematron-select-full-path"/>
                </xsl:attribute>
                <svrl:text>[supp-file-xref-conformity-4] <xsl:text/>
                   <xsl:value-of select="."/>
-                  <xsl:text/> - It looks like the citation content does not match what it directs to.</svrl:text>
+                  <xsl:text/> - It looks like the citation content does not match what it directs to. The only case where this can be ignored is if this points to an audio file.</svrl:text>
             </svrl:failed-assert>
          </xsl:otherwise>
       </xsl:choose>

--- a/src/final-package-JATS-schematron.sch
+++ b/src/final-package-JATS-schematron.sch
@@ -5703,8 +5703,8 @@
       <report test="contains($rid,'supp') and not(matches(.,'[Ss]upplementary file')) and ($pre-text != ' and ') and ($pre-text != '–') and ($pre-text != ', ')" role="warning" id="supp-file-xref-conformity-3">
         <value-of select="."/> - citation points to a supplementary file, but does not include the string 'Supplementary file', which is very unusual.</report>
       
-      <assert test="contains(.,$last-rid-no)" role="error" id="supp-file-xref-conformity-4">
-        <value-of select="."/> - It looks like the citation content does not match what it directs to.</assert>
+      <assert test="contains(.,$last-rid-no)" role="warning" id="supp-file-xref-conformity-4">
+        <value-of select="."/> - It looks like the citation content does not match what it directs to. The only case where this can be ignored is if this points to an audio file.</assert>
       
       <assert test="$last-text-no = $last-rid-no" role="warning" id="supp-file-xref-conformity-5">
         <value-of select="."/> - It looks like the citation content does not match what it directs to. Check that it is correct.</assert>

--- a/src/pre-JATS-schematron.sch
+++ b/src/pre-JATS-schematron.sch
@@ -5481,7 +5481,7 @@
       
       <report test="contains($rid,'supp') and not(matches(.,'[Ss]upplementary file')) and ($pre-text != ' and ') and ($pre-text != '–') and ($pre-text != ', ')" role="warning" id="supp-file-xref-conformity-3">[supp-file-xref-conformity-3] <value-of select="."/> - citation points to a supplementary file, but does not include the string 'Supplementary file', which is very unusual.</report>
       
-      <assert test="contains(.,$last-rid-no)" role="error" id="supp-file-xref-conformity-4">[supp-file-xref-conformity-4] <value-of select="."/> - It looks like the citation content does not match what it directs to.</assert>
+      <assert test="contains(.,$last-rid-no)" role="warning" id="supp-file-xref-conformity-4">[supp-file-xref-conformity-4] <value-of select="."/> - It looks like the citation content does not match what it directs to. The only case where this can be ignored is if this points to an audio file.</assert>
       
       <assert test="$last-text-no = $last-rid-no" role="warning" id="supp-file-xref-conformity-5">[supp-file-xref-conformity-5] <value-of select="."/> - It looks like the citation content does not match what it directs to. Check that it is correct.</assert>
       

--- a/src/pre-JATS-schematron.xsl
+++ b/src/pre-JATS-schematron.xsl
@@ -26167,19 +26167,19 @@
          </svrl:successful-report>
       </xsl:if>
 
-		    <!--ASSERT error-->
+		    <!--ASSERT warning-->
       <xsl:choose>
          <xsl:when test="contains(.,$last-rid-no)"/>
          <xsl:otherwise>
             <svrl:failed-assert xmlns:svrl="http://purl.oclc.org/dsdl/svrl" test="contains(.,$last-rid-no)">
                <xsl:attribute name="id">supp-file-xref-conformity-4</xsl:attribute>
-               <xsl:attribute name="role">error</xsl:attribute>
+               <xsl:attribute name="role">warning</xsl:attribute>
                <xsl:attribute name="location">
                   <xsl:apply-templates select="." mode="schematron-select-full-path"/>
                </xsl:attribute>
                <svrl:text>[supp-file-xref-conformity-4] <xsl:text/>
                   <xsl:value-of select="."/>
-                  <xsl:text/> - It looks like the citation content does not match what it directs to.</svrl:text>
+                  <xsl:text/> - It looks like the citation content does not match what it directs to. The only case where this can be ignored is if this points to an audio file.</svrl:text>
             </svrl:failed-assert>
          </xsl:otherwise>
       </xsl:choose>

--- a/src/schematron.sch
+++ b/src/schematron.sch
@@ -8252,8 +8252,8 @@ tokenize(substring-after($text,' et al'),' ')[2]
         id="supp-file-xref-conformity-3"><value-of select="."/> - citation points to a supplementary file, but does not include the string 'Supplementary file', which is very unusual.</report>
       
       <assert test="contains(.,$last-rid-no)" 
-        role="error" 
-        id="supp-file-xref-conformity-4"><value-of select="."/> - It looks like the citation content does not match what it directs to.</assert>
+        role="warning" 
+        id="supp-file-xref-conformity-4"><value-of select="."/> - It looks like the citation content does not match what it directs to. The only case where this can be ignored is if this points to an audio file.</assert>
       
       <assert test="$last-text-no = $last-rid-no" 
         role="warning" 

--- a/test/tests/gen/supp-file-xref-conformance/supp-file-xref-conformity-4/fail.xml
+++ b/test/tests/gen/supp-file-xref-conformance/supp-file-xref-conformity-4/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="supp-file-xref-conformity-4.sch"?>
 <!--Context: xref[@ref-type='supplementary-material']
 Test: assert    contains(.,$last-rid-no)
-Message:  - It looks like the citation content does not match what it directs to. -->
+Message:  - It looks like the citation content does not match what it directs to. The only case where this can be ignored is if this points to an audio file. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <xref ref-type="supplementary-material" rid="supp1">Supplementary file 2</xref>

--- a/test/tests/gen/supp-file-xref-conformance/supp-file-xref-conformity-4/pass.xml
+++ b/test/tests/gen/supp-file-xref-conformance/supp-file-xref-conformity-4/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="supp-file-xref-conformity-4.sch"?>
 <!--Context: xref[@ref-type='supplementary-material']
 Test: assert    contains(.,$last-rid-no)
-Message:  - It looks like the citation content does not match what it directs to. -->
+Message:  - It looks like the citation content does not match what it directs to. The only case where this can be ignored is if this points to an audio file. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>
     <xref ref-type="supplementary-material" rid="supp1">Supplementary file 1</xref>

--- a/test/tests/gen/supp-file-xref-conformance/supp-file-xref-conformity-4/supp-file-xref-conformity-4.sch
+++ b/test/tests/gen/supp-file-xref-conformance/supp-file-xref-conformity-4/supp-file-xref-conformity-4.sch
@@ -947,8 +947,8 @@
       <let name="last-rid-no" value="substring($rid-no,string-length($rid-no))"/>
       <let name="pre-text" value="preceding-sibling::text()[1]"/>
       <let name="post-text" value="following-sibling::text()[1]"/>
-      <assert test="contains(.,$last-rid-no)" role="error" id="supp-file-xref-conformity-4">
-        <value-of select="."/> - It looks like the citation content does not match what it directs to.</assert>
+      <assert test="contains(.,$last-rid-no)" role="warning" id="supp-file-xref-conformity-4">
+        <value-of select="."/> - It looks like the citation content does not match what it directs to. The only case where this can be ignored is if this points to an audio file.</assert>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/xspec/schematron.sch
+++ b/test/xspec/schematron.sch
@@ -5704,8 +5704,8 @@
       <report test="contains($rid,'supp') and not(matches(.,'[Ss]upplementary file')) and ($pre-text != ' and ') and ($pre-text != '–') and ($pre-text != ', ')" role="warning" id="supp-file-xref-conformity-3">
         <value-of select="."/> - citation points to a supplementary file, but does not include the string 'Supplementary file', which is very unusual.</report>
       
-      <assert test="contains(.,$last-rid-no)" role="error" id="supp-file-xref-conformity-4">
-        <value-of select="."/> - It looks like the citation content does not match what it directs to.</assert>
+      <assert test="contains(.,$last-rid-no)" role="warning" id="supp-file-xref-conformity-4">
+        <value-of select="."/> - It looks like the citation content does not match what it directs to. The only case where this can be ignored is if this points to an audio file.</assert>
       
       <assert test="$last-text-no = $last-rid-no" role="warning" id="supp-file-xref-conformity-5">
         <value-of select="."/> - It looks like the citation content does not match what it directs to. Check that it is correct.</assert>

--- a/test/xspec/schematron.xspec
+++ b/test/xspec/schematron.xspec
@@ -11823,12 +11823,12 @@
       </x:scenario>
       <x:scenario label="supp-file-xref-conformity-4-pass">
         <x:context href="../tests/gen/supp-file-xref-conformance/supp-file-xref-conformity-4/pass.xml"/>
-        <x:expect-not-assert id="supp-file-xref-conformity-4" role="error"/>
+        <x:expect-not-assert id="supp-file-xref-conformity-4" role="warning"/>
         <x:expect-not-assert id="supp-file-xref-conformance-xspec-assert" role="error"/>
       </x:scenario>
       <x:scenario label="supp-file-xref-conformity-4-fail">
         <x:context href="../tests/gen/supp-file-xref-conformance/supp-file-xref-conformity-4/fail.xml"/>
-        <x:expect-assert id="supp-file-xref-conformity-4" role="error"/>
+        <x:expect-assert id="supp-file-xref-conformity-4" role="warning"/>
         <x:expect-not-assert id="supp-file-xref-conformance-xspec-assert" role="error"/>
       </x:scenario>
       <x:scenario label="supp-file-xref-conformity-5-pass">


### PR DESCRIPTION
- `supp-file-xref-conformity-4` now a warning because of audio files.