### PR TITLE
fix: various updates

### DIFF
--- a/src/final-JATS-schematron.sch
+++ b/src/final-JATS-schematron.sch
@@ -1388,7 +1388,7 @@
       
       <assert test="count(contrib[@contrib-type='senior_editor']) = 1" role="error" id="editor-conformance-1">[editor-conformance-1] contrib-group[@content-type='section'] must contain one (and only 1) Senior Editor (contrib[@contrib-type='senior_editor']).</assert>
       
-      <assert test="count(contrib[@contrib-type='editor']) = 1" role="error" id="editor-conformance-2">[editor-conformance-2] contrib-group[@content-type='section'] must contain one (and only 1) Reviewing Editor (contrib[@contrib-type='editor']).</assert>
+      <assert test="count(contrib[@contrib-type='editor']) = 1" role="warning" id="editor-conformance-2">[editor-conformance-2] contrib-group[@content-type='section'] should contain one (and only 1) Reviewing Editor (contrib[@contrib-type='editor']). This one doesn't which is almost definitely incorrect and needs correcting.</assert>
       
     </rule>
   </pattern>
@@ -1716,6 +1716,8 @@
       <assert test="parent::article-meta" role="error" id="pub-history-parent">[pub-history-parent] <name/> is only allowed to be captured as a child of article-meta. This one is a child of <value-of select="parent::*/name()"/>.</assert>
       
       <assert test="count(event) = 1" role="error" id="pub-history-child">[pub-history-child] <name/> must have one, and only one, event element. This one has <value-of select="count(event)"/>.</assert>
+      
+      <report test="event/date[@date-type='preprint']" role="info" id="preprint-flag">[preprint-flag] This article has a preprint date - <value-of select="event/date[@date-type='preprint']/@iso-8601-date"/>. eLife: please check that it is correct.</report>
     </rule>
   </pattern>
   <pattern id="event-tests-pattern">
@@ -1844,8 +1846,7 @@
   </pattern>
   <pattern id="medicine-abstract-tests-pattern">
     <rule context="article-meta[article-categories/subj-group[@subj-group-type='heading']/subject[. = ('Medicine','Epidemiology and Global Health')] and contains(title-group[1]/article-title[1],': ')]/abstract[not(@abstract-type)]" id="medicine-abstract-tests">
-      <!-- temporarily a warning. Should be error -->
-      <assert test="sec" role="warning" id="medicine-abstract-conformance">[medicine-abstract-conformance] Medicine articles with a colon in their title must have a structured abstract. Either the colon in the title is incorrect, or the abstract should be changed to a structured format.</assert>
+      <assert test="sec" role="warning" id="medicine-abstract-conformance">[medicine-abstract-conformance] Medicine articles with a colon in their title should likely have a structured abstract. If there is no note in eJP about this, either the colon in the title is incorrect, or the abstract should be changed to a structured format.</assert>
       
     </rule>
   </pattern>

--- a/src/final-JATS-schematron.xsl
+++ b/src/final-JATS-schematron.xsl
@@ -6658,17 +6658,17 @@
          </xsl:otherwise>
       </xsl:choose>
 
-		    <!--ASSERT error-->
+		    <!--ASSERT warning-->
       <xsl:choose>
          <xsl:when test="count(contrib[@contrib-type='editor']) = 1"/>
          <xsl:otherwise>
             <svrl:failed-assert xmlns:svrl="http://purl.oclc.org/dsdl/svrl" test="count(contrib[@contrib-type='editor']) = 1">
                <xsl:attribute name="id">editor-conformance-2</xsl:attribute>
-               <xsl:attribute name="role">error</xsl:attribute>
+               <xsl:attribute name="role">warning</xsl:attribute>
                <xsl:attribute name="location">
                   <xsl:apply-templates select="." mode="schematron-select-full-path"/>
                </xsl:attribute>
-               <svrl:text>[editor-conformance-2] contrib-group[@content-type='section'] must contain one (and only 1) Reviewing Editor (contrib[@contrib-type='editor']).</svrl:text>
+               <svrl:text>[editor-conformance-2] contrib-group[@content-type='section'] should contain one (and only 1) Reviewing Editor (contrib[@contrib-type='editor']). This one doesn't which is almost definitely incorrect and needs correcting.</svrl:text>
             </svrl:failed-assert>
          </xsl:otherwise>
       </xsl:choose>
@@ -8173,6 +8173,20 @@
             </svrl:failed-assert>
          </xsl:otherwise>
       </xsl:choose>
+
+		    <!--REPORT info-->
+      <xsl:if test="event/date[@date-type='preprint']">
+         <svrl:successful-report xmlns:svrl="http://purl.oclc.org/dsdl/svrl" test="event/date[@date-type='preprint']">
+            <xsl:attribute name="id">preprint-flag</xsl:attribute>
+            <xsl:attribute name="role">info</xsl:attribute>
+            <xsl:attribute name="location">
+               <xsl:apply-templates select="." mode="schematron-select-full-path"/>
+            </xsl:attribute>
+            <svrl:text>[preprint-flag] This article has a preprint date - <xsl:text/>
+               <xsl:value-of select="event/date[@date-type='preprint']/@iso-8601-date"/>
+               <xsl:text/>. eLife: please check that it is correct.</svrl:text>
+         </svrl:successful-report>
+      </xsl:if>
       <xsl:apply-templates select="*" mode="M96"/>
    </xsl:template>
    <xsl:template match="text()" priority="-1" mode="M96"/>
@@ -8828,7 +8842,7 @@
                <xsl:attribute name="location">
                   <xsl:apply-templates select="." mode="schematron-select-full-path"/>
                </xsl:attribute>
-               <svrl:text>[medicine-abstract-conformance] Medicine articles with a colon in their title must have a structured abstract. Either the colon in the title is incorrect, or the abstract should be changed to a structured format.</svrl:text>
+               <svrl:text>[medicine-abstract-conformance] Medicine articles with a colon in their title should likely have a structured abstract. If there is no note in eJP about this, either the colon in the title is incorrect, or the abstract should be changed to a structured format.</svrl:text>
             </svrl:failed-assert>
          </xsl:otherwise>
       </xsl:choose>

--- a/src/final-package-JATS-schematron.sch
+++ b/src/final-package-JATS-schematron.sch
@@ -1396,7 +1396,7 @@
       
       <assert test="count(contrib[@contrib-type='senior_editor']) = 1" role="error" id="editor-conformance-1">contrib-group[@content-type='section'] must contain one (and only 1) Senior Editor (contrib[@contrib-type='senior_editor']).</assert>
       
-      <assert test="count(contrib[@contrib-type='editor']) = 1" role="error" id="editor-conformance-2">contrib-group[@content-type='section'] must contain one (and only 1) Reviewing Editor (contrib[@contrib-type='editor']).</assert>
+      <assert test="count(contrib[@contrib-type='editor']) = 1" role="warning" id="editor-conformance-2">contrib-group[@content-type='section'] should contain one (and only 1) Reviewing Editor (contrib[@contrib-type='editor']). This one doesn't which is almost definitely incorrect and needs correcting.</assert>
       
     </rule>
   </pattern>
@@ -1737,6 +1737,8 @@
       
       <assert test="count(event) = 1" role="error" id="pub-history-child">
         <name/> must have one, and only one, event element. This one has <value-of select="count(event)"/>.</assert>
+      
+      <report test="event/date[@date-type='preprint']" role="info" id="preprint-flag">This article has a preprint date - <value-of select="event/date[@date-type='preprint']/@iso-8601-date"/>. eLife: please check that it is correct.</report>
     </rule>
   </pattern>
   <pattern id="event-tests-pattern">
@@ -1877,8 +1879,7 @@
   </pattern>
   <pattern id="medicine-abstract-tests-pattern">
     <rule context="article-meta[article-categories/subj-group[@subj-group-type='heading']/subject[. = ('Medicine','Epidemiology and Global Health')] and contains(title-group[1]/article-title[1],': ')]/abstract[not(@abstract-type)]" id="medicine-abstract-tests">
-      <!-- temporarily a warning. Should be error -->
-      <assert test="sec" role="warning" id="medicine-abstract-conformance">Medicine articles with a colon in their title must have a structured abstract. Either the colon in the title is incorrect, or the abstract should be changed to a structured format.</assert>
+      <assert test="sec" role="warning" id="medicine-abstract-conformance">Medicine articles with a colon in their title should likely have a structured abstract. If there is no note in eJP about this, either the colon in the title is incorrect, or the abstract should be changed to a structured format.</assert>
       
     </rule>
   </pattern>

--- a/src/pre-JATS-schematron.sch
+++ b/src/pre-JATS-schematron.sch
@@ -1333,7 +1333,7 @@
       
       <assert test="count(contrib[@contrib-type='senior_editor']) = 1" role="error" id="editor-conformance-1">[editor-conformance-1] contrib-group[@content-type='section'] must contain one (and only 1) Senior Editor (contrib[@contrib-type='senior_editor']).</assert>
       
-      <assert test="count(contrib[@contrib-type='editor']) = 1" role="error" id="editor-conformance-2">[editor-conformance-2] contrib-group[@content-type='section'] must contain one (and only 1) Reviewing Editor (contrib[@contrib-type='editor']).</assert>
+      <assert test="count(contrib[@contrib-type='editor']) = 1" role="warning" id="editor-conformance-2">[editor-conformance-2] contrib-group[@content-type='section'] should contain one (and only 1) Reviewing Editor (contrib[@contrib-type='editor']). This one doesn't which is almost definitely incorrect and needs correcting.</assert>
       
     </rule>
   </pattern>
@@ -1661,6 +1661,8 @@
       <assert test="parent::article-meta" role="error" id="pub-history-parent">[pub-history-parent] <name/> is only allowed to be captured as a child of article-meta. This one is a child of <value-of select="parent::*/name()"/>.</assert>
       
       <assert test="count(event) = 1" role="error" id="pub-history-child">[pub-history-child] <name/> must have one, and only one, event element. This one has <value-of select="count(event)"/>.</assert>
+      
+      <report test="event/date[@date-type='preprint']" role="info" id="preprint-flag">[preprint-flag] This article has a preprint date - <value-of select="event/date[@date-type='preprint']/@iso-8601-date"/>. eLife: please check that it is correct.</report>
     </rule>
   </pattern>
   <pattern id="event-tests-pattern">
@@ -1789,8 +1791,7 @@
   </pattern>
   <pattern id="medicine-abstract-tests-pattern">
     <rule context="article-meta[article-categories/subj-group[@subj-group-type='heading']/subject[. = ('Medicine','Epidemiology and Global Health')] and contains(title-group[1]/article-title[1],': ')]/abstract[not(@abstract-type)]" id="medicine-abstract-tests">
-      <!-- temporarily a warning. Should be error -->
-      <assert test="sec" role="warning" id="medicine-abstract-conformance">[medicine-abstract-conformance] Medicine articles with a colon in their title must have a structured abstract. Either the colon in the title is incorrect, or the abstract should be changed to a structured format.</assert>
+      <assert test="sec" role="warning" id="medicine-abstract-conformance">[medicine-abstract-conformance] Medicine articles with a colon in their title should likely have a structured abstract. If there is no note in eJP about this, either the colon in the title is incorrect, or the abstract should be changed to a structured format.</assert>
       
     </rule>
   </pattern>

--- a/src/pre-JATS-schematron.xsl
+++ b/src/pre-JATS-schematron.xsl
@@ -6578,17 +6578,17 @@
          </xsl:otherwise>
       </xsl:choose>
 
-		    <!--ASSERT error-->
+		    <!--ASSERT warning-->
       <xsl:choose>
          <xsl:when test="count(contrib[@contrib-type='editor']) = 1"/>
          <xsl:otherwise>
             <svrl:failed-assert xmlns:svrl="http://purl.oclc.org/dsdl/svrl" test="count(contrib[@contrib-type='editor']) = 1">
                <xsl:attribute name="id">editor-conformance-2</xsl:attribute>
-               <xsl:attribute name="role">error</xsl:attribute>
+               <xsl:attribute name="role">warning</xsl:attribute>
                <xsl:attribute name="location">
                   <xsl:apply-templates select="." mode="schematron-select-full-path"/>
                </xsl:attribute>
-               <svrl:text>[editor-conformance-2] contrib-group[@content-type='section'] must contain one (and only 1) Reviewing Editor (contrib[@contrib-type='editor']).</svrl:text>
+               <svrl:text>[editor-conformance-2] contrib-group[@content-type='section'] should contain one (and only 1) Reviewing Editor (contrib[@contrib-type='editor']). This one doesn't which is almost definitely incorrect and needs correcting.</svrl:text>
             </svrl:failed-assert>
          </xsl:otherwise>
       </xsl:choose>
@@ -8095,6 +8095,20 @@
             </svrl:failed-assert>
          </xsl:otherwise>
       </xsl:choose>
+
+		    <!--REPORT info-->
+      <xsl:if test="event/date[@date-type='preprint']">
+         <svrl:successful-report xmlns:svrl="http://purl.oclc.org/dsdl/svrl" test="event/date[@date-type='preprint']">
+            <xsl:attribute name="id">preprint-flag</xsl:attribute>
+            <xsl:attribute name="role">info</xsl:attribute>
+            <xsl:attribute name="location">
+               <xsl:apply-templates select="." mode="schematron-select-full-path"/>
+            </xsl:attribute>
+            <svrl:text>[preprint-flag] This article has a preprint date - <xsl:text/>
+               <xsl:value-of select="event/date[@date-type='preprint']/@iso-8601-date"/>
+               <xsl:text/>. eLife: please check that it is correct.</svrl:text>
+         </svrl:successful-report>
+      </xsl:if>
       <xsl:apply-templates select="*" mode="M94"/>
    </xsl:template>
    <xsl:template match="text()" priority="-1" mode="M94"/>
@@ -8750,7 +8764,7 @@
                <xsl:attribute name="location">
                   <xsl:apply-templates select="." mode="schematron-select-full-path"/>
                </xsl:attribute>
-               <svrl:text>[medicine-abstract-conformance] Medicine articles with a colon in their title must have a structured abstract. Either the colon in the title is incorrect, or the abstract should be changed to a structured format.</svrl:text>
+               <svrl:text>[medicine-abstract-conformance] Medicine articles with a colon in their title should likely have a structured abstract. If there is no note in eJP about this, either the colon in the title is incorrect, or the abstract should be changed to a structured format.</svrl:text>
             </svrl:failed-assert>
          </xsl:otherwise>
       </xsl:choose>

--- a/src/schematron.sch
+++ b/src/schematron.sch
@@ -1614,8 +1614,8 @@
         id="editor-conformance-1">contrib-group[@content-type='section'] must contain one (and only 1) Senior Editor (contrib[@contrib-type='senior_editor']).</assert>
       
       <assert test="count(contrib[@contrib-type='editor']) = 1" 
-        role="error" 
-        id="editor-conformance-2">contrib-group[@content-type='section'] must contain one (and only 1) Reviewing Editor (contrib[@contrib-type='editor']).</assert>
+        role="warning" 
+        id="editor-conformance-2">contrib-group[@content-type='section'] should contain one (and only 1) Reviewing Editor (contrib[@contrib-type='editor']). This one doesn't which is almost definitely incorrect and needs correcting.</assert>
       
     </rule>
     
@@ -2090,6 +2090,10 @@
       <assert test="count(event) = 1" 
         role="error" 
         id="pub-history-child"><name/> must have one, and only one, event element. This one has <value-of select="count(event)"/>.</assert>
+      
+      <report test="event/date[@date-type='preprint']" 
+        role="info" 
+        id="preprint-flag">This article has a preprint date - <value-of select="event/date[@date-type='preprint']/@iso-8601-date"/>. eLife: please check that it is correct.</report>
     </rule>
     
     <rule context="event" id="event-tests">
@@ -2288,10 +2292,9 @@
     </rule>
     
     <rule context="article-meta[article-categories/subj-group[@subj-group-type='heading']/subject[. = ('Medicine','Epidemiology and Global Health')] and contains(title-group[1]/article-title[1],': ')]/abstract[not(@abstract-type)]" id="medicine-abstract-tests">
-      <!-- temporarily a warning. Should be error -->
       <assert test="sec" 
         role="warning" 
-        id="medicine-abstract-conformance">Medicine articles with a colon in their title must have a structured abstract. Either the colon in the title is incorrect, or the abstract should be changed to a structured format.</assert>
+        id="medicine-abstract-conformance">Medicine articles with a colon in their title should likely have a structured abstract. If there is no note in eJP about this, either the colon in the title is incorrect, or the abstract should be changed to a structured format.</assert>
       
     </rule>
     

--- a/test/tests/gen/medicine-abstract-tests/medicine-abstract-conformance/fail.xml
+++ b/test/tests/gen/medicine-abstract-tests/medicine-abstract-conformance/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="medicine-abstract-conformance.sch"?>
 <!--Context: article-meta[article-categories/subj-group[@subj-group-type='heading']/subject[. = ('Medicine','Epidemiology and Global Health')] and contains(title-group[1]/article-title[1],': ')]/abstract[not(@abstract-type)]
 Test: assert    sec
-Message: Medicine articles with a colon in their title must have a structured abstract. Either the colon in the title is incorrect, or the abstract should be changed to a structured format. -->
+Message: Medicine articles with a colon in their title should likely have a structured abstract. If there is no note in eJP about this, either the colon in the title is incorrect, or the abstract should be changed to a structured format. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>
     <article-meta>

--- a/test/tests/gen/medicine-abstract-tests/medicine-abstract-conformance/medicine-abstract-conformance.sch
+++ b/test/tests/gen/medicine-abstract-tests/medicine-abstract-conformance/medicine-abstract-conformance.sch
@@ -1029,7 +1029,7 @@
   </xsl:function>
   <pattern id="article-metadata">
     <rule context="article-meta[article-categories/subj-group[@subj-group-type='heading']/subject[. = ('Medicine','Epidemiology and Global Health')] and contains(title-group[1]/article-title[1],': ')]/abstract[not(@abstract-type)]" id="medicine-abstract-tests">
-      <assert test="sec" role="warning" id="medicine-abstract-conformance">Medicine articles with a colon in their title must have a structured abstract. Either the colon in the title is incorrect, or the abstract should be changed to a structured format.</assert>
+      <assert test="sec" role="warning" id="medicine-abstract-conformance">Medicine articles with a colon in their title should likely have a structured abstract. If there is no note in eJP about this, either the colon in the title is incorrect, or the abstract should be changed to a structured format.</assert>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/medicine-abstract-tests/medicine-abstract-conformance/pass.xml
+++ b/test/tests/gen/medicine-abstract-tests/medicine-abstract-conformance/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="medicine-abstract-conformance.sch"?>
 <!--Context: article-meta[article-categories/subj-group[@subj-group-type='heading']/subject[. = ('Medicine','Epidemiology and Global Health')] and contains(title-group[1]/article-title[1],': ')]/abstract[not(@abstract-type)]
 Test: assert    sec
-Message: Medicine articles with a colon in their title must have a structured abstract. Either the colon in the title is incorrect, or the abstract should be changed to a structured format. -->
+Message: Medicine articles with a colon in their title should likely have a structured abstract. If there is no note in eJP about this, either the colon in the title is incorrect, or the abstract should be changed to a structured format. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>
     <article-meta>

--- a/test/tests/gen/pub-history-tests/preprint-flag/fail.xml
+++ b/test/tests/gen/pub-history-tests/preprint-flag/fail.xml
@@ -1,0 +1,9 @@
+<?oxygen SCHSchema="preprint-flag.sch"?>
+<!--Context: pub-history
+Test: report    event/date[@date-type='preprint']
+Message: This article has a preprint date - . eLife: please check that it is correct. -->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <pub-history/>
+  </article>
+</root>

--- a/test/tests/gen/pub-history-tests/preprint-flag/fail.xml
+++ b/test/tests/gen/pub-history-tests/preprint-flag/fail.xml
@@ -4,6 +4,16 @@ Test: report    event/date[@date-type='preprint']
 Message: This article has a preprint date - . eLife: please check that it is correct. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>
-    <pub-history/>
+    <pub-history>
+      <event>
+        <event-desc>This manuscript was published as a preprint at bioRxiv.</event-desc>
+        <date date-type="preprint" iso-8601-date="2021-05-27">
+          <day>27</day>
+          <month>05</month>
+          <year>2021</year>
+        </date>
+        <self-uri content-type="preprint" xlink:href="https://doi.org/10.1101/2021.05.25.445638"/>
+      </event>
+    </pub-history>
   </article>
 </root>

--- a/test/tests/gen/pub-history-tests/preprint-flag/pass.xml
+++ b/test/tests/gen/pub-history-tests/preprint-flag/pass.xml
@@ -1,0 +1,20 @@
+<?oxygen SCHSchema="preprint-flag.sch"?>
+<!--Context: pub-history
+Test: report    event/date[@date-type='preprint']
+Message: This article has a preprint date - . eLife: please check that it is correct. -->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML"
+  xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <pub-history>
+      <event>
+        <event-desc>This manuscript was published as a preprint at bioRxiv.</event-desc>
+        <date date-type="preprint" iso-8601-date="2021-05-27">
+          <day>27</day>
+          <month>05</month>
+          <year>2021</year>
+        </date>
+        <self-uri content-type="preprint" xlink:href="https://doi.org/10.1101/2021.05.25.445638"/>
+      </event>
+    </pub-history>
+  </article>
+</root>

--- a/test/tests/gen/pub-history-tests/preprint-flag/pass.xml
+++ b/test/tests/gen/pub-history-tests/preprint-flag/pass.xml
@@ -5,16 +5,6 @@ Message: This article has a preprint date - . eLife: please check that it is cor
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML"
   xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>
-    <pub-history>
-      <event>
-        <event-desc>This manuscript was published as a preprint at bioRxiv.</event-desc>
-        <date date-type="preprint" iso-8601-date="2021-05-27">
-          <day>27</day>
-          <month>05</month>
-          <year>2021</year>
-        </date>
-        <self-uri content-type="preprint" xlink:href="https://doi.org/10.1101/2021.05.25.445638"/>
-      </event>
-    </pub-history>
+    <pub-history/>
   </article>
 </root>

--- a/test/tests/gen/pub-history-tests/preprint-flag/preprint-flag.sch
+++ b/test/tests/gen/pub-history-tests/preprint-flag/preprint-flag.sch
@@ -1028,13 +1028,13 @@
     
   </xsl:function>
   <pattern id="article-metadata">
-    <rule context="article/front/article-meta/contrib-group[@content-type='section']" id="test-editor-contrib-group">
-      <assert test="count(contrib[@contrib-type='editor']) = 1" role="warning" id="editor-conformance-2">contrib-group[@content-type='section'] should contain one (and only 1) Reviewing Editor (contrib[@contrib-type='editor']). This one doesn't which is almost definitely incorrect and needs correcting.</assert>
+    <rule context="pub-history" id="pub-history-tests">
+      <report test="event/date[@date-type='preprint']" role="info" id="preprint-flag">This article has a preprint date - <value-of select="event/date[@date-type='preprint']/@iso-8601-date"/>. eLife: please check that it is correct.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::article/front/article-meta/contrib-group[@content-type='section']" role="error" id="test-editor-contrib-group-xspec-assert">article/front/article-meta/contrib-group[@content-type='section'] must be present.</assert>
+      <assert test="descendant::pub-history" role="error" id="pub-history-tests-xspec-assert">pub-history must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/test-editor-contrib-group/editor-conformance-2/fail.xml
+++ b/test/tests/gen/test-editor-contrib-group/editor-conformance-2/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="editor-conformance-2.sch"?>
 <!--Context: article/front/article-meta/contrib-group[@content-type='section']
 Test: assert    count(contrib[@contrib-type='editor']) = 1
-Message: contrib-group[@content-type='section'] must contain one (and only 1) Reviewing Editor (contrib[@contrib-type='editor']). -->
+Message: contrib-group[@content-type='section'] should contain one (and only 1) Reviewing Editor (contrib[@contrib-type='editor']). This one doesn't which is almost definitely incorrect and needs correcting. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>
     <front>

--- a/test/tests/gen/test-editor-contrib-group/editor-conformance-2/pass.xml
+++ b/test/tests/gen/test-editor-contrib-group/editor-conformance-2/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="editor-conformance-2.sch"?>
 <!--Context: article/front/article-meta/contrib-group[@content-type='section']
 Test: assert    count(contrib[@contrib-type='editor']) = 1
-Message: contrib-group[@content-type='section'] must contain one (and only 1) Reviewing Editor (contrib[@contrib-type='editor']). -->
+Message: contrib-group[@content-type='section'] should contain one (and only 1) Reviewing Editor (contrib[@contrib-type='editor']). This one doesn't which is almost definitely incorrect and needs correcting. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>
     <front>

--- a/test/xspec/schematron.sch
+++ b/test/xspec/schematron.sch
@@ -1390,7 +1390,7 @@
       
       <assert test="count(contrib[@contrib-type='senior_editor']) = 1" role="error" id="editor-conformance-1">contrib-group[@content-type='section'] must contain one (and only 1) Senior Editor (contrib[@contrib-type='senior_editor']).</assert>
       
-      <assert test="count(contrib[@contrib-type='editor']) = 1" role="error" id="editor-conformance-2">contrib-group[@content-type='section'] must contain one (and only 1) Reviewing Editor (contrib[@contrib-type='editor']).</assert>
+      <assert test="count(contrib[@contrib-type='editor']) = 1" role="warning" id="editor-conformance-2">contrib-group[@content-type='section'] should contain one (and only 1) Reviewing Editor (contrib[@contrib-type='editor']). This one doesn't which is almost definitely incorrect and needs correcting.</assert>
       
     </rule>
   </pattern>
@@ -1732,6 +1732,8 @@
       
       <assert test="count(event) = 1" role="error" id="pub-history-child">
         <name/> must have one, and only one, event element. This one has <value-of select="count(event)"/>.</assert>
+      
+      <report test="event/date[@date-type='preprint']" role="info" id="preprint-flag">This article has a preprint date - <value-of select="event/date[@date-type='preprint']/@iso-8601-date"/>. eLife: please check that it is correct.</report>
     </rule>
   </pattern>
   <pattern id="event-tests-pattern">
@@ -1872,8 +1874,7 @@
   </pattern>
   <pattern id="medicine-abstract-tests-pattern">
     <rule context="article-meta[article-categories/subj-group[@subj-group-type='heading']/subject[. = ('Medicine','Epidemiology and Global Health')] and contains(title-group[1]/article-title[1],': ')]/abstract[not(@abstract-type)]" id="medicine-abstract-tests">
-      <!-- temporarily a warning. Should be error -->
-      <assert test="sec" role="warning" id="medicine-abstract-conformance">Medicine articles with a colon in their title must have a structured abstract. Either the colon in the title is incorrect, or the abstract should be changed to a structured format.</assert>
+      <assert test="sec" role="warning" id="medicine-abstract-conformance">Medicine articles with a colon in their title should likely have a structured abstract. If there is no note in eJP about this, either the colon in the title is incorrect, or the abstract should be changed to a structured format.</assert>
       
     </rule>
   </pattern>

--- a/test/xspec/schematron.xspec
+++ b/test/xspec/schematron.xspec
@@ -877,12 +877,12 @@
       </x:scenario>
       <x:scenario label="editor-conformance-2-pass">
         <x:context href="../tests/gen/test-editor-contrib-group/editor-conformance-2/pass.xml"/>
-        <x:expect-not-assert id="editor-conformance-2" role="error"/>
+        <x:expect-not-assert id="editor-conformance-2" role="warning"/>
         <x:expect-not-assert id="test-editor-contrib-group-xspec-assert" role="error"/>
       </x:scenario>
       <x:scenario label="editor-conformance-2-fail">
         <x:context href="../tests/gen/test-editor-contrib-group/editor-conformance-2/fail.xml"/>
-        <x:expect-assert id="editor-conformance-2" role="error"/>
+        <x:expect-assert id="editor-conformance-2" role="warning"/>
         <x:expect-not-assert id="test-editor-contrib-group-xspec-assert" role="error"/>
       </x:scenario>
     </x:scenario>
@@ -1735,6 +1735,16 @@
       <x:scenario label="pub-history-child-fail">
         <x:context href="../tests/gen/pub-history-tests/pub-history-child/fail.xml"/>
         <x:expect-assert id="pub-history-child" role="error"/>
+        <x:expect-not-assert id="pub-history-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="preprint-flag-pass">
+        <x:context href="../tests/gen/pub-history-tests/preprint-flag/pass.xml"/>
+        <x:expect-not-report id="preprint-flag" role="info"/>
+        <x:expect-not-assert id="pub-history-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="preprint-flag-fail">
+        <x:context href="../tests/gen/pub-history-tests/preprint-flag/fail.xml"/>
+        <x:expect-report id="preprint-flag" role="info"/>
         <x:expect-not-assert id="pub-history-tests-xspec-assert" role="error"/>
       </x:scenario>
     </x:scenario>


### PR DESCRIPTION
- downgrade `editor-conformance-2` to waring
- Add info check `preprint-flag`
- `medicine-abstract-conformance` to stay as warning