### PR TITLE
fix: bug with text-v-object-cite-test

### DIFF
--- a/src/final-JATS-schematron.sch
+++ b/src/final-JATS-schematron.sch
@@ -5815,7 +5815,7 @@
   
   <pattern id="unlinked-object-cite-pattern">
     <rule context="fig[not(ancestor::sub-article) and label]|       table-wrap[not(ancestor::sub-article) and label[not(contains(.,'ey resources table'))]]|       media[not(ancestor::sub-article) and label]|       supplementary-material[not(ancestor::sub-article) and label]" id="unlinked-object-cite">
-      <let name="cite1" value="replace(label[1],'\.','')"/>
+      <let name="cite1" value="replace(label[1],'[\(\)\.]','')"/>
       <let name="pre-regex" value="replace($cite1,'—','[—–\\-]')"/>
       
       <let name="regex" value="replace($pre-regex,'\s','[\\s ]')"/>

--- a/src/final-JATS-schematron.xsl
+++ b/src/final-JATS-schematron.xsl
@@ -27578,7 +27578,7 @@
 
 	  <!--RULE unlinked-object-cite-->
    <xsl:template match="fig[not(ancestor::sub-article) and label]|       table-wrap[not(ancestor::sub-article) and label[not(contains(.,'ey resources table'))]]|       media[not(ancestor::sub-article) and label]|       supplementary-material[not(ancestor::sub-article) and label]" priority="1000" mode="M420">
-      <xsl:variable name="cite1" select="replace(label[1],'\.','')"/>
+      <xsl:variable name="cite1" select="replace(label[1],'[\(\)\.]','')"/>
       <xsl:variable name="pre-regex" select="replace($cite1,'—','[—–\\-]')"/>
       <xsl:variable name="regex" select="replace($pre-regex,'\s','[\\s ]')"/>
       <xsl:variable name="article-text" select="string-join(         for $x in ancestor::article/*[local-name() = 'body' or local-name() = 'back']//*         return if ($x/local-name()='label') then ()         else if ($x/ancestor::sub-article or $x/local-name()='sub-article') then ()         else if ($x/ancestor::sec[@sec-type='data-availability']) then ()         else if ($x/ancestor::sec[@sec-type='additional-information']) then ()         else if ($x/ancestor::ref-list) then ()         else if ($x/local-name() = 'xref') then ()         else $x/text(),'')"/>

--- a/src/final-package-JATS-schematron.sch
+++ b/src/final-package-JATS-schematron.sch
@@ -5984,7 +5984,7 @@
   
   <pattern id="unlinked-object-cite-pattern">
     <rule context="fig[not(ancestor::sub-article) and label]|       table-wrap[not(ancestor::sub-article) and label[not(contains(.,'ey resources table'))]]|       media[not(ancestor::sub-article) and label]|       supplementary-material[not(ancestor::sub-article) and label]" id="unlinked-object-cite">
-      <let name="cite1" value="replace(label[1],'\.','')"/>
+      <let name="cite1" value="replace(label[1],'[\(\)\.]','')"/>
       <let name="pre-regex" value="replace($cite1,'—','[—–\\-]')"/>
       <!-- Account for no break spaces in text -->
       <let name="regex" value="replace($pre-regex,'\s','[\\s ]')"/>

--- a/src/pre-JATS-schematron.sch
+++ b/src/pre-JATS-schematron.sch
@@ -5753,7 +5753,7 @@
   
   <pattern id="unlinked-object-cite-pattern">
     <rule context="fig[not(ancestor::sub-article) and label]|       table-wrap[not(ancestor::sub-article) and label[not(contains(.,'ey resources table'))]]|       media[not(ancestor::sub-article) and label]|       supplementary-material[not(ancestor::sub-article) and label]" id="unlinked-object-cite">
-      <let name="cite1" value="replace(label[1],'\.','')"/>
+      <let name="cite1" value="replace(label[1],'[\(\)\.]','')"/>
       <let name="pre-regex" value="replace($cite1,'—','[—–\\-]')"/>
       
       <let name="regex" value="replace($pre-regex,'\s','[\\s ]')"/>

--- a/src/pre-JATS-schematron.xsl
+++ b/src/pre-JATS-schematron.xsl
@@ -27412,7 +27412,7 @@
 
 	  <!--RULE unlinked-object-cite-->
    <xsl:template match="fig[not(ancestor::sub-article) and label]|       table-wrap[not(ancestor::sub-article) and label[not(contains(.,'ey resources table'))]]|       media[not(ancestor::sub-article) and label]|       supplementary-material[not(ancestor::sub-article) and label]" priority="1000" mode="M418">
-      <xsl:variable name="cite1" select="replace(label[1],'\.','')"/>
+      <xsl:variable name="cite1" select="replace(label[1],'[\(\)\.]','')"/>
       <xsl:variable name="pre-regex" select="replace($cite1,'—','[—–\\-]')"/>
       <xsl:variable name="regex" select="replace($pre-regex,'\s','[\\s ]')"/>
       <xsl:variable name="article-text" select="string-join(         for $x in ancestor::article/*[local-name() = 'body' or local-name() = 'back']//*         return if ($x/local-name()='label') then ()         else if ($x/ancestor::sub-article or $x/local-name()='sub-article') then ()         else if ($x/ancestor::sec[@sec-type='data-availability']) then ()         else if ($x/ancestor::sec[@sec-type='additional-information']) then ()         else if ($x/ancestor::ref-list) then ()         else if ($x/local-name() = 'xref') then ()         else $x/text(),'')"/>

--- a/src/schematron.sch
+++ b/src/schematron.sch
@@ -8650,7 +8650,7 @@ tokenize(substring-after($text,' et al'),' ')[2]
       table-wrap[not(ancestor::sub-article) and label[not(contains(.,'ey resources table'))]]|
       media[not(ancestor::sub-article) and label]|
       supplementary-material[not(ancestor::sub-article) and label]" id="unlinked-object-cite">
-      <let name="cite1" value="replace(label[1],'\.','')"/>
+      <let name="cite1" value="replace(label[1],'[\(\)\.]','')"/>
       <let name="pre-regex" value="replace($cite1,'—','[—–\\-]')"/>
       <!-- Account for no break spaces in text -->
       <let name="regex" value="replace($pre-regex,'\s','[\\s ]')"/>

--- a/test/tests/gen/unlinked-object-cite/text-v-object-cite-test/text-v-object-cite-test.sch
+++ b/test/tests/gen/unlinked-object-cite/text-v-object-cite-test/text-v-object-cite-test.sch
@@ -1029,7 +1029,7 @@
   </xsl:function>
   <pattern id="unlinked-object-cite-pattern">
     <rule context="fig[not(ancestor::sub-article) and label]|       table-wrap[not(ancestor::sub-article) and label[not(contains(.,'ey resources table'))]]|       media[not(ancestor::sub-article) and label]|       supplementary-material[not(ancestor::sub-article) and label]" id="unlinked-object-cite">
-      <let name="cite1" value="replace(label[1],'\.','')"/>
+      <let name="cite1" value="replace(label[1],'[\(\)\.]','')"/>
       <let name="pre-regex" value="replace($cite1,'—','[—–\\-]')"/>
       <let name="regex" value="replace($pre-regex,'\s','[\\s ]')"/>
       <let name="article-text" value="string-join(         for $x in ancestor::article/*[local-name() = 'body' or local-name() = 'back']//*         return if ($x/local-name()='label') then ()         else if ($x/ancestor::sub-article or $x/local-name()='sub-article') then ()         else if ($x/ancestor::sec[@sec-type='data-availability']) then ()         else if ($x/ancestor::sec[@sec-type='additional-information']) then ()         else if ($x/ancestor::ref-list) then ()         else if ($x/local-name() = 'xref') then ()         else $x/text(),'')"/>

--- a/test/xspec/schematron.sch
+++ b/test/xspec/schematron.sch
@@ -5987,7 +5987,7 @@
   
   <pattern id="unlinked-object-cite-pattern">
     <rule context="fig[not(ancestor::sub-article) and label]|       table-wrap[not(ancestor::sub-article) and label[not(contains(.,'ey resources table'))]]|       media[not(ancestor::sub-article) and label]|       supplementary-material[not(ancestor::sub-article) and label]" id="unlinked-object-cite">
-      <let name="cite1" value="replace(label[1],'\.','')"/>
+      <let name="cite1" value="replace(label[1],'[\(\)\.]','')"/>
       <let name="pre-regex" value="replace($cite1,'—','[—–\\-]')"/>
       <!-- Account for no break spaces in text -->
       <let name="regex" value="replace($pre-regex,'\s','[\\s ]')"/>


### PR DESCRIPTION
- `text-v-object-cite-test` no longer fatal errors if labels contain single brackets