### PR TITLE
fix: no fatal error if more than one doi in ref

### DIFF
--- a/src/final-JATS-schematron.sch
+++ b/src/final-JATS-schematron.sch
@@ -5078,7 +5078,7 @@
       
       <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/references#self-cite-1" test="lower-case(pub-id[@pub-id-type='doi'][1]) = $article-doi" role="error" id="self-cite-1">[self-cite-1] '<value-of select="@publication-type"/>' type reference has a doi which is the same as this article - <value-of select="pub-id[@pub-id-type='doi']"/>. Is the reference correct? If it is intentional, please remove the reference, and replace citations in the text with the text 'current work' or similar.</report>
       
-      <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/references#self-cite-1" test="(lower-case(pub-id[@pub-id-type='doi']) != $article-doi) and                (lower-case(source[1]) = 'elife') and                ((lower-case(article-title[1]) = $title) or (lower-case(chapter-title[1]) = $title)) " role="error" id="self-cite-2">[self-cite-2] '<value-of select="@publication-type"/>' type reference looks to possibly be citing itself. If that's the case (and this isn't an error within the reference), please delete the reference and replace any citations in the text with the text 'current work'.</report>
+      <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/references#self-cite-1" test="(lower-case(pub-id[@pub-id-type='doi'][1]) != $article-doi) and                (lower-case(source[1]) = 'elife') and                ((lower-case(article-title[1]) = $title) or (lower-case(chapter-title[1]) = $title)) " role="error" id="self-cite-2">[self-cite-2] '<value-of select="@publication-type"/>' type reference looks to possibly be citing itself. If that's the case (and this isn't an error within the reference), please delete the reference and replace any citations in the text with the text 'current work'.</report>
       
     </rule>
   </pattern>
@@ -5917,6 +5917,8 @@
       <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/references#pub-id-test-5" test="ends-with(.,'.')" role="error" id="pub-id-test-5">[pub-id-test-5] <value-of select="@pub-id-type"/> pub-id ends with a full stop - <value-of select="."/> - which is not correct. Please remove the full stop.</report>
       
       <report test="matches(.,'\p{Zs}$')" role="error" id="pub-id-test-6">[pub-id-test-6] <value-of select="@pub-id-type"/> pub-id ends with space(s) which is incorrect - '<value-of select="."/>'.</report>
+      
+      <report test="preceding-sibling::pub-id/@pub-id-type = @pub-id-type" role="error" id="indistinct-pub-ids">[indistinct-pub-ids] element-citation for <value-of select="e:citation-format1(parent::element-citation)"/> has more than one pub-id with the type <value-of select="@pub-id-type"/>, which cannot be correct - <value-of select="."/>.</report>
       
     </rule>
   </pattern>

--- a/src/final-JATS-schematron.xsl
+++ b/src/final-JATS-schematron.xsl
@@ -24363,8 +24363,8 @@
       </xsl:if>
 
 		    <!--REPORT error-->
-      <xsl:if test="(lower-case(pub-id[@pub-id-type='doi']) != $article-doi) and                (lower-case(source[1]) = 'elife') and                ((lower-case(article-title[1]) = $title) or (lower-case(chapter-title[1]) = $title)) ">
-         <svrl:successful-report xmlns:svrl="http://purl.oclc.org/dsdl/svrl" test="(lower-case(pub-id[@pub-id-type='doi']) != $article-doi) and (lower-case(source[1]) = 'elife') and ((lower-case(article-title[1]) = $title) or (lower-case(chapter-title[1]) = $title))">
+      <xsl:if test="(lower-case(pub-id[@pub-id-type='doi'][1]) != $article-doi) and                (lower-case(source[1]) = 'elife') and                ((lower-case(article-title[1]) = $title) or (lower-case(chapter-title[1]) = $title)) ">
+         <svrl:successful-report xmlns:svrl="http://purl.oclc.org/dsdl/svrl" test="(lower-case(pub-id[@pub-id-type='doi'][1]) != $article-doi) and (lower-case(source[1]) = 'elife') and ((lower-case(article-title[1]) = $title) or (lower-case(chapter-title[1]) = $title))">
             <xsl:attribute name="id">self-cite-2</xsl:attribute>
             <xsl:attribute name="see">https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/references#self-cite-1</xsl:attribute>
             <xsl:attribute name="role">error</xsl:attribute>
@@ -28191,6 +28191,24 @@
                <xsl:text/> pub-id ends with space(s) which is incorrect - '<xsl:text/>
                <xsl:value-of select="."/>
                <xsl:text/>'.</svrl:text>
+         </svrl:successful-report>
+      </xsl:if>
+
+		    <!--REPORT error-->
+      <xsl:if test="preceding-sibling::pub-id/@pub-id-type = @pub-id-type">
+         <svrl:successful-report xmlns:svrl="http://purl.oclc.org/dsdl/svrl" test="preceding-sibling::pub-id/@pub-id-type = @pub-id-type">
+            <xsl:attribute name="id">indistinct-pub-ids</xsl:attribute>
+            <xsl:attribute name="role">error</xsl:attribute>
+            <xsl:attribute name="location">
+               <xsl:apply-templates select="." mode="schematron-select-full-path"/>
+            </xsl:attribute>
+            <svrl:text>[indistinct-pub-ids] element-citation for <xsl:text/>
+               <xsl:value-of select="e:citation-format1(parent::element-citation)"/>
+               <xsl:text/> has more than one pub-id with the type <xsl:text/>
+               <xsl:value-of select="@pub-id-type"/>
+               <xsl:text/>, which cannot be correct - <xsl:text/>
+               <xsl:value-of select="."/>
+               <xsl:text/>.</svrl:text>
          </svrl:successful-report>
       </xsl:if>
       <xsl:apply-templates select="*" mode="M438"/>

--- a/src/final-package-JATS-schematron.sch
+++ b/src/final-package-JATS-schematron.sch
@@ -5240,7 +5240,7 @@
       
       <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/references#self-cite-1" test="lower-case(pub-id[@pub-id-type='doi'][1]) = $article-doi" role="error" id="self-cite-1">'<value-of select="@publication-type"/>' type reference has a doi which is the same as this article - <value-of select="pub-id[@pub-id-type='doi']"/>. Is the reference correct? If it is intentional, please remove the reference, and replace citations in the text with the text 'current work' or similar.</report>
       
-      <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/references#self-cite-1" test="(lower-case(pub-id[@pub-id-type='doi']) != $article-doi) and                (lower-case(source[1]) = 'elife') and                ((lower-case(article-title[1]) = $title) or (lower-case(chapter-title[1]) = $title)) " role="error" id="self-cite-2">'<value-of select="@publication-type"/>' type reference looks to possibly be citing itself. If that's the case (and this isn't an error within the reference), please delete the reference and replace any citations in the text with the text 'current work'.</report>
+      <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/references#self-cite-1" test="(lower-case(pub-id[@pub-id-type='doi'][1]) != $article-doi) and                (lower-case(source[1]) = 'elife') and                ((lower-case(article-title[1]) = $title) or (lower-case(chapter-title[1]) = $title)) " role="error" id="self-cite-2">'<value-of select="@publication-type"/>' type reference looks to possibly be citing itself. If that's the case (and this isn't an error within the reference), please delete the reference and replace any citations in the text with the text 'current work'.</report>
       
     </rule>
   </pattern>
@@ -6083,6 +6083,8 @@
       
       <report test="matches(.,'\p{Zs}$')" role="error" id="pub-id-test-6">
         <value-of select="@pub-id-type"/> pub-id ends with space(s) which is incorrect - '<value-of select="."/>'.</report>
+      
+      <report test="preceding-sibling::pub-id/@pub-id-type = @pub-id-type" role="error" id="indistinct-pub-ids">element-citation for <value-of select="e:citation-format1(parent::element-citation)"/> has more than one pub-id with the type <value-of select="@pub-id-type"/>, which cannot be correct - <value-of select="."/>.</report>
       
     </rule>
   </pattern>

--- a/src/pre-JATS-schematron.sch
+++ b/src/pre-JATS-schematron.sch
@@ -5021,7 +5021,7 @@
       
       <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/references#self-cite-1" test="lower-case(pub-id[@pub-id-type='doi'][1]) = $article-doi" role="error" id="self-cite-1">[self-cite-1] '<value-of select="@publication-type"/>' type reference has a doi which is the same as this article - <value-of select="pub-id[@pub-id-type='doi']"/>. Is the reference correct? If it is intentional, please remove the reference, and replace citations in the text with the text 'current work' or similar.</report>
       
-      <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/references#self-cite-1" test="(lower-case(pub-id[@pub-id-type='doi']) != $article-doi) and                (lower-case(source[1]) = 'elife') and                ((lower-case(article-title[1]) = $title) or (lower-case(chapter-title[1]) = $title)) " role="error" id="self-cite-2">[self-cite-2] '<value-of select="@publication-type"/>' type reference looks to possibly be citing itself. If that's the case (and this isn't an error within the reference), please delete the reference and replace any citations in the text with the text 'current work'.</report>
+      <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/references#self-cite-1" test="(lower-case(pub-id[@pub-id-type='doi'][1]) != $article-doi) and                (lower-case(source[1]) = 'elife') and                ((lower-case(article-title[1]) = $title) or (lower-case(chapter-title[1]) = $title)) " role="error" id="self-cite-2">[self-cite-2] '<value-of select="@publication-type"/>' type reference looks to possibly be citing itself. If that's the case (and this isn't an error within the reference), please delete the reference and replace any citations in the text with the text 'current work'.</report>
       
     </rule>
   </pattern>
@@ -5859,6 +5859,8 @@
       <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/references#pub-id-test-5" test="ends-with(.,'.')" role="error" id="pub-id-test-5">[pub-id-test-5] <value-of select="@pub-id-type"/> pub-id ends with a full stop - <value-of select="."/> - which is not correct. Please remove the full stop.</report>
       
       <report test="matches(.,'\p{Zs}$')" role="error" id="pub-id-test-6">[pub-id-test-6] <value-of select="@pub-id-type"/> pub-id ends with space(s) which is incorrect - '<value-of select="."/>'.</report>
+      
+      <report test="preceding-sibling::pub-id/@pub-id-type = @pub-id-type" role="error" id="indistinct-pub-ids">[indistinct-pub-ids] element-citation for <value-of select="e:citation-format1(parent::element-citation)"/> has more than one pub-id with the type <value-of select="@pub-id-type"/>, which cannot be correct - <value-of select="."/>.</report>
       
     </rule>
   </pattern>

--- a/src/pre-JATS-schematron.xsl
+++ b/src/pre-JATS-schematron.xsl
@@ -24263,8 +24263,8 @@
       </xsl:if>
 
 		    <!--REPORT error-->
-      <xsl:if test="(lower-case(pub-id[@pub-id-type='doi']) != $article-doi) and                (lower-case(source[1]) = 'elife') and                ((lower-case(article-title[1]) = $title) or (lower-case(chapter-title[1]) = $title)) ">
-         <svrl:successful-report xmlns:svrl="http://purl.oclc.org/dsdl/svrl" test="(lower-case(pub-id[@pub-id-type='doi']) != $article-doi) and (lower-case(source[1]) = 'elife') and ((lower-case(article-title[1]) = $title) or (lower-case(chapter-title[1]) = $title))">
+      <xsl:if test="(lower-case(pub-id[@pub-id-type='doi'][1]) != $article-doi) and                (lower-case(source[1]) = 'elife') and                ((lower-case(article-title[1]) = $title) or (lower-case(chapter-title[1]) = $title)) ">
+         <svrl:successful-report xmlns:svrl="http://purl.oclc.org/dsdl/svrl" test="(lower-case(pub-id[@pub-id-type='doi'][1]) != $article-doi) and (lower-case(source[1]) = 'elife') and ((lower-case(article-title[1]) = $title) or (lower-case(chapter-title[1]) = $title))">
             <xsl:attribute name="id">self-cite-2</xsl:attribute>
             <xsl:attribute name="see">https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/references#self-cite-1</xsl:attribute>
             <xsl:attribute name="role">error</xsl:attribute>
@@ -28090,6 +28090,24 @@
                <xsl:text/> pub-id ends with space(s) which is incorrect - '<xsl:text/>
                <xsl:value-of select="."/>
                <xsl:text/>'.</svrl:text>
+         </svrl:successful-report>
+      </xsl:if>
+
+		    <!--REPORT error-->
+      <xsl:if test="preceding-sibling::pub-id/@pub-id-type = @pub-id-type">
+         <svrl:successful-report xmlns:svrl="http://purl.oclc.org/dsdl/svrl" test="preceding-sibling::pub-id/@pub-id-type = @pub-id-type">
+            <xsl:attribute name="id">indistinct-pub-ids</xsl:attribute>
+            <xsl:attribute name="role">error</xsl:attribute>
+            <xsl:attribute name="location">
+               <xsl:apply-templates select="." mode="schematron-select-full-path"/>
+            </xsl:attribute>
+            <svrl:text>[indistinct-pub-ids] element-citation for <xsl:text/>
+               <xsl:value-of select="e:citation-format1(parent::element-citation)"/>
+               <xsl:text/> has more than one pub-id with the type <xsl:text/>
+               <xsl:value-of select="@pub-id-type"/>
+               <xsl:text/>, which cannot be correct - <xsl:text/>
+               <xsl:value-of select="."/>
+               <xsl:text/>.</svrl:text>
          </svrl:successful-report>
       </xsl:if>
       <xsl:apply-templates select="*" mode="M436"/>

--- a/src/schematron.sch
+++ b/src/schematron.sch
@@ -7411,7 +7411,7 @@ else self::*/local-name() = $allowed-p-blocks"
         id="self-cite-1">'<value-of select="@publication-type"/>' type reference has a doi which is the same as this article - <value-of select="pub-id[@pub-id-type='doi']"/>. Is the reference correct? If it is intentional, please remove the reference, and replace citations in the text with the text 'current work' or similar.</report>
       
       <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/references#self-cite-1"
-        test="(lower-case(pub-id[@pub-id-type='doi']) != $article-doi) and 
+        test="(lower-case(pub-id[@pub-id-type='doi'][1]) != $article-doi) and 
               (lower-case(source[1]) = 'elife') and 
               ((lower-case(article-title[1]) = $title) or (lower-case(chapter-title[1]) = $title)) "
         role="error" 
@@ -8726,6 +8726,10 @@ else self::*/local-name() = $allowed-p-blocks"
       <report test="matches(.,'\p{Zs}$')" 
         role="error" 
         id="pub-id-test-6"><value-of select="@pub-id-type"/> pub-id ends with space(s) which is incorrect - '<value-of select="."/>'.</report>
+      
+      <report test="preceding-sibling::pub-id/@pub-id-type = @pub-id-type" 
+        role="error" 
+        id="indistinct-pub-ids">element-citation for <value-of select="e:citation-format1(parent::element-citation)"/> has more than one pub-id with the type <value-of select="@pub-id-type"/>, which cannot be correct - <value-of select="."/>.</report>
       
     </rule>
     

--- a/test/tests/gen/elem-citation-software/elem-cit-software-pub-id-ext-link/fail.xml
+++ b/test/tests/gen/elem-citation-software/elem-cit-software-pub-id-ext-link/fail.xml
@@ -2,8 +2,7 @@
 <!--Context: element-citation[@publication-type = 'software']
 Test: report    pub-id and ext-link
 Message: Software reference '' has both <pub-id> <ext-link> elements. There can only be one or the other, not both. -->
-<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML"
-  xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>
     <ref id="bib67">
       <element-citation publication-type="software">
@@ -14,8 +13,7 @@ Message: Software reference '' has both <pub-id> <ext-link> elements. There can 
         <data-title>....</data-title>
         <source>Zenodo</source>
         <pub-id pub-id-type="doi">10.5281/zenodo.gfiewpguipreguwigfirue</pub-id>
-        <ext-link ext-link-type="uri" xlink:href="https://basex-validator.elifesciences.org/"
-          >https://basex-validator.elifesciences.org/</ext-link>
+        <ext-link ext-link-type="uri" xlink:href="https://basex-validator.elifesciences.org/">https://basex-validator.elifesciences.org/</ext-link>
       </element-citation>
     </ref>
   </article>

--- a/test/tests/gen/elem-citation-software/elem-cit-software-pub-id-ext-link/pass.xml
+++ b/test/tests/gen/elem-citation-software/elem-cit-software-pub-id-ext-link/pass.xml
@@ -2,8 +2,7 @@
 <!--Context: element-citation[@publication-type = 'software']
 Test: report    pub-id and ext-link
 Message: Software reference '' has both <pub-id> <ext-link> elements. There can only be one or the other, not both. -->
-<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML"
-  xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>
     <ref id="bib67">
       <element-citation publication-type="software">

--- a/test/tests/gen/elem-citation/self-cite-2/fail.xml
+++ b/test/tests/gen/elem-citation/self-cite-2/fail.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="self-cite-2.sch"?>
 <!--Context: element-citation
-Test: report    (lower-case(pub-id[@pub-id-type='doi']) != $article-doi) and (lower-case(source[1]) = 'elife') and ((lower-case(article-title[1]) = $title) or (lower-case(chapter-title[1]) = $title))
+Test: report    (lower-case(pub-id[@pub-id-type='doi'][1]) != $article-doi) and (lower-case(source[1]) = 'elife') and ((lower-case(article-title[1]) = $title) or (lower-case(chapter-title[1]) = $title))
 Message: '' type reference looks to possibly be citing itself. If that's the case (and this isn't an error within the reference), please delete the reference and replace any citations in the text with the text 'current work'. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>

--- a/test/tests/gen/elem-citation/self-cite-2/pass.xml
+++ b/test/tests/gen/elem-citation/self-cite-2/pass.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="self-cite-2.sch"?>
 <!--Context: element-citation
-Test: report    (lower-case(pub-id[@pub-id-type='doi']) != $article-doi) and (lower-case(source[1]) = 'elife') and ((lower-case(article-title[1]) = $title) or (lower-case(chapter-title[1]) = $title))
+Test: report    (lower-case(pub-id[@pub-id-type='doi'][1]) != $article-doi) and (lower-case(source[1]) = 'elife') and ((lower-case(article-title[1]) = $title) or (lower-case(chapter-title[1]) = $title))
 Message: '' type reference looks to possibly be citing itself. If that's the case (and this isn't an error within the reference), please delete the reference and replace any citations in the text with the text 'current work'. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>

--- a/test/tests/gen/pub-id-tests/indistinct-pub-ids/fail.xml
+++ b/test/tests/gen/pub-id-tests/indistinct-pub-ids/fail.xml
@@ -1,0 +1,47 @@
+<?oxygen SCHSchema="indistinct-pub-ids.sch"?>
+<!--Context: element-citation/pub-id
+Test: report    preceding-sibling::pub-id/@pub-id-type = @pub-id-type
+Message: element-citation for  has more than one pub-id with the type , which cannot be correct - . -->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <ref id="bib19">
+      <element-citation publication-type="report">
+        <person-group person-group-type="author">
+          <name>
+            <surname>Imai</surname>
+            <given-names>N</given-names>
+          </name>
+          <name>
+            <surname>Cori</surname>
+            <given-names>A</given-names>
+          </name>
+          <name>
+            <surname>Dorigatti</surname>
+            <given-names>I</given-names>
+          </name>
+          <name>
+            <surname>Baguelin</surname>
+            <given-names>M</given-names>
+          </name>
+          <name>
+            <surname>Donnelly</surname>
+            <given-names>C</given-names>
+          </name>
+          <name>
+            <surname>Riley</surname>
+            <given-names>S</given-names>
+          </name>
+          <name>
+            <surname>Ferguson</surname>
+            <given-names>N</given-names>
+          </name>
+        </person-group>
+        <year iso-8601-date="2020">2020</year>
+        <source>Report 3: Transmissibility of 2019-nCoV</source>
+        <publisher-name>Imperial College London</publisher-name>
+        <pub-id pub-id-type="doi">10.25561/77148</pub-id>
+        <pub-id pub-id-type="doi">10.25561/77148</pub-id>
+      </element-citation>
+    </ref>
+  </article>
+</root>

--- a/test/tests/gen/pub-id-tests/indistinct-pub-ids/indistinct-pub-ids.sch
+++ b/test/tests/gen/pub-id-tests/indistinct-pub-ids/indistinct-pub-ids.sch
@@ -1196,16 +1196,14 @@
     <xsl:sequence select="count(tokenize($arg,'(\r\n?|\n\r?)'))"/>
     
   </xsl:function>
-  <pattern id="element-citation-high-tests">
-    <rule context="element-citation" id="elem-citation">
-      <let name="article-doi" value="lower-case(ancestor::article/descendant::article-meta[1]/article-id[@pub-id-type='doi'][1])"/>
-      <let name="title" value="lower-case(ancestor::article/descendant::article-meta[1]/descendant::article-title[1])"/>
-      <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/references#self-cite-1" test="(lower-case(pub-id[@pub-id-type='doi'][1]) != $article-doi) and                (lower-case(source[1]) = 'elife') and                ((lower-case(article-title[1]) = $title) or (lower-case(chapter-title[1]) = $title)) " role="error" id="self-cite-2">'<value-of select="@publication-type"/>' type reference looks to possibly be citing itself. If that's the case (and this isn't an error within the reference), please delete the reference and replace any citations in the text with the text 'current work'.</report>
+  <pattern id="pub-id-pattern">
+    <rule context="element-citation/pub-id" id="pub-id-tests">
+      <report test="preceding-sibling::pub-id/@pub-id-type = @pub-id-type" role="error" id="indistinct-pub-ids">element-citation for <value-of select="e:citation-format1(parent::element-citation)"/> has more than one pub-id with the type <value-of select="@pub-id-type"/>, which cannot be correct - <value-of select="."/>.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::element-citation" role="error" id="elem-citation-xspec-assert">element-citation must be present.</assert>
+      <assert test="descendant::element-citation/pub-id" role="error" id="pub-id-tests-xspec-assert">element-citation/pub-id must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/pub-id-tests/indistinct-pub-ids/pass.xml
+++ b/test/tests/gen/pub-id-tests/indistinct-pub-ids/pass.xml
@@ -40,7 +40,6 @@ Message: element-citation for  has more than one pub-id with the type , which ca
         <source>Report 3: Transmissibility of 2019-nCoV</source>
         <publisher-name>Imperial College London</publisher-name>
         <pub-id pub-id-type="doi">10.25561/77148</pub-id>
-        <pub-id pub-id-type="doi">10.25561/77148</pub-id>
       </element-citation>
     </ref>
   </article>

--- a/test/tests/gen/pub-id-tests/indistinct-pub-ids/pass.xml
+++ b/test/tests/gen/pub-id-tests/indistinct-pub-ids/pass.xml
@@ -1,0 +1,47 @@
+<?oxygen SCHSchema="indistinct-pub-ids.sch"?>
+<!--Context: element-citation/pub-id
+Test: report    preceding-sibling::pub-id/@pub-id-type = @pub-id-type
+Message: element-citation for  has more than one pub-id with the type , which cannot be correct - . -->
+<root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+  <article>
+    <ref id="bib19">
+      <element-citation publication-type="report">
+        <person-group person-group-type="author">
+          <name>
+            <surname>Imai</surname>
+            <given-names>N</given-names>
+          </name>
+          <name>
+            <surname>Cori</surname>
+            <given-names>A</given-names>
+          </name>
+          <name>
+            <surname>Dorigatti</surname>
+            <given-names>I</given-names>
+          </name>
+          <name>
+            <surname>Baguelin</surname>
+            <given-names>M</given-names>
+          </name>
+          <name>
+            <surname>Donnelly</surname>
+            <given-names>C</given-names>
+          </name>
+          <name>
+            <surname>Riley</surname>
+            <given-names>S</given-names>
+          </name>
+          <name>
+            <surname>Ferguson</surname>
+            <given-names>N</given-names>
+          </name>
+        </person-group>
+        <year iso-8601-date="2020">2020</year>
+        <source>Report 3: Transmissibility of 2019-nCoV</source>
+        <publisher-name>Imperial College London</publisher-name>
+        <pub-id pub-id-type="doi">10.25561/77148</pub-id>
+        <pub-id pub-id-type="doi">10.25561/77148</pub-id>
+      </element-citation>
+    </ref>
+  </article>
+</root>

--- a/test/tests/gen/software-ref-tests/ref-software-test-7/fail.xml
+++ b/test/tests/gen/software-ref-tests/ref-software-test-7/fail.xml
@@ -4,8 +4,7 @@ Test: report    matches(lower-case(source[1]),'^osf$|open science framework|zeno
 Message:  software ref (with id '') does not have a URL or a DOI which is incorrect. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>
-    <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML"
-      xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+    <root>
       <article>
         <ref id="bib67">
           <element-citation publication-type="software">

--- a/test/tests/gen/software-ref-tests/ref-software-test-7/pass.xml
+++ b/test/tests/gen/software-ref-tests/ref-software-test-7/pass.xml
@@ -4,8 +4,7 @@ Test: report    matches(lower-case(source[1]),'^osf$|open science framework|zeno
 Message:  software ref (with id '') does not have a URL or a DOI which is incorrect. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
   <article>
-    <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML"
-      xmlns:ali="http://www.niso.org/schemas/ali/1.0/">
+    <root>
       <article>
         <ref id="bib67">
           <element-citation publication-type="software">

--- a/test/xspec/schematron.sch
+++ b/test/xspec/schematron.sch
@@ -5251,7 +5251,7 @@
       
       <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/references#self-cite-1" test="lower-case(pub-id[@pub-id-type='doi'][1]) = $article-doi" role="error" id="self-cite-1">'<value-of select="@publication-type"/>' type reference has a doi which is the same as this article - <value-of select="pub-id[@pub-id-type='doi']"/>. Is the reference correct? If it is intentional, please remove the reference, and replace citations in the text with the text 'current work' or similar.</report>
       
-      <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/references#self-cite-1" test="(lower-case(pub-id[@pub-id-type='doi']) != $article-doi) and                (lower-case(source[1]) = 'elife') and                ((lower-case(article-title[1]) = $title) or (lower-case(chapter-title[1]) = $title)) " role="error" id="self-cite-2">'<value-of select="@publication-type"/>' type reference looks to possibly be citing itself. If that's the case (and this isn't an error within the reference), please delete the reference and replace any citations in the text with the text 'current work'.</report>
+      <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/references#self-cite-1" test="(lower-case(pub-id[@pub-id-type='doi'][1]) != $article-doi) and                (lower-case(source[1]) = 'elife') and                ((lower-case(article-title[1]) = $title) or (lower-case(chapter-title[1]) = $title)) " role="error" id="self-cite-2">'<value-of select="@publication-type"/>' type reference looks to possibly be citing itself. If that's the case (and this isn't an error within the reference), please delete the reference and replace any citations in the text with the text 'current work'.</report>
       
     </rule>
   </pattern>
@@ -6095,6 +6095,8 @@
       
       <report test="matches(.,'\p{Zs}$')" role="error" id="pub-id-test-6">
         <value-of select="@pub-id-type"/> pub-id ends with space(s) which is incorrect - '<value-of select="."/>'.</report>
+      
+      <report test="preceding-sibling::pub-id/@pub-id-type = @pub-id-type" role="error" id="indistinct-pub-ids">element-citation for <value-of select="e:citation-format1(parent::element-citation)"/> has more than one pub-id with the type <value-of select="@pub-id-type"/>, which cannot be correct - <value-of select="."/>.</report>
       
     </rule>
   </pattern>

--- a/test/xspec/schematron.xspec
+++ b/test/xspec/schematron.xspec
@@ -12033,6 +12033,16 @@
         <x:expect-report id="pub-id-test-6" role="error"/>
         <x:expect-not-assert id="pub-id-tests-xspec-assert" role="error"/>
       </x:scenario>
+      <x:scenario label="indistinct-pub-ids-pass">
+        <x:context href="../tests/gen/pub-id-tests/indistinct-pub-ids/pass.xml"/>
+        <x:expect-not-report id="indistinct-pub-ids" role="error"/>
+        <x:expect-not-assert id="pub-id-tests-xspec-assert" role="error"/>
+      </x:scenario>
+      <x:scenario label="indistinct-pub-ids-fail">
+        <x:context href="../tests/gen/pub-id-tests/indistinct-pub-ids/fail.xml"/>
+        <x:expect-report id="indistinct-pub-ids" role="error"/>
+        <x:expect-not-assert id="pub-id-tests-xspec-assert" role="error"/>
+      </x:scenario>
     </x:scenario>
     <x:scenario label="pub-id-xlink-href-tests">
       <x:scenario label="pub-id-url-conformance-test-pass">


### PR DESCRIPTION
- `self-cite-1` no longer causes fatal error if `element-citation` has more than one `pub-id[@pub-id-type='doi']`
- Add `indistinct-pub-ids` to catch refs with more than one pub-id.