### PR TITLE
chore: changes for digest abstract type

### DIFF
--- a/src/final-JATS-schematron.sch
+++ b/src/final-JATS-schematron.sch
@@ -1359,6 +1359,9 @@
     <let name="subj-type" value="descendant::subj-group[@subj-group-type='display-channel']/subject[1]"/>
     <let name="exceptions" value="('Insight',$notice-display-types)"/>
     <let name="no-digest" value="('Scientific Correspondence','Replication Study','Research Advance','Registered Report',$notice-display-types,$features-subj)"/>
+    <let name="abs-count" value="count(abstract)"/>
+    <let name="abs-standard-count" value="count(abstract[not(@abstract-type)])"/>
+    <let name="digest-count" value="count(abstract[@abstract-type=('plain-language-summary','executive-summary')])"/>
     
 	<assert test="matches($article-id,'^\d{5}$')" role="error" id="test-article-id">[test-article-id] article-id must consist only of 5 digits. Currently it is <value-of select="article-id[@pub-id-type='publisher-id']"/>
       </assert> 
@@ -1404,9 +1407,9 @@
     <assert see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/licensing-and-copyright#test-permissions-presence" test="count(permissions) = 1" role="error" id="test-permissions-presence">[test-permissions-presence] There must be one and only one permissions element in the article-meta. Currently there are <value-of select="count(permissions)"/>
       </assert>
 		  
-    <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/article-structure/abstract-digest-impact-statement#test-abstracts" test="not($article-type = $notice-article-types) and (count(abstract[not(@abstract-type='executive-summary')]) != 1 or (count(abstract[not(@abstract-type='executive-summary')]) != 1 and count(abstract[@abstract-type='executive-summary']) != 1))" role="error" id="test-abstracts">[test-abstracts] There must either be only one abstract or one abstract and one abstract[@abstract-type="executive-summary]. No other variations are allowed.</report>
+    <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/article-structure/abstract-digest-impact-statement#test-abstracts" test="not($article-type = $notice-article-types) and ($abs-count gt 2 or $abs-standard-count != 1 or $digest-count gt 1 or ($abs-count != $abs-standard-count + $digest-count))" role="error" id="test-abstracts">[test-abstracts] There must either be only one abstract or one abstract and one abstract[@abstract-type="plain-language-summary"]. No other variations are allowed.</report>
     
-    <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/article-structure/abstract-digest-impact-statement#test-no-digest" test="($subj-type= $no-digest) and abstract[@abstract-type='executive-summary']" role="error" id="test-no-digest">[test-no-digest] '<value-of select="$subj-type"/>' cannot have a digest.</report>
+    <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/article-structure/abstract-digest-impact-statement#test-no-digest" test="($subj-type= $no-digest) and abstract[@abstract-type=('executive-summary','plain-language-summary')]" role="error" id="test-no-digest">[test-no-digest] '<value-of select="$subj-type"/>' cannot have a digest.</report>
 	 
     <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/funding-information#test-funding-group-presence" test="if ($article-type = $features-article-types) then ()       else if ($subj-type = ('Scientific Correspondence',$notice-display-types)) then ()       else count(funding-group) != 1" role="error" id="test-funding-group-presence">[test-funding-group-presence] There must be one and only one funding-group element in the article-meta. Currently there are <value-of select="count(funding-group)"/>.</report>
     
@@ -5956,7 +5959,7 @@
    </rule>
   </pattern>
   <pattern id="feature-abstract-tests-pattern">
-    <rule context="front//abstract[@abstract-type='executive-summary']" id="feature-abstract-tests">
+    <rule context="front//abstract[@abstract-type=('executive-summary','plain-language-summary')]" id="feature-abstract-tests">
      
      <assert see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/article-structure/abstract-digest-impact-statement#feature-abstract-test-1" test="count(title) = 1" role="error" id="feature-abstract-test-1">[feature-abstract-test-1] abstract must contain one and only one title.</assert>
      
@@ -5966,7 +5969,7 @@
    </rule>
   </pattern>
   <pattern id="digest-tests-pattern">
-    <rule context="front//abstract[@abstract-type='executive-summary']/p" id="digest-tests">
+    <rule context="front//abstract[@abstract-type=('executive-summary','plain-language-summary')]/p" id="digest-tests">
      
      <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/article-structure/abstract-digest-impact-statement#digest-test-1" test="matches(.,'^\p{Ll}')" role="warning" id="digest-test-1">[digest-test-1] digest paragraph starts with a lowercase letter. Is that correct? Or has a paragraph been incorrectly split into two?</report>
      

--- a/src/final-JATS-schematron.xsl
+++ b/src/final-JATS-schematron.xsl
@@ -6252,6 +6252,9 @@
       <xsl:variable name="subj-type" select="descendant::subj-group[@subj-group-type='display-channel']/subject[1]"/>
       <xsl:variable name="exceptions" select="('Insight',$notice-display-types)"/>
       <xsl:variable name="no-digest" select="('Scientific Correspondence','Replication Study','Research Advance','Registered Report',$notice-display-types,$features-subj)"/>
+      <xsl:variable name="abs-count" select="count(abstract)"/>
+      <xsl:variable name="abs-standard-count" select="count(abstract[not(@abstract-type)])"/>
+      <xsl:variable name="digest-count" select="count(abstract[@abstract-type=('plain-language-summary','executive-summary')])"/>
 
 		    <!--ASSERT error-->
       <xsl:choose>
@@ -6502,21 +6505,21 @@
       </xsl:choose>
 
 		    <!--REPORT error-->
-      <xsl:if test="not($article-type = $notice-article-types) and (count(abstract[not(@abstract-type='executive-summary')]) != 1 or (count(abstract[not(@abstract-type='executive-summary')]) != 1 and count(abstract[@abstract-type='executive-summary']) != 1))">
-         <svrl:successful-report xmlns:svrl="http://purl.oclc.org/dsdl/svrl" test="not($article-type = $notice-article-types) and (count(abstract[not(@abstract-type='executive-summary')]) != 1 or (count(abstract[not(@abstract-type='executive-summary')]) != 1 and count(abstract[@abstract-type='executive-summary']) != 1))">
+      <xsl:if test="not($article-type = $notice-article-types) and ($abs-count gt 2 or $abs-standard-count != 1 or $digest-count gt 1 or ($abs-count != $abs-standard-count + $digest-count))">
+         <svrl:successful-report xmlns:svrl="http://purl.oclc.org/dsdl/svrl" test="not($article-type = $notice-article-types) and ($abs-count gt 2 or $abs-standard-count != 1 or $digest-count gt 1 or ($abs-count != $abs-standard-count + $digest-count))">
             <xsl:attribute name="id">test-abstracts</xsl:attribute>
             <xsl:attribute name="see">https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/article-structure/abstract-digest-impact-statement#test-abstracts</xsl:attribute>
             <xsl:attribute name="role">error</xsl:attribute>
             <xsl:attribute name="location">
                <xsl:apply-templates select="." mode="schematron-select-full-path"/>
             </xsl:attribute>
-            <svrl:text>[test-abstracts] There must either be only one abstract or one abstract and one abstract[@abstract-type="executive-summary]. No other variations are allowed.</svrl:text>
+            <svrl:text>[test-abstracts] There must either be only one abstract or one abstract and one abstract[@abstract-type="plain-language-summary"]. No other variations are allowed.</svrl:text>
          </svrl:successful-report>
       </xsl:if>
 
 		    <!--REPORT error-->
-      <xsl:if test="($subj-type= $no-digest) and abstract[@abstract-type='executive-summary']">
-         <svrl:successful-report xmlns:svrl="http://purl.oclc.org/dsdl/svrl" test="($subj-type= $no-digest) and abstract[@abstract-type='executive-summary']">
+      <xsl:if test="($subj-type= $no-digest) and abstract[@abstract-type=('executive-summary','plain-language-summary')]">
+         <svrl:successful-report xmlns:svrl="http://purl.oclc.org/dsdl/svrl" test="($subj-type= $no-digest) and abstract[@abstract-type=('executive-summary','plain-language-summary')]">
             <xsl:attribute name="id">test-no-digest</xsl:attribute>
             <xsl:attribute name="see">https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/article-structure/abstract-digest-impact-statement#test-no-digest</xsl:attribute>
             <xsl:attribute name="role">error</xsl:attribute>
@@ -28377,7 +28380,7 @@
 
 
 	  <!--RULE feature-abstract-tests-->
-   <xsl:template match="front//abstract[@abstract-type='executive-summary']" priority="1000" mode="M442">
+   <xsl:template match="front//abstract[@abstract-type=('executive-summary','plain-language-summary')]" priority="1000" mode="M442">
 
 		<!--ASSERT error-->
       <xsl:choose>
@@ -28424,7 +28427,7 @@
 
 
 	  <!--RULE digest-tests-->
-   <xsl:template match="front//abstract[@abstract-type='executive-summary']/p" priority="1000" mode="M443">
+   <xsl:template match="front//abstract[@abstract-type=('executive-summary','plain-language-summary')]/p" priority="1000" mode="M443">
 
 		<!--REPORT warning-->
       <xsl:if test="matches(.,'^\p{Ll}')">

--- a/src/final-package-JATS-schematron.sch
+++ b/src/final-package-JATS-schematron.sch
@@ -1367,6 +1367,9 @@
     <let name="subj-type" value="descendant::subj-group[@subj-group-type='display-channel']/subject[1]"/>
     <let name="exceptions" value="('Insight',$notice-display-types)"/>
     <let name="no-digest" value="('Scientific Correspondence','Replication Study','Research Advance','Registered Report',$notice-display-types,$features-subj)"/>
+    <let name="abs-count" value="count(abstract)"/>
+    <let name="abs-standard-count" value="count(abstract[not(@abstract-type)])"/>
+    <let name="digest-count" value="count(abstract[@abstract-type=('plain-language-summary','executive-summary')])"/>
     
 	<assert test="matches($article-id,'^\d{5}$')" role="error" id="test-article-id">article-id must consist only of 5 digits. Currently it is <value-of select="article-id[@pub-id-type='publisher-id']"/>
       </assert> 
@@ -1412,9 +1415,9 @@
     <assert see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/licensing-and-copyright#test-permissions-presence" test="count(permissions) = 1" role="error" id="test-permissions-presence">There must be one and only one permissions element in the article-meta. Currently there are <value-of select="count(permissions)"/>
       </assert>
 		  
-    <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/article-structure/abstract-digest-impact-statement#test-abstracts" test="not($article-type = $notice-article-types) and (count(abstract[not(@abstract-type='executive-summary')]) != 1 or (count(abstract[not(@abstract-type='executive-summary')]) != 1 and count(abstract[@abstract-type='executive-summary']) != 1))" role="error" id="test-abstracts">There must either be only one abstract or one abstract and one abstract[@abstract-type="executive-summary]. No other variations are allowed.</report>
+    <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/article-structure/abstract-digest-impact-statement#test-abstracts" test="not($article-type = $notice-article-types) and ($abs-count gt 2 or $abs-standard-count != 1 or $digest-count gt 1 or ($abs-count != $abs-standard-count + $digest-count))" role="error" id="test-abstracts">There must either be only one abstract or one abstract and one abstract[@abstract-type="plain-language-summary"]. No other variations are allowed.</report>
     
-    <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/article-structure/abstract-digest-impact-statement#test-no-digest" test="($subj-type= $no-digest) and abstract[@abstract-type='executive-summary']" role="error" id="test-no-digest">'<value-of select="$subj-type"/>' cannot have a digest.</report>
+    <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/article-structure/abstract-digest-impact-statement#test-no-digest" test="($subj-type= $no-digest) and abstract[@abstract-type=('executive-summary','plain-language-summary')]" role="error" id="test-no-digest">'<value-of select="$subj-type"/>' cannot have a digest.</report>
 	 
     <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/funding-information#test-funding-group-presence" test="if ($article-type = $features-article-types) then ()       else if ($subj-type = ('Scientific Correspondence',$notice-display-types)) then ()       else count(funding-group) != 1" role="error" id="test-funding-group-presence">There must be one and only one funding-group element in the article-meta. Currently there are <value-of select="count(funding-group)"/>.</report>
     
@@ -6122,7 +6125,7 @@
    </rule>
   </pattern>
   <pattern id="feature-abstract-tests-pattern">
-    <rule context="front//abstract[@abstract-type='executive-summary']" id="feature-abstract-tests">
+    <rule context="front//abstract[@abstract-type=('executive-summary','plain-language-summary')]" id="feature-abstract-tests">
      
      <assert see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/article-structure/abstract-digest-impact-statement#feature-abstract-test-1" test="count(title) = 1" role="error" id="feature-abstract-test-1">abstract must contain one and only one title.</assert>
      
@@ -6132,7 +6135,7 @@
    </rule>
   </pattern>
   <pattern id="digest-tests-pattern">
-    <rule context="front//abstract[@abstract-type='executive-summary']/p" id="digest-tests">
+    <rule context="front//abstract[@abstract-type=('executive-summary','plain-language-summary')]/p" id="digest-tests">
      
      <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/article-structure/abstract-digest-impact-statement#digest-test-1" test="matches(.,'^\p{Ll}')" role="warning" id="digest-test-1">digest paragraph starts with a lowercase letter. Is that correct? Or has a paragraph been incorrectly split into two?</report>
      

--- a/src/pre-JATS-schematron.sch
+++ b/src/pre-JATS-schematron.sch
@@ -1304,6 +1304,9 @@
     <let name="subj-type" value="descendant::subj-group[@subj-group-type='display-channel']/subject[1]"/>
     <let name="exceptions" value="('Insight',$notice-display-types)"/>
     <let name="no-digest" value="('Scientific Correspondence','Replication Study','Research Advance','Registered Report',$notice-display-types,$features-subj)"/>
+    <let name="abs-count" value="count(abstract)"/>
+    <let name="abs-standard-count" value="count(abstract[not(@abstract-type)])"/>
+    <let name="digest-count" value="count(abstract[@abstract-type=('plain-language-summary','executive-summary')])"/>
     
 	<assert test="matches($article-id,'^\d{5}$')" role="error" id="test-article-id">[test-article-id] article-id must consist only of 5 digits. Currently it is <value-of select="article-id[@pub-id-type='publisher-id']"/>
       </assert> 
@@ -1349,9 +1352,9 @@
     <assert see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/licensing-and-copyright#test-permissions-presence" test="count(permissions) = 1" role="error" id="test-permissions-presence">[test-permissions-presence] There must be one and only one permissions element in the article-meta. Currently there are <value-of select="count(permissions)"/>
       </assert>
 		  
-    <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/article-structure/abstract-digest-impact-statement#test-abstracts" test="not($article-type = $notice-article-types) and (count(abstract[not(@abstract-type='executive-summary')]) != 1 or (count(abstract[not(@abstract-type='executive-summary')]) != 1 and count(abstract[@abstract-type='executive-summary']) != 1))" role="error" id="test-abstracts">[test-abstracts] There must either be only one abstract or one abstract and one abstract[@abstract-type="executive-summary]. No other variations are allowed.</report>
+    <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/article-structure/abstract-digest-impact-statement#test-abstracts" test="not($article-type = $notice-article-types) and ($abs-count gt 2 or $abs-standard-count != 1 or $digest-count gt 1 or ($abs-count != $abs-standard-count + $digest-count))" role="error" id="test-abstracts">[test-abstracts] There must either be only one abstract or one abstract and one abstract[@abstract-type="plain-language-summary"]. No other variations are allowed.</report>
     
-    <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/article-structure/abstract-digest-impact-statement#test-no-digest" test="($subj-type= $no-digest) and abstract[@abstract-type='executive-summary']" role="error" id="test-no-digest">[test-no-digest] '<value-of select="$subj-type"/>' cannot have a digest.</report>
+    <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/article-structure/abstract-digest-impact-statement#test-no-digest" test="($subj-type= $no-digest) and abstract[@abstract-type=('executive-summary','plain-language-summary')]" role="error" id="test-no-digest">[test-no-digest] '<value-of select="$subj-type"/>' cannot have a digest.</report>
 	 
     <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/funding-information#test-funding-group-presence" test="if ($article-type = $features-article-types) then ()       else if ($subj-type = ('Scientific Correspondence',$notice-display-types)) then ()       else count(funding-group) != 1" role="error" id="test-funding-group-presence">[test-funding-group-presence] There must be one and only one funding-group element in the article-meta. Currently there are <value-of select="count(funding-group)"/>.</report>
     
@@ -5898,7 +5901,7 @@
    </rule>
   </pattern>
   <pattern id="feature-abstract-tests-pattern">
-    <rule context="front//abstract[@abstract-type='executive-summary']" id="feature-abstract-tests">
+    <rule context="front//abstract[@abstract-type=('executive-summary','plain-language-summary')]" id="feature-abstract-tests">
      
      <assert see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/article-structure/abstract-digest-impact-statement#feature-abstract-test-1" test="count(title) = 1" role="error" id="feature-abstract-test-1">[feature-abstract-test-1] abstract must contain one and only one title.</assert>
      
@@ -5908,7 +5911,7 @@
    </rule>
   </pattern>
   <pattern id="digest-tests-pattern">
-    <rule context="front//abstract[@abstract-type='executive-summary']/p" id="digest-tests">
+    <rule context="front//abstract[@abstract-type=('executive-summary','plain-language-summary')]/p" id="digest-tests">
      
      <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/article-structure/abstract-digest-impact-statement#digest-test-1" test="matches(.,'^\p{Ll}')" role="warning" id="digest-test-1">[digest-test-1] digest paragraph starts with a lowercase letter. Is that correct? Or has a paragraph been incorrectly split into two?</report>
      

--- a/src/pre-JATS-schematron.xsl
+++ b/src/pre-JATS-schematron.xsl
@@ -6172,6 +6172,9 @@
       <xsl:variable name="subj-type" select="descendant::subj-group[@subj-group-type='display-channel']/subject[1]"/>
       <xsl:variable name="exceptions" select="('Insight',$notice-display-types)"/>
       <xsl:variable name="no-digest" select="('Scientific Correspondence','Replication Study','Research Advance','Registered Report',$notice-display-types,$features-subj)"/>
+      <xsl:variable name="abs-count" select="count(abstract)"/>
+      <xsl:variable name="abs-standard-count" select="count(abstract[not(@abstract-type)])"/>
+      <xsl:variable name="digest-count" select="count(abstract[@abstract-type=('plain-language-summary','executive-summary')])"/>
 
 		    <!--ASSERT error-->
       <xsl:choose>
@@ -6422,21 +6425,21 @@
       </xsl:choose>
 
 		    <!--REPORT error-->
-      <xsl:if test="not($article-type = $notice-article-types) and (count(abstract[not(@abstract-type='executive-summary')]) != 1 or (count(abstract[not(@abstract-type='executive-summary')]) != 1 and count(abstract[@abstract-type='executive-summary']) != 1))">
-         <svrl:successful-report xmlns:svrl="http://purl.oclc.org/dsdl/svrl" test="not($article-type = $notice-article-types) and (count(abstract[not(@abstract-type='executive-summary')]) != 1 or (count(abstract[not(@abstract-type='executive-summary')]) != 1 and count(abstract[@abstract-type='executive-summary']) != 1))">
+      <xsl:if test="not($article-type = $notice-article-types) and ($abs-count gt 2 or $abs-standard-count != 1 or $digest-count gt 1 or ($abs-count != $abs-standard-count + $digest-count))">
+         <svrl:successful-report xmlns:svrl="http://purl.oclc.org/dsdl/svrl" test="not($article-type = $notice-article-types) and ($abs-count gt 2 or $abs-standard-count != 1 or $digest-count gt 1 or ($abs-count != $abs-standard-count + $digest-count))">
             <xsl:attribute name="id">test-abstracts</xsl:attribute>
             <xsl:attribute name="see">https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/article-structure/abstract-digest-impact-statement#test-abstracts</xsl:attribute>
             <xsl:attribute name="role">error</xsl:attribute>
             <xsl:attribute name="location">
                <xsl:apply-templates select="." mode="schematron-select-full-path"/>
             </xsl:attribute>
-            <svrl:text>[test-abstracts] There must either be only one abstract or one abstract and one abstract[@abstract-type="executive-summary]. No other variations are allowed.</svrl:text>
+            <svrl:text>[test-abstracts] There must either be only one abstract or one abstract and one abstract[@abstract-type="plain-language-summary"]. No other variations are allowed.</svrl:text>
          </svrl:successful-report>
       </xsl:if>
 
 		    <!--REPORT error-->
-      <xsl:if test="($subj-type= $no-digest) and abstract[@abstract-type='executive-summary']">
-         <svrl:successful-report xmlns:svrl="http://purl.oclc.org/dsdl/svrl" test="($subj-type= $no-digest) and abstract[@abstract-type='executive-summary']">
+      <xsl:if test="($subj-type= $no-digest) and abstract[@abstract-type=('executive-summary','plain-language-summary')]">
+         <svrl:successful-report xmlns:svrl="http://purl.oclc.org/dsdl/svrl" test="($subj-type= $no-digest) and abstract[@abstract-type=('executive-summary','plain-language-summary')]">
             <xsl:attribute name="id">test-no-digest</xsl:attribute>
             <xsl:attribute name="see">https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/article-structure/abstract-digest-impact-statement#test-no-digest</xsl:attribute>
             <xsl:attribute name="role">error</xsl:attribute>
@@ -28276,7 +28279,7 @@
 
 
 	  <!--RULE feature-abstract-tests-->
-   <xsl:template match="front//abstract[@abstract-type='executive-summary']" priority="1000" mode="M440">
+   <xsl:template match="front//abstract[@abstract-type=('executive-summary','plain-language-summary')]" priority="1000" mode="M440">
 
 		<!--ASSERT error-->
       <xsl:choose>
@@ -28323,7 +28326,7 @@
 
 
 	  <!--RULE digest-tests-->
-   <xsl:template match="front//abstract[@abstract-type='executive-summary']/p" priority="1000" mode="M441">
+   <xsl:template match="front//abstract[@abstract-type=('executive-summary','plain-language-summary')]/p" priority="1000" mode="M441">
 
 		<!--REPORT warning-->
       <xsl:if test="matches(.,'^\p{Ll}')">

--- a/src/schematron.sch
+++ b/src/schematron.sch
@@ -1477,6 +1477,9 @@
     <let name="subj-type" value="descendant::subj-group[@subj-group-type='display-channel']/subject[1]"/>
     <let name="exceptions" value="('Insight',$notice-display-types)"/>
     <let name="no-digest" value="('Scientific Correspondence','Replication Study','Research Advance','Registered Report',$notice-display-types,$features-subj)"/>
+    <let name="abs-count" value="count(abstract)"/>
+    <let name="abs-standard-count" value="count(abstract[not(@abstract-type)])"/>
+    <let name="digest-count" value="count(abstract[@abstract-type=('plain-language-summary','executive-summary')])"/>
     
 	<assert test="matches($article-id,'^\d{5}$')" 
         role="error" 
@@ -1550,12 +1553,12 @@
         id="test-permissions-presence">There must be one and only one permissions element in the article-meta. Currently there are <value-of select="count(permissions)"/></assert>
 		  
     <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/article-structure/abstract-digest-impact-statement#test-abstracts" 
-      test="not($article-type = $notice-article-types) and (count(abstract[not(@abstract-type='executive-summary')]) != 1 or (count(abstract[not(@abstract-type='executive-summary')]) != 1 and count(abstract[@abstract-type='executive-summary']) != 1))" 
+      test="not($article-type = $notice-article-types) and ($abs-count gt 2 or $abs-standard-count != 1 or $digest-count gt 1 or ($abs-count != $abs-standard-count + $digest-count))" 
         role="error" 
-        id="test-abstracts">There must either be only one abstract or one abstract and one abstract[@abstract-type="executive-summary]. No other variations are allowed.</report>
+        id="test-abstracts">There must either be only one abstract or one abstract and one abstract[@abstract-type="plain-language-summary"]. No other variations are allowed.</report>
     
     <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/article-structure/abstract-digest-impact-statement#test-no-digest" 
-      test="($subj-type= $no-digest) and abstract[@abstract-type='executive-summary']" 
+      test="($subj-type= $no-digest) and abstract[@abstract-type=('executive-summary','plain-language-summary')]" 
         role="error" 
         id="test-no-digest">'<value-of select="$subj-type"/>' cannot have a digest.</report>
 	 
@@ -8782,7 +8785,7 @@ else self::*/local-name() = $allowed-p-blocks"
      
    </rule>
    
-   <rule context="front//abstract[@abstract-type='executive-summary']" id="feature-abstract-tests">
+   <rule context="front//abstract[@abstract-type=('executive-summary','plain-language-summary')]" id="feature-abstract-tests">
      
      <assert see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/article-structure/abstract-digest-impact-statement#feature-abstract-test-1"
        test="count(title) = 1" 
@@ -8796,7 +8799,7 @@ else self::*/local-name() = $allowed-p-blocks"
      
    </rule>
    
-   <rule context="front//abstract[@abstract-type='executive-summary']/p" id="digest-tests">
+   <rule context="front//abstract[@abstract-type=('executive-summary','plain-language-summary')]/p" id="digest-tests">
      
      <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/article-structure/abstract-digest-impact-statement#digest-test-1"
        test="matches(.,'^\p{Ll}')" 

--- a/test/tests/gen/digest-tests/digest-test-1/digest-test-1.sch
+++ b/test/tests/gen/digest-tests/digest-test-1/digest-test-1.sch
@@ -1197,13 +1197,13 @@
     
   </xsl:function>
   <pattern id="features">
-    <rule context="front//abstract[@abstract-type='executive-summary']/p" id="digest-tests">
+    <rule context="front//abstract[@abstract-type=('executive-summary','plain-language-summary')]/p" id="digest-tests">
       <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/article-structure/abstract-digest-impact-statement#digest-test-1" test="matches(.,'^\p{Ll}')" role="warning" id="digest-test-1">digest paragraph starts with a lowercase letter. Is that correct? Or has a paragraph been incorrectly split into two?</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::front//abstract[@abstract-type='executive-summary']/p" role="error" id="digest-tests-xspec-assert">front//abstract[@abstract-type='executive-summary']/p must be present.</assert>
+      <assert test="descendant::front//abstract[@abstract-type=('executive-summary','plain-language-summary')]/p" role="error" id="digest-tests-xspec-assert">front//abstract[@abstract-type=('executive-summary','plain-language-summary')]/p must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/digest-tests/digest-test-1/fail.xml
+++ b/test/tests/gen/digest-tests/digest-test-1/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="digest-test-1.sch"?>
-<!--Context: front//abstract[@abstract-type='executive-summary']/p
+<!--Context: front//abstract[@abstract-type=('executive-summary','plain-language-summary')]/p
 Test: report    matches(.,'^\p{Ll}')
 Message: digest paragraph starts with a lowercase letter. Is that correct? Or has a paragraph been incorrectly split into two? -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">

--- a/test/tests/gen/digest-tests/digest-test-1/pass.xml
+++ b/test/tests/gen/digest-tests/digest-test-1/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="digest-test-1.sch"?>
-<!--Context: front//abstract[@abstract-type='executive-summary']/p
+<!--Context: front//abstract[@abstract-type=('executive-summary','plain-language-summary')]/p
 Test: report    matches(.,'^\p{Ll}')
 Message: digest paragraph starts with a lowercase letter. Is that correct? Or has a paragraph been incorrectly split into two? -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">

--- a/test/tests/gen/digest-tests/final-digest-query-test/fail.xml
+++ b/test/tests/gen/digest-tests/final-digest-query-test/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="final-digest-query-test.sch"?>
-<!--Context: front//abstract[@abstract-type='executive-summary']/p
+<!--Context: front//abstract[@abstract-type=('executive-summary','plain-language-summary')]/p
 Test: report    matches(.,'\[[Qq][Uu][Ee][Rr][Yy]')
 Message:  element contains [Query] or [QUERY] which should be removed -  -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">

--- a/test/tests/gen/digest-tests/final-digest-query-test/final-digest-query-test.sch
+++ b/test/tests/gen/digest-tests/final-digest-query-test/final-digest-query-test.sch
@@ -1197,7 +1197,7 @@
     
   </xsl:function>
   <pattern id="features">
-    <rule context="front//abstract[@abstract-type='executive-summary']/p" id="digest-tests">
+    <rule context="front//abstract[@abstract-type=('executive-summary','plain-language-summary')]/p" id="digest-tests">
       <report test="matches(.,'\[[Qq][Uu][Ee][Rr][Yy]')" role="error" id="final-digest-query-test">
         <value-of select="name()"/> element contains [Query] or [QUERY] which should be removed - <value-of select="."/>
       </report>
@@ -1205,7 +1205,7 @@
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::front//abstract[@abstract-type='executive-summary']/p" role="error" id="digest-tests-xspec-assert">front//abstract[@abstract-type='executive-summary']/p must be present.</assert>
+      <assert test="descendant::front//abstract[@abstract-type=('executive-summary','plain-language-summary')]/p" role="error" id="digest-tests-xspec-assert">front//abstract[@abstract-type=('executive-summary','plain-language-summary')]/p must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/digest-tests/final-digest-query-test/pass.xml
+++ b/test/tests/gen/digest-tests/final-digest-query-test/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="final-digest-query-test.sch"?>
-<!--Context: front//abstract[@abstract-type='executive-summary']/p
+<!--Context: front//abstract[@abstract-type=('executive-summary','plain-language-summary')]/p
 Test: report    matches(.,'\[[Qq][Uu][Ee][Rr][Yy]')
 Message:  element contains [Query] or [QUERY] which should be removed -  -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">

--- a/test/tests/gen/digest-tests/final-digest-test-2/fail.xml
+++ b/test/tests/gen/digest-tests/final-digest-test-2/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="final-digest-test-2.sch"?>
-<!--Context: front//abstract[@abstract-type='executive-summary']/p
+<!--Context: front//abstract[@abstract-type=('executive-summary','plain-language-summary')]/p
 Test: report    matches(.,'\[[Oo][Kk]\??\]')
 Message: digest paragraph contains [OK] or [OK?] which should be removed -  -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">

--- a/test/tests/gen/digest-tests/final-digest-test-2/final-digest-test-2.sch
+++ b/test/tests/gen/digest-tests/final-digest-test-2/final-digest-test-2.sch
@@ -1197,14 +1197,14 @@
     
   </xsl:function>
   <pattern id="features">
-    <rule context="front//abstract[@abstract-type='executive-summary']/p" id="digest-tests">
+    <rule context="front//abstract[@abstract-type=('executive-summary','plain-language-summary')]/p" id="digest-tests">
       <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/article-structure/abstract-digest-impact-statement#final-digest-test-2" test="matches(.,'\[[Oo][Kk]\??\]')" role="error" id="final-digest-test-2">digest paragraph contains [OK] or [OK?] which should be removed - <value-of select="."/>
       </report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::front//abstract[@abstract-type='executive-summary']/p" role="error" id="digest-tests-xspec-assert">front//abstract[@abstract-type='executive-summary']/p must be present.</assert>
+      <assert test="descendant::front//abstract[@abstract-type=('executive-summary','plain-language-summary')]/p" role="error" id="digest-tests-xspec-assert">front//abstract[@abstract-type=('executive-summary','plain-language-summary')]/p must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/digest-tests/final-digest-test-2/pass.xml
+++ b/test/tests/gen/digest-tests/final-digest-test-2/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="final-digest-test-2.sch"?>
-<!--Context: front//abstract[@abstract-type='executive-summary']/p
+<!--Context: front//abstract[@abstract-type=('executive-summary','plain-language-summary')]/p
 Test: report    matches(.,'\[[Oo][Kk]\??\]')
 Message: digest paragraph contains [OK] or [OK?] which should be removed -  -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">

--- a/test/tests/gen/feature-abstract-tests/feature-abstract-test-1/fail.xml
+++ b/test/tests/gen/feature-abstract-tests/feature-abstract-test-1/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="feature-abstract-test-1.sch"?>
-<!--Context: front//abstract[@abstract-type='executive-summary']
+<!--Context: front//abstract[@abstract-type=('executive-summary','plain-language-summary')]
 Test: assert    count(title) = 1
 Message: abstract must contain one and only one title. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">

--- a/test/tests/gen/feature-abstract-tests/feature-abstract-test-1/feature-abstract-test-1.sch
+++ b/test/tests/gen/feature-abstract-tests/feature-abstract-test-1/feature-abstract-test-1.sch
@@ -1197,13 +1197,13 @@
     
   </xsl:function>
   <pattern id="features">
-    <rule context="front//abstract[@abstract-type='executive-summary']" id="feature-abstract-tests">
+    <rule context="front//abstract[@abstract-type=('executive-summary','plain-language-summary')]" id="feature-abstract-tests">
       <assert see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/article-structure/abstract-digest-impact-statement#feature-abstract-test-1" test="count(title) = 1" role="error" id="feature-abstract-test-1">abstract must contain one and only one title.</assert>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::front//abstract[@abstract-type='executive-summary']" role="error" id="feature-abstract-tests-xspec-assert">front//abstract[@abstract-type='executive-summary'] must be present.</assert>
+      <assert test="descendant::front//abstract[@abstract-type=('executive-summary','plain-language-summary')]" role="error" id="feature-abstract-tests-xspec-assert">front//abstract[@abstract-type=('executive-summary','plain-language-summary')] must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/feature-abstract-tests/feature-abstract-test-1/pass.xml
+++ b/test/tests/gen/feature-abstract-tests/feature-abstract-test-1/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="feature-abstract-test-1.sch"?>
-<!--Context: front//abstract[@abstract-type='executive-summary']
+<!--Context: front//abstract[@abstract-type=('executive-summary','plain-language-summary')]
 Test: assert    count(title) = 1
 Message: abstract must contain one and only one title. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">

--- a/test/tests/gen/feature-abstract-tests/feature-abstract-test-2/fail.xml
+++ b/test/tests/gen/feature-abstract-tests/feature-abstract-test-2/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="feature-abstract-test-2.sch"?>
-<!--Context: front//abstract[@abstract-type='executive-summary']
+<!--Context: front//abstract[@abstract-type=('executive-summary','plain-language-summary')]
 Test: assert    title = 'eLife digest'
 Message: abstract title must contain 'eLife digest'. Possible superfluous characters -  -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">

--- a/test/tests/gen/feature-abstract-tests/feature-abstract-test-2/feature-abstract-test-2.sch
+++ b/test/tests/gen/feature-abstract-tests/feature-abstract-test-2/feature-abstract-test-2.sch
@@ -1197,14 +1197,14 @@
     
   </xsl:function>
   <pattern id="features">
-    <rule context="front//abstract[@abstract-type='executive-summary']" id="feature-abstract-tests">
+    <rule context="front//abstract[@abstract-type=('executive-summary','plain-language-summary')]" id="feature-abstract-tests">
       <assert see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/article-structure/abstract-digest-impact-statement#feature-abstract-test-2" test="title = 'eLife digest'" role="error" id="feature-abstract-test-2">abstract title must contain 'eLife digest'. Possible superfluous characters - <value-of select="replace(title,'eLife digest','')"/>
       </assert>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::front//abstract[@abstract-type='executive-summary']" role="error" id="feature-abstract-tests-xspec-assert">front//abstract[@abstract-type='executive-summary'] must be present.</assert>
+      <assert test="descendant::front//abstract[@abstract-type=('executive-summary','plain-language-summary')]" role="error" id="feature-abstract-tests-xspec-assert">front//abstract[@abstract-type=('executive-summary','plain-language-summary')] must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/feature-abstract-tests/feature-abstract-test-2/pass.xml
+++ b/test/tests/gen/feature-abstract-tests/feature-abstract-test-2/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="feature-abstract-test-2.sch"?>
-<!--Context: front//abstract[@abstract-type='executive-summary']
+<!--Context: front//abstract[@abstract-type=('executive-summary','plain-language-summary')]
 Test: assert    title = 'eLife digest'
 Message: abstract title must contain 'eLife digest'. Possible superfluous characters -  -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">

--- a/test/tests/gen/test-article-metadata/preprint-presence/preprint-presence.sch
+++ b/test/tests/gen/test-article-metadata/preprint-presence/preprint-presence.sch
@@ -1203,6 +1203,9 @@
       <let name="subj-type" value="descendant::subj-group[@subj-group-type='display-channel']/subject[1]"/>
       <let name="exceptions" value="('Insight',$notice-display-types)"/>
       <let name="no-digest" value="('Scientific Correspondence','Replication Study','Research Advance','Registered Report',$notice-display-types,$features-subj)"/>
+      <let name="abs-count" value="count(abstract)"/>
+      <let name="abs-standard-count" value="count(abstract[not(@abstract-type)])"/>
+      <let name="digest-count" value="count(abstract[@abstract-type=('plain-language-summary','executive-summary')])"/>
       <report test="($subj-type=('Research Article','Research Advance','Tools and Resources','Short Report')) and (history/date[@date-type='received']/@iso-8601-date gt '2021-07-01') and not(pub-history[event[self-uri[@content-type='preprint']]])" role="warning" id="preprint-presence">This <value-of select="$subj-type"/> was received on '<value-of select="history/date[@date-type='received']/@iso-8601-date"/>' (after the preprint mandate) but does not have preprint information. Is that correct?</report>
     </rule>
   </pattern>

--- a/test/tests/gen/test-article-metadata/test-abstracts/fail.xml
+++ b/test/tests/gen/test-article-metadata/test-abstracts/fail.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="test-abstracts.sch"?>
 <!--Context: article/front/article-meta
-Test: report    not($article-type = $notice-article-types) and (count(abstract[not(@abstract-type='executive-summary')]) != 1 or (count(abstract[not(@abstract-type='executive-summary')]) != 1 and count(abstract[@abstract-type='executive-summary']) != 1))
-Message: There must either be only one abstract or one abstract and one abstract[@abstract-type="executive-summary]. No other variations are allowed. -->
+Test: report    not($article-type = $notice-article-types) and ($abs-count gt 2 or $abs-standard-count != 1 or $digest-count gt 1 or ($abs-count != $abs-standard-count + $digest-count))
+Message: There must either be only one abstract or one abstract and one abstract[@abstract-type="plain-language-summary"]. No other variations are allowed. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article article-type="research-article">
     <front>
@@ -104,7 +104,8 @@ Message: There must either be only one abstract or one abstract and one abstract
           </license>
         </permissions>
         <self-uri content-type="pdf" xlink:href="elife-00000.pdf"/>
-        
+        <abstract/>
+        <abstract/>
         <kwd-group kwd-group-type="author-keywords">
           <kwd>learning</kwd>
           <kwd>modelling</kwd>

--- a/test/tests/gen/test-article-metadata/test-abstracts/pass.xml
+++ b/test/tests/gen/test-article-metadata/test-abstracts/pass.xml
@@ -1,7 +1,7 @@
 <?oxygen SCHSchema="test-abstracts.sch"?>
 <!--Context: article/front/article-meta
-Test: report    not($article-type = $notice-article-types) and (count(abstract[not(@abstract-type='executive-summary')]) != 1 or (count(abstract[not(@abstract-type='executive-summary')]) != 1 and count(abstract[@abstract-type='executive-summary']) != 1))
-Message: There must either be only one abstract or one abstract and one abstract[@abstract-type="executive-summary]. No other variations are allowed. -->
+Test: report    not($article-type = $notice-article-types) and ($abs-count gt 2 or $abs-standard-count != 1 or $digest-count gt 1 or ($abs-count != $abs-standard-count + $digest-count))
+Message: There must either be only one abstract or one abstract and one abstract[@abstract-type="plain-language-summary"]. No other variations are allowed. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article article-type="research-article">
     <front>

--- a/test/tests/gen/test-article-metadata/test-abstracts/test-abstracts.sch
+++ b/test/tests/gen/test-article-metadata/test-abstracts/test-abstracts.sch
@@ -1203,7 +1203,10 @@
       <let name="subj-type" value="descendant::subj-group[@subj-group-type='display-channel']/subject[1]"/>
       <let name="exceptions" value="('Insight',$notice-display-types)"/>
       <let name="no-digest" value="('Scientific Correspondence','Replication Study','Research Advance','Registered Report',$notice-display-types,$features-subj)"/>
-      <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/article-structure/abstract-digest-impact-statement#test-abstracts" test="not($article-type = $notice-article-types) and (count(abstract[not(@abstract-type='executive-summary')]) != 1 or (count(abstract[not(@abstract-type='executive-summary')]) != 1 and count(abstract[@abstract-type='executive-summary']) != 1))" role="error" id="test-abstracts">There must either be only one abstract or one abstract and one abstract[@abstract-type="executive-summary]. No other variations are allowed.</report>
+      <let name="abs-count" value="count(abstract)"/>
+      <let name="abs-standard-count" value="count(abstract[not(@abstract-type)])"/>
+      <let name="digest-count" value="count(abstract[@abstract-type=('plain-language-summary','executive-summary')])"/>
+      <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/article-structure/abstract-digest-impact-statement#test-abstracts" test="not($article-type = $notice-article-types) and ($abs-count gt 2 or $abs-standard-count != 1 or $digest-count gt 1 or ($abs-count != $abs-standard-count + $digest-count))" role="error" id="test-abstracts">There must either be only one abstract or one abstract and one abstract[@abstract-type="plain-language-summary"]. No other variations are allowed.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/test-article-metadata/test-article-doi-1/test-article-doi-1.sch
+++ b/test/tests/gen/test-article-metadata/test-article-doi-1/test-article-doi-1.sch
@@ -1203,6 +1203,9 @@
       <let name="subj-type" value="descendant::subj-group[@subj-group-type='display-channel']/subject[1]"/>
       <let name="exceptions" value="('Insight',$notice-display-types)"/>
       <let name="no-digest" value="('Scientific Correspondence','Replication Study','Research Advance','Registered Report',$notice-display-types,$features-subj)"/>
+      <let name="abs-count" value="count(abstract)"/>
+      <let name="abs-standard-count" value="count(abstract[not(@abstract-type)])"/>
+      <let name="digest-count" value="count(abstract[@abstract-type=('plain-language-summary','executive-summary')])"/>
       <assert test="starts-with(article-id[@pub-id-type='doi'][1],'10.7554/eLife.')" role="error" id="test-article-doi-1">Article level DOI must start with '10.7554/eLife.'. Currently it is <value-of select="article-id[@pub-id-type='doi']"/>
       </assert>
     </rule>

--- a/test/tests/gen/test-article-metadata/test-article-doi-2/test-article-doi-2.sch
+++ b/test/tests/gen/test-article-metadata/test-article-doi-2/test-article-doi-2.sch
@@ -1203,6 +1203,9 @@
       <let name="subj-type" value="descendant::subj-group[@subj-group-type='display-channel']/subject[1]"/>
       <let name="exceptions" value="('Insight',$notice-display-types)"/>
       <let name="no-digest" value="('Scientific Correspondence','Replication Study','Research Advance','Registered Report',$notice-display-types,$features-subj)"/>
+      <let name="abs-count" value="count(abstract)"/>
+      <let name="abs-standard-count" value="count(abstract[not(@abstract-type)])"/>
+      <let name="digest-count" value="count(abstract[@abstract-type=('plain-language-summary','executive-summary')])"/>
       <assert test="substring-after(article-id[@pub-id-type='doi'][1],'10.7554/eLife.') = $article-id" role="error" id="test-article-doi-2">Article level DOI must be a concatenation of '10.7554/eLife.' and the article-id. Currently it is <value-of select="article-id[@pub-id-type='doi']"/>
       </assert>
     </rule>

--- a/test/tests/gen/test-article-metadata/test-article-id/test-article-id.sch
+++ b/test/tests/gen/test-article-metadata/test-article-id/test-article-id.sch
@@ -1203,6 +1203,9 @@
       <let name="subj-type" value="descendant::subj-group[@subj-group-type='display-channel']/subject[1]"/>
       <let name="exceptions" value="('Insight',$notice-display-types)"/>
       <let name="no-digest" value="('Scientific Correspondence','Replication Study','Research Advance','Registered Report',$notice-display-types,$features-subj)"/>
+      <let name="abs-count" value="count(abstract)"/>
+      <let name="abs-standard-count" value="count(abstract[not(@abstract-type)])"/>
+      <let name="digest-count" value="count(abstract[@abstract-type=('plain-language-summary','executive-summary')])"/>
       <assert test="matches($article-id,'^\d{5}$')" role="error" id="test-article-id">article-id must consist only of 5 digits. Currently it is <value-of select="article-id[@pub-id-type='publisher-id']"/>
       </assert>
     </rule>

--- a/test/tests/gen/test-article-metadata/test-article-presence/test-article-presence.sch
+++ b/test/tests/gen/test-article-metadata/test-article-presence/test-article-presence.sch
@@ -1203,6 +1203,9 @@
       <let name="subj-type" value="descendant::subj-group[@subj-group-type='display-channel']/subject[1]"/>
       <let name="exceptions" value="('Insight',$notice-display-types)"/>
       <let name="no-digest" value="('Scientific Correspondence','Replication Study','Research Advance','Registered Report',$notice-display-types,$features-subj)"/>
+      <let name="abs-count" value="count(abstract)"/>
+      <let name="abs-standard-count" value="count(abstract[not(@abstract-type)])"/>
+      <let name="digest-count" value="count(abstract[@abstract-type=('plain-language-summary','executive-summary')])"/>
       <assert test="count(article-categories) = 1" role="error" id="test-article-presence">There must be one article-categories element in the article-meta. Currently there are <value-of select="count(article-categories)"/>
       </assert>
     </rule>

--- a/test/tests/gen/test-article-metadata/test-auth-kwd-group-presence-1/test-auth-kwd-group-presence-1.sch
+++ b/test/tests/gen/test-article-metadata/test-auth-kwd-group-presence-1/test-auth-kwd-group-presence-1.sch
@@ -1203,6 +1203,9 @@
       <let name="subj-type" value="descendant::subj-group[@subj-group-type='display-channel']/subject[1]"/>
       <let name="exceptions" value="('Insight',$notice-display-types)"/>
       <let name="no-digest" value="('Scientific Correspondence','Replication Study','Research Advance','Registered Report',$notice-display-types,$features-subj)"/>
+      <let name="abs-count" value="count(abstract)"/>
+      <let name="abs-standard-count" value="count(abstract[not(@abstract-type)])"/>
+      <let name="digest-count" value="count(abstract[@abstract-type=('plain-language-summary','executive-summary')])"/>
       <report test="if ($subj-type = $notice-display-types) then ()       else count(kwd-group[@kwd-group-type='author-keywords']) != 1" role="error" id="test-auth-kwd-group-presence-1">One author keyword group must be present in article-meta.</report>
     </rule>
   </pattern>

--- a/test/tests/gen/test-article-metadata/test-auth-kwd-group-presence-2/test-auth-kwd-group-presence-2.sch
+++ b/test/tests/gen/test-article-metadata/test-auth-kwd-group-presence-2/test-auth-kwd-group-presence-2.sch
@@ -1203,6 +1203,9 @@
       <let name="subj-type" value="descendant::subj-group[@subj-group-type='display-channel']/subject[1]"/>
       <let name="exceptions" value="('Insight',$notice-display-types)"/>
       <let name="no-digest" value="('Scientific Correspondence','Replication Study','Research Advance','Registered Report',$notice-display-types,$features-subj)"/>
+      <let name="abs-count" value="count(abstract)"/>
+      <let name="abs-standard-count" value="count(abstract[not(@abstract-type)])"/>
+      <let name="digest-count" value="count(abstract[@abstract-type=('plain-language-summary','executive-summary')])"/>
       <report test="if ($subj-type = $notice-display-types) then (count(kwd-group[@kwd-group-type='author-keywords']) != 0)       else ()" role="error" id="test-auth-kwd-group-presence-2">
         <value-of select="$subj-type"/> articles must not have any author keywords</report>
     </rule>

--- a/test/tests/gen/test-article-metadata/test-custom-meta-group-presence/test-custom-meta-group-presence.sch
+++ b/test/tests/gen/test-article-metadata/test-custom-meta-group-presence/test-custom-meta-group-presence.sch
@@ -1203,6 +1203,9 @@
       <let name="subj-type" value="descendant::subj-group[@subj-group-type='display-channel']/subject[1]"/>
       <let name="exceptions" value="('Insight',$notice-display-types)"/>
       <let name="no-digest" value="('Scientific Correspondence','Replication Study','Research Advance','Registered Report',$notice-display-types,$features-subj)"/>
+      <let name="abs-count" value="count(abstract)"/>
+      <let name="abs-standard-count" value="count(abstract[not(@abstract-type)])"/>
+      <let name="digest-count" value="count(abstract[@abstract-type=('plain-language-summary','executive-summary')])"/>
       <report test="if ($subj-type = $exceptions) then ()       else count(custom-meta-group) != 1" role="error" id="test-custom-meta-group-presence">One custom-meta-group should be present in article-meta for all article types except Insights, Retractions, Corrections and Expressions of Concern.</report>
     </rule>
   </pattern>

--- a/test/tests/gen/test-article-metadata/test-elocation-presence/test-elocation-presence.sch
+++ b/test/tests/gen/test-article-metadata/test-elocation-presence/test-elocation-presence.sch
@@ -1203,6 +1203,9 @@
       <let name="subj-type" value="descendant::subj-group[@subj-group-type='display-channel']/subject[1]"/>
       <let name="exceptions" value="('Insight',$notice-display-types)"/>
       <let name="no-digest" value="('Scientific Correspondence','Replication Study','Research Advance','Registered Report',$notice-display-types,$features-subj)"/>
+      <let name="abs-count" value="count(abstract)"/>
+      <let name="abs-standard-count" value="count(abstract[not(@abstract-type)])"/>
+      <let name="digest-count" value="count(abstract[@abstract-type=('plain-language-summary','executive-summary')])"/>
       <assert test="elocation-id" role="error" id="test-elocation-presence">There must be a child elocation-id in article-meta.</assert>
     </rule>
   </pattern>

--- a/test/tests/gen/test-article-metadata/test-epub-date/test-epub-date.sch
+++ b/test/tests/gen/test-article-metadata/test-epub-date/test-epub-date.sch
@@ -1203,6 +1203,9 @@
       <let name="subj-type" value="descendant::subj-group[@subj-group-type='display-channel']/subject[1]"/>
       <let name="exceptions" value="('Insight',$notice-display-types)"/>
       <let name="no-digest" value="('Scientific Correspondence','Replication Study','Research Advance','Registered Report',$notice-display-types,$features-subj)"/>
+      <let name="abs-count" value="count(abstract)"/>
+      <let name="abs-standard-count" value="count(abstract[not(@abstract-type)])"/>
+      <let name="digest-count" value="count(abstract[@abstract-type=('plain-language-summary','executive-summary')])"/>
       <assert test="pub-date[@publication-format='electronic'][@date-type='publication']" role="error" id="test-epub-date">There must be a child pub-date[@publication-format='electronic'][@date-type='publication'] in article-meta.</assert>
     </rule>
   </pattern>

--- a/test/tests/gen/test-article-metadata/test-funding-group-presence/test-funding-group-presence.sch
+++ b/test/tests/gen/test-article-metadata/test-funding-group-presence/test-funding-group-presence.sch
@@ -1203,6 +1203,9 @@
       <let name="subj-type" value="descendant::subj-group[@subj-group-type='display-channel']/subject[1]"/>
       <let name="exceptions" value="('Insight',$notice-display-types)"/>
       <let name="no-digest" value="('Scientific Correspondence','Replication Study','Research Advance','Registered Report',$notice-display-types,$features-subj)"/>
+      <let name="abs-count" value="count(abstract)"/>
+      <let name="abs-standard-count" value="count(abstract[not(@abstract-type)])"/>
+      <let name="digest-count" value="count(abstract[@abstract-type=('plain-language-summary','executive-summary')])"/>
       <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/funding-information#test-funding-group-presence" test="if ($article-type = $features-article-types) then ()       else if ($subj-type = ('Scientific Correspondence',$notice-display-types)) then ()       else count(funding-group) != 1" role="error" id="test-funding-group-presence">There must be one and only one funding-group element in the article-meta. Currently there are <value-of select="count(funding-group)"/>.</report>
     </rule>
   </pattern>

--- a/test/tests/gen/test-article-metadata/test-history-presence/test-history-presence.sch
+++ b/test/tests/gen/test-article-metadata/test-history-presence/test-history-presence.sch
@@ -1203,6 +1203,9 @@
       <let name="subj-type" value="descendant::subj-group[@subj-group-type='display-channel']/subject[1]"/>
       <let name="exceptions" value="('Insight',$notice-display-types)"/>
       <let name="no-digest" value="('Scientific Correspondence','Replication Study','Research Advance','Registered Report',$notice-display-types,$features-subj)"/>
+      <let name="abs-count" value="count(abstract)"/>
+      <let name="abs-standard-count" value="count(abstract[not(@abstract-type)])"/>
+      <let name="digest-count" value="count(abstract[@abstract-type=('plain-language-summary','executive-summary')])"/>
       <report test="not($article-type = ($notice-article-types,'article-commentary')) and count(history) != 1" role="error" id="test-history-presence">There must be one and only one history element in the article-meta. Currently there are <value-of select="count(history)"/>
       </report>
     </rule>

--- a/test/tests/gen/test-article-metadata/test-no-digest/fail.xml
+++ b/test/tests/gen/test-article-metadata/test-no-digest/fail.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="test-no-digest.sch"?>
 <!--Context: article/front/article-meta
-Test: report    ($subj-type= $no-digest) and abstract[@abstract-type='executive-summary']
+Test: report    ($subj-type= $no-digest) and abstract[@abstract-type=('executive-summary','plain-language-summary')]
 Message: '' cannot have a digest. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article article-type="article-commentary">

--- a/test/tests/gen/test-article-metadata/test-no-digest/pass.xml
+++ b/test/tests/gen/test-article-metadata/test-no-digest/pass.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="test-no-digest.sch"?>
 <!--Context: article/front/article-meta
-Test: report    ($subj-type= $no-digest) and abstract[@abstract-type='executive-summary']
+Test: report    ($subj-type= $no-digest) and abstract[@abstract-type=('executive-summary','plain-language-summary')]
 Message: '' cannot have a digest. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article article-type="research-article">

--- a/test/tests/gen/test-article-metadata/test-no-digest/test-no-digest.sch
+++ b/test/tests/gen/test-article-metadata/test-no-digest/test-no-digest.sch
@@ -1203,7 +1203,10 @@
       <let name="subj-type" value="descendant::subj-group[@subj-group-type='display-channel']/subject[1]"/>
       <let name="exceptions" value="('Insight',$notice-display-types)"/>
       <let name="no-digest" value="('Scientific Correspondence','Replication Study','Research Advance','Registered Report',$notice-display-types,$features-subj)"/>
-      <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/article-structure/abstract-digest-impact-statement#test-no-digest" test="($subj-type= $no-digest) and abstract[@abstract-type='executive-summary']" role="error" id="test-no-digest">'<value-of select="$subj-type"/>' cannot have a digest.</report>
+      <let name="abs-count" value="count(abstract)"/>
+      <let name="abs-standard-count" value="count(abstract[not(@abstract-type)])"/>
+      <let name="digest-count" value="count(abstract[@abstract-type=('plain-language-summary','executive-summary')])"/>
+      <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/article-structure/abstract-digest-impact-statement#test-no-digest" test="($subj-type= $no-digest) and abstract[@abstract-type=('executive-summary','plain-language-summary')]" role="error" id="test-no-digest">'<value-of select="$subj-type"/>' cannot have a digest.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/test-article-metadata/test-permissions-presence/test-permissions-presence.sch
+++ b/test/tests/gen/test-article-metadata/test-permissions-presence/test-permissions-presence.sch
@@ -1203,6 +1203,9 @@
       <let name="subj-type" value="descendant::subj-group[@subj-group-type='display-channel']/subject[1]"/>
       <let name="exceptions" value="('Insight',$notice-display-types)"/>
       <let name="no-digest" value="('Scientific Correspondence','Replication Study','Research Advance','Registered Report',$notice-display-types,$features-subj)"/>
+      <let name="abs-count" value="count(abstract)"/>
+      <let name="abs-standard-count" value="count(abstract[not(@abstract-type)])"/>
+      <let name="digest-count" value="count(abstract[@abstract-type=('plain-language-summary','executive-summary')])"/>
       <assert see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/licensing-and-copyright#test-permissions-presence" test="count(permissions) = 1" role="error" id="test-permissions-presence">There must be one and only one permissions element in the article-meta. Currently there are <value-of select="count(permissions)"/>
       </assert>
     </rule>

--- a/test/tests/gen/test-article-metadata/test-pub-collection-presence/test-pub-collection-presence.sch
+++ b/test/tests/gen/test-article-metadata/test-pub-collection-presence/test-pub-collection-presence.sch
@@ -1203,6 +1203,9 @@
       <let name="subj-type" value="descendant::subj-group[@subj-group-type='display-channel']/subject[1]"/>
       <let name="exceptions" value="('Insight',$notice-display-types)"/>
       <let name="no-digest" value="('Scientific Correspondence','Replication Study','Research Advance','Registered Report',$notice-display-types,$features-subj)"/>
+      <let name="abs-count" value="count(abstract)"/>
+      <let name="abs-standard-count" value="count(abstract[not(@abstract-type)])"/>
+      <let name="digest-count" value="count(abstract[@abstract-type=('plain-language-summary','executive-summary')])"/>
       <assert test="pub-date[@pub-type='collection']" role="error" id="test-pub-collection-presence">There must be a child pub-date[@pub-type='collection'] in article-meta.</assert>
     </rule>
   </pattern>

--- a/test/tests/gen/test-article-metadata/test-ro-kwd-group-presence-1/test-ro-kwd-group-presence-1.sch
+++ b/test/tests/gen/test-article-metadata/test-ro-kwd-group-presence-1/test-ro-kwd-group-presence-1.sch
@@ -1203,6 +1203,9 @@
       <let name="subj-type" value="descendant::subj-group[@subj-group-type='display-channel']/subject[1]"/>
       <let name="exceptions" value="('Insight',$notice-display-types)"/>
       <let name="no-digest" value="('Scientific Correspondence','Replication Study','Research Advance','Registered Report',$notice-display-types,$features-subj)"/>
+      <let name="abs-count" value="count(abstract)"/>
+      <let name="abs-standard-count" value="count(abstract[not(@abstract-type)])"/>
+      <let name="digest-count" value="count(abstract[@abstract-type=('plain-language-summary','executive-summary')])"/>
       <report test="count(kwd-group[@kwd-group-type='research-organism']) gt 1" role="error" id="test-ro-kwd-group-presence-1">More than 1 Research organism keyword group is present in article-meta. This is incorrect.</report>
     </rule>
   </pattern>

--- a/test/tests/gen/test-article-metadata/test-ro-kwd-group-presence-2/test-ro-kwd-group-presence-2.sch
+++ b/test/tests/gen/test-article-metadata/test-ro-kwd-group-presence-2/test-ro-kwd-group-presence-2.sch
@@ -1203,6 +1203,9 @@
       <let name="subj-type" value="descendant::subj-group[@subj-group-type='display-channel']/subject[1]"/>
       <let name="exceptions" value="('Insight',$notice-display-types)"/>
       <let name="no-digest" value="('Scientific Correspondence','Replication Study','Research Advance','Registered Report',$notice-display-types,$features-subj)"/>
+      <let name="abs-count" value="count(abstract)"/>
+      <let name="abs-standard-count" value="count(abstract[not(@abstract-type)])"/>
+      <let name="digest-count" value="count(abstract[@abstract-type=('plain-language-summary','executive-summary')])"/>
       <report test="if ($subj-type = ('Research Article', 'Research Advance', 'Replication Study', 'Research Communication'))       then (count(kwd-group[@kwd-group-type='research-organism']) = 0)       else ()" role="warning" id="test-ro-kwd-group-presence-2">
         <value-of select="$subj-type"/> does not contain a Research Organism keyword group. Is this correct?</report>
     </rule>

--- a/test/tests/gen/test-article-metadata/test-self-uri-att/test-self-uri-att.sch
+++ b/test/tests/gen/test-article-metadata/test-self-uri-att/test-self-uri-att.sch
@@ -1203,6 +1203,9 @@
       <let name="subj-type" value="descendant::subj-group[@subj-group-type='display-channel']/subject[1]"/>
       <let name="exceptions" value="('Insight',$notice-display-types)"/>
       <let name="no-digest" value="('Scientific Correspondence','Replication Study','Research Advance','Registered Report',$notice-display-types,$features-subj)"/>
+      <let name="abs-count" value="count(abstract)"/>
+      <let name="abs-standard-count" value="count(abstract[not(@abstract-type)])"/>
+      <let name="digest-count" value="count(abstract[@abstract-type=('plain-language-summary','executive-summary')])"/>
       <report test="not($article-type = $notice-article-types) and not(self-uri[@content-type='pdf'])" role="error" id="test-self-uri-att">self-uri must have an @content-type="pdf"</report>
     </rule>
   </pattern>

--- a/test/tests/gen/test-article-metadata/test-self-uri-pdf-1/test-self-uri-pdf-1.sch
+++ b/test/tests/gen/test-article-metadata/test-self-uri-pdf-1/test-self-uri-pdf-1.sch
@@ -1203,6 +1203,9 @@
       <let name="subj-type" value="descendant::subj-group[@subj-group-type='display-channel']/subject[1]"/>
       <let name="exceptions" value="('Insight',$notice-display-types)"/>
       <let name="no-digest" value="('Scientific Correspondence','Replication Study','Research Advance','Registered Report',$notice-display-types,$features-subj)"/>
+      <let name="abs-count" value="count(abstract)"/>
+      <let name="abs-standard-count" value="count(abstract[not(@abstract-type)])"/>
+      <let name="digest-count" value="count(abstract[@abstract-type=('plain-language-summary','executive-summary')])"/>
       <report test="not($article-type = $notice-article-types) and not(self-uri[starts-with(@xlink:href,concat('elife-', $article-id))])" role="error" id="test-self-uri-pdf-1">self-uri must have attribute xlink:href="elife-xxxxx.pdf" where xxxxx = the article-id. Currently it is <value-of select="self-uri/@xlink:href"/>. It should start with elife-<value-of select="$article-id"/>.</report>
     </rule>
   </pattern>

--- a/test/tests/gen/test-article-metadata/test-self-uri-pdf-2/test-self-uri-pdf-2.sch
+++ b/test/tests/gen/test-article-metadata/test-self-uri-pdf-2/test-self-uri-pdf-2.sch
@@ -1203,6 +1203,9 @@
       <let name="subj-type" value="descendant::subj-group[@subj-group-type='display-channel']/subject[1]"/>
       <let name="exceptions" value="('Insight',$notice-display-types)"/>
       <let name="no-digest" value="('Scientific Correspondence','Replication Study','Research Advance','Registered Report',$notice-display-types,$features-subj)"/>
+      <let name="abs-count" value="count(abstract)"/>
+      <let name="abs-standard-count" value="count(abstract[not(@abstract-type)])"/>
+      <let name="digest-count" value="count(abstract[@abstract-type=('plain-language-summary','executive-summary')])"/>
       <report test="not($article-type = $notice-article-types) and not(self-uri[matches(@xlink:href, '^elife-[\d]{5}\.pdf$|^elife-[\d]{5}-v[0-9]{1,2}\.pdf$')])" role="error" id="test-self-uri-pdf-2">self-uri does not conform.</report>
     </rule>
   </pattern>

--- a/test/tests/gen/test-article-metadata/test-self-uri-presence/test-self-uri-presence.sch
+++ b/test/tests/gen/test-article-metadata/test-self-uri-presence/test-self-uri-presence.sch
@@ -1203,6 +1203,9 @@
       <let name="subj-type" value="descendant::subj-group[@subj-group-type='display-channel']/subject[1]"/>
       <let name="exceptions" value="('Insight',$notice-display-types)"/>
       <let name="no-digest" value="('Scientific Correspondence','Replication Study','Research Advance','Registered Report',$notice-display-types,$features-subj)"/>
+      <let name="abs-count" value="count(abstract)"/>
+      <let name="abs-standard-count" value="count(abstract[not(@abstract-type)])"/>
+      <let name="digest-count" value="count(abstract[@abstract-type=('plain-language-summary','executive-summary')])"/>
       <report test="not($article-type = $notice-article-types) and not(self-uri)" role="error" id="test-self-uri-presence">There must be a child self-uri in article-meta.</report>
     </rule>
   </pattern>

--- a/test/tests/gen/test-article-metadata/test-title-group-presence/test-title-group-presence.sch
+++ b/test/tests/gen/test-article-metadata/test-title-group-presence/test-title-group-presence.sch
@@ -1203,6 +1203,9 @@
       <let name="subj-type" value="descendant::subj-group[@subj-group-type='display-channel']/subject[1]"/>
       <let name="exceptions" value="('Insight',$notice-display-types)"/>
       <let name="no-digest" value="('Scientific Correspondence','Replication Study','Research Advance','Registered Report',$notice-display-types,$features-subj)"/>
+      <let name="abs-count" value="count(abstract)"/>
+      <let name="abs-standard-count" value="count(abstract[not(@abstract-type)])"/>
+      <let name="digest-count" value="count(abstract[@abstract-type=('plain-language-summary','executive-summary')])"/>
       <assert test="title-group[article-title]" role="error" id="test-title-group-presence">title-group containing article-title must be present.</assert>
     </rule>
   </pattern>

--- a/test/tests/gen/test-article-metadata/test-volume-contents/test-volume-contents.sch
+++ b/test/tests/gen/test-article-metadata/test-volume-contents/test-volume-contents.sch
@@ -1203,6 +1203,9 @@
       <let name="subj-type" value="descendant::subj-group[@subj-group-type='display-channel']/subject[1]"/>
       <let name="exceptions" value="('Insight',$notice-display-types)"/>
       <let name="no-digest" value="('Scientific Correspondence','Replication Study','Research Advance','Registered Report',$notice-display-types,$features-subj)"/>
+      <let name="abs-count" value="count(abstract)"/>
+      <let name="abs-standard-count" value="count(abstract[not(@abstract-type)])"/>
+      <let name="digest-count" value="count(abstract[@abstract-type=('plain-language-summary','executive-summary')])"/>
       <assert test="matches(volume[1],'^[0-9]*$')" role="error" id="test-volume-contents">volume must only contain a number.</assert>
     </rule>
   </pattern>

--- a/test/tests/gen/test-article-metadata/test-volume-presence/test-volume-presence.sch
+++ b/test/tests/gen/test-article-metadata/test-volume-presence/test-volume-presence.sch
@@ -1203,6 +1203,9 @@
       <let name="subj-type" value="descendant::subj-group[@subj-group-type='display-channel']/subject[1]"/>
       <let name="exceptions" value="('Insight',$notice-display-types)"/>
       <let name="no-digest" value="('Scientific Correspondence','Replication Study','Research Advance','Registered Report',$notice-display-types,$features-subj)"/>
+      <let name="abs-count" value="count(abstract)"/>
+      <let name="abs-standard-count" value="count(abstract[not(@abstract-type)])"/>
+      <let name="digest-count" value="count(abstract[@abstract-type=('plain-language-summary','executive-summary')])"/>
       <assert test="volume" role="error" id="test-volume-presence">There must be a child volume in article-meta.</assert>
     </rule>
   </pattern>

--- a/test/xspec/schematron.sch
+++ b/test/xspec/schematron.sch
@@ -1361,6 +1361,9 @@
     <let name="subj-type" value="descendant::subj-group[@subj-group-type='display-channel']/subject[1]"/>
     <let name="exceptions" value="('Insight',$notice-display-types)"/>
     <let name="no-digest" value="('Scientific Correspondence','Replication Study','Research Advance','Registered Report',$notice-display-types,$features-subj)"/>
+    <let name="abs-count" value="count(abstract)"/>
+    <let name="abs-standard-count" value="count(abstract[not(@abstract-type)])"/>
+    <let name="digest-count" value="count(abstract[@abstract-type=('plain-language-summary','executive-summary')])"/>
     
 	<assert test="matches($article-id,'^\d{5}$')" role="error" id="test-article-id">article-id must consist only of 5 digits. Currently it is <value-of select="article-id[@pub-id-type='publisher-id']"/>
       </assert> 
@@ -1406,9 +1409,9 @@
     <assert see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/licensing-and-copyright#test-permissions-presence" test="count(permissions) = 1" role="error" id="test-permissions-presence">There must be one and only one permissions element in the article-meta. Currently there are <value-of select="count(permissions)"/>
       </assert>
 		  
-    <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/article-structure/abstract-digest-impact-statement#test-abstracts" test="not($article-type = $notice-article-types) and (count(abstract[not(@abstract-type='executive-summary')]) != 1 or (count(abstract[not(@abstract-type='executive-summary')]) != 1 and count(abstract[@abstract-type='executive-summary']) != 1))" role="error" id="test-abstracts">There must either be only one abstract or one abstract and one abstract[@abstract-type="executive-summary]. No other variations are allowed.</report>
+    <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/article-structure/abstract-digest-impact-statement#test-abstracts" test="not($article-type = $notice-article-types) and ($abs-count gt 2 or $abs-standard-count != 1 or $digest-count gt 1 or ($abs-count != $abs-standard-count + $digest-count))" role="error" id="test-abstracts">There must either be only one abstract or one abstract and one abstract[@abstract-type="plain-language-summary"]. No other variations are allowed.</report>
     
-    <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/article-structure/abstract-digest-impact-statement#test-no-digest" test="($subj-type= $no-digest) and abstract[@abstract-type='executive-summary']" role="error" id="test-no-digest">'<value-of select="$subj-type"/>' cannot have a digest.</report>
+    <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/article-structure/abstract-digest-impact-statement#test-no-digest" test="($subj-type= $no-digest) and abstract[@abstract-type=('executive-summary','plain-language-summary')]" role="error" id="test-no-digest">'<value-of select="$subj-type"/>' cannot have a digest.</report>
 	 
     <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/funding-information#test-funding-group-presence" test="if ($article-type = $features-article-types) then ()       else if ($subj-type = ('Scientific Correspondence',$notice-display-types)) then ()       else count(funding-group) != 1" role="error" id="test-funding-group-presence">There must be one and only one funding-group element in the article-meta. Currently there are <value-of select="count(funding-group)"/>.</report>
     
@@ -6134,7 +6137,7 @@
    </rule>
   </pattern>
   <pattern id="feature-abstract-tests-pattern">
-    <rule context="front//abstract[@abstract-type='executive-summary']" id="feature-abstract-tests">
+    <rule context="front//abstract[@abstract-type=('executive-summary','plain-language-summary')]" id="feature-abstract-tests">
      
      <assert see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/article-structure/abstract-digest-impact-statement#feature-abstract-test-1" test="count(title) = 1" role="error" id="feature-abstract-test-1">abstract must contain one and only one title.</assert>
      
@@ -6144,7 +6147,7 @@
    </rule>
   </pattern>
   <pattern id="digest-tests-pattern">
-    <rule context="front//abstract[@abstract-type='executive-summary']/p" id="digest-tests">
+    <rule context="front//abstract[@abstract-type=('executive-summary','plain-language-summary')]/p" id="digest-tests">
      
      <report see="https://elifesciences.gitbook.io/productionhowto/-M1eY9ikxECYR-0OcnGt/article-details/content/article-structure/abstract-digest-impact-statement#digest-test-1" test="matches(.,'^\p{Ll}')" role="warning" id="digest-test-1">digest paragraph starts with a lowercase letter. Is that correct? Or has a paragraph been incorrectly split into two?</report>
      
@@ -9401,8 +9404,8 @@
       <assert test="descendant::element-citation/pub-id" role="error" id="pub-id-tests-xspec-assert">element-citation/pub-id must be present.</assert>
       <assert test="descendant::pub-id[@xlink:href]" role="error" id="pub-id-xlink-href-tests-xspec-assert">pub-id[@xlink:href] must be present.</assert>
       <assert test="descendant::article-meta[descendant::subj-group[@subj-group-type='display-channel']/subject = $features-subj]//title-group/article-title" role="error" id="feature-title-tests-xspec-assert">article-meta[descendant::subj-group[@subj-group-type='display-channel']/subject = $features-subj]//title-group/article-title must be present.</assert>
-      <assert test="descendant::front//abstract[@abstract-type='executive-summary']" role="error" id="feature-abstract-tests-xspec-assert">front//abstract[@abstract-type='executive-summary'] must be present.</assert>
-      <assert test="descendant::front//abstract[@abstract-type='executive-summary']/p" role="error" id="digest-tests-xspec-assert">front//abstract[@abstract-type='executive-summary']/p must be present.</assert>
+      <assert test="descendant::front//abstract[@abstract-type=('executive-summary','plain-language-summary')]" role="error" id="feature-abstract-tests-xspec-assert">front//abstract[@abstract-type=('executive-summary','plain-language-summary')] must be present.</assert>
+      <assert test="descendant::front//abstract[@abstract-type=('executive-summary','plain-language-summary')]/p" role="error" id="digest-tests-xspec-assert">front//abstract[@abstract-type=('executive-summary','plain-language-summary')]/p must be present.</assert>
       <assert test="descendant::subj-group[@subj-group-type='sub-display-channel']/subject" role="error" id="feature-subj-tests-xspec-assert">subj-group[@subj-group-type='sub-display-channel']/subject must be present.</assert>
       <assert test="descendant::article-categories[subj-group[@subj-group-type='display-channel']/subject = $features-subj]" role="error" id="feature-article-category-tests-xspec-assert">article-categories[subj-group[@subj-group-type='display-channel']/subject = $features-subj] must be present.</assert>
       <assert test="descendant::article//article-meta[article-categories//subj-group[@subj-group-type='display-channel']/subject=$features-subj]//contrib[@contrib-type='author']" role="error" id="feature-author-tests-xspec-assert">article//article-meta[article-categories//subj-group[@subj-group-type='display-channel']/subject=$features-subj]//contrib[@contrib-type='author'] must be present.</assert>


### PR DESCRIPTION
Digest now captured using `plain-language-summary`.