### PR TITLE
chore: editorials don't requite history dates

### DIFF
--- a/src/final-JATS-schematron.sch
+++ b/src/final-JATS-schematron.sch
@@ -1395,7 +1395,7 @@
     
     <report test="not($article-type = $notice-article-types) and not(self-uri[matches(@xlink:href, '^elife-[\d]{5}\.pdf$|^elife-[\d]{5}-v[0-9]{1,2}\.pdf$')])" role="error" id="test-self-uri-pdf-2">[test-self-uri-pdf-2] self-uri does not conform.</report>
 		
-    <report test="not($article-type = ($notice-article-types,'article-commentary')) and count(history) != 1" role="error" id="test-history-presence">[test-history-presence] There must be one and only one history element in the article-meta. Currently there are <value-of select="count(history)"/>
+    <report test="not($article-type = ($notice-article-types,'article-commentary','editorial')) and count(history) != 1" role="error" id="test-history-presence">[test-history-presence] There must be one and only one history element in the article-meta. Currently there are <value-of select="count(history)"/>
       </report>
     
     <!-- Add this once all history is removed from insights

--- a/src/final-JATS-schematron.xsl
+++ b/src/final-JATS-schematron.xsl
@@ -6480,8 +6480,8 @@
       </xsl:if>
 
 		    <!--REPORT error-->
-      <xsl:if test="not($article-type = ($notice-article-types,'article-commentary')) and count(history) != 1">
-         <svrl:successful-report xmlns:svrl="http://purl.oclc.org/dsdl/svrl" test="not($article-type = ($notice-article-types,'article-commentary')) and count(history) != 1">
+      <xsl:if test="not($article-type = ($notice-article-types,'article-commentary','editorial')) and count(history) != 1">
+         <svrl:successful-report xmlns:svrl="http://purl.oclc.org/dsdl/svrl" test="not($article-type = ($notice-article-types,'article-commentary','editorial')) and count(history) != 1">
             <xsl:attribute name="id">test-history-presence</xsl:attribute>
             <xsl:attribute name="role">error</xsl:attribute>
             <xsl:attribute name="location">

--- a/src/final-package-JATS-schematron.sch
+++ b/src/final-package-JATS-schematron.sch
@@ -1403,7 +1403,7 @@
     
     <report test="not($article-type = $notice-article-types) and not(self-uri[matches(@xlink:href, '^elife-[\d]{5}\.pdf$|^elife-[\d]{5}-v[0-9]{1,2}\.pdf$')])" role="error" id="test-self-uri-pdf-2">self-uri does not conform.</report>
 		
-    <report test="not($article-type = ($notice-article-types,'article-commentary')) and count(history) != 1" role="error" id="test-history-presence">There must be one and only one history element in the article-meta. Currently there are <value-of select="count(history)"/>
+    <report test="not($article-type = ($notice-article-types,'article-commentary','editorial')) and count(history) != 1" role="error" id="test-history-presence">There must be one and only one history element in the article-meta. Currently there are <value-of select="count(history)"/>
       </report>
     
     <!-- Add this once all history is removed from insights

--- a/src/pre-JATS-schematron.sch
+++ b/src/pre-JATS-schematron.sch
@@ -1340,7 +1340,7 @@
     
     <report test="not($article-type = $notice-article-types) and not(self-uri[matches(@xlink:href, '^elife-[\d]{5}\.pdf$|^elife-[\d]{5}-v[0-9]{1,2}\.pdf$')])" role="error" id="test-self-uri-pdf-2">[test-self-uri-pdf-2] self-uri does not conform.</report>
 		
-    <report test="not($article-type = ($notice-article-types,'article-commentary')) and count(history) != 1" role="error" id="test-history-presence">[test-history-presence] There must be one and only one history element in the article-meta. Currently there are <value-of select="count(history)"/>
+    <report test="not($article-type = ($notice-article-types,'article-commentary','editorial')) and count(history) != 1" role="error" id="test-history-presence">[test-history-presence] There must be one and only one history element in the article-meta. Currently there are <value-of select="count(history)"/>
       </report>
     
     <!-- Add this once all history is removed from insights

--- a/src/pre-JATS-schematron.xsl
+++ b/src/pre-JATS-schematron.xsl
@@ -6400,8 +6400,8 @@
       </xsl:if>
 
 		    <!--REPORT error-->
-      <xsl:if test="not($article-type = ($notice-article-types,'article-commentary')) and count(history) != 1">
-         <svrl:successful-report xmlns:svrl="http://purl.oclc.org/dsdl/svrl" test="not($article-type = ($notice-article-types,'article-commentary')) and count(history) != 1">
+      <xsl:if test="not($article-type = ($notice-article-types,'article-commentary','editorial')) and count(history) != 1">
+         <svrl:successful-report xmlns:svrl="http://purl.oclc.org/dsdl/svrl" test="not($article-type = ($notice-article-types,'article-commentary','editorial')) and count(history) != 1">
             <xsl:attribute name="id">test-history-presence</xsl:attribute>
             <xsl:attribute name="role">error</xsl:attribute>
             <xsl:attribute name="location">

--- a/src/schematron.sch
+++ b/src/schematron.sch
@@ -1537,7 +1537,7 @@
         role="error" 
         id="test-self-uri-pdf-2">self-uri does not conform.</report>
 		
-    <report test="not($article-type = ($notice-article-types,'article-commentary')) and count(history) != 1" 
+    <report test="not($article-type = ($notice-article-types,'article-commentary','editorial')) and count(history) != 1" 
         role="error" 
         id="test-history-presence">There must be one and only one history element in the article-meta. Currently there are <value-of select="count(history)"/></report>
     

--- a/test/tests/gen/test-article-metadata/test-history-presence/fail.xml
+++ b/test/tests/gen/test-article-metadata/test-history-presence/fail.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="test-history-presence.sch"?>
 <!--Context: article/front/article-meta
-Test: report    not($article-type = ($notice-article-types,'article-commentary')) and count(history) != 1
+Test: report    not($article-type = ($notice-article-types,'article-commentary','editorial')) and count(history) != 1
 Message: There must be one and only one history element in the article-meta. Currently there are  -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article article-type="research-article">

--- a/test/tests/gen/test-article-metadata/test-history-presence/pass.xml
+++ b/test/tests/gen/test-article-metadata/test-history-presence/pass.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="test-history-presence.sch"?>
 <!--Context: article/front/article-meta
-Test: report    not($article-type = ($notice-article-types,'article-commentary')) and count(history) != 1
+Test: report    not($article-type = ($notice-article-types,'article-commentary','editorial')) and count(history) != 1
 Message: There must be one and only one history element in the article-meta. Currently there are  -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article article-type="research-article">

--- a/test/tests/gen/test-article-metadata/test-history-presence/test-history-presence.sch
+++ b/test/tests/gen/test-article-metadata/test-history-presence/test-history-presence.sch
@@ -1206,7 +1206,7 @@
       <let name="abs-count" value="count(abstract)"/>
       <let name="abs-standard-count" value="count(abstract[not(@abstract-type)])"/>
       <let name="digest-count" value="count(abstract[@abstract-type=('plain-language-summary','executive-summary')])"/>
-      <report test="not($article-type = ($notice-article-types,'article-commentary')) and count(history) != 1" role="error" id="test-history-presence">There must be one and only one history element in the article-meta. Currently there are <value-of select="count(history)"/>
+      <report test="not($article-type = ($notice-article-types,'article-commentary','editorial')) and count(history) != 1" role="error" id="test-history-presence">There must be one and only one history element in the article-meta. Currently there are <value-of select="count(history)"/>
       </report>
     </rule>
   </pattern>

--- a/test/xspec/schematron.sch
+++ b/test/xspec/schematron.sch
@@ -1397,7 +1397,7 @@
     
     <report test="not($article-type = $notice-article-types) and not(self-uri[matches(@xlink:href, '^elife-[\d]{5}\.pdf$|^elife-[\d]{5}-v[0-9]{1,2}\.pdf$')])" role="error" id="test-self-uri-pdf-2">self-uri does not conform.</report>
 		
-    <report test="not($article-type = ($notice-article-types,'article-commentary')) and count(history) != 1" role="error" id="test-history-presence">There must be one and only one history element in the article-meta. Currently there are <value-of select="count(history)"/>
+    <report test="not($article-type = ($notice-article-types,'article-commentary','editorial')) and count(history) != 1" role="error" id="test-history-presence">There must be one and only one history element in the article-meta. Currently there are <value-of select="count(history)"/>
       </report>
     
     <!-- Add this once all history is removed from insights


### PR DESCRIPTION
- Don't fire `test-history-presence` for Editorials