### PR TITLE
chore: change to custom-meta-test-9

### DIFF
--- a/src/final-JATS-schematron.sch
+++ b/src/final-JATS-schematron.sch
@@ -2639,7 +2639,7 @@
       
       
       
-      <report see="https://elifeproduction.slab.com/posts/abstracts-digests-and-impact-statements-tiau2k6x#final-custom-meta-test-9" test="matches(.,'[Ww]e show|[Ww]e present|[Tt]his study|[Tt]his paper')" role="error" id="final-custom-meta-test-9">[final-custom-meta-test-9] Impact statement contains a possessive phrase. This is not allowed.</report>
+      <report see="https://elifeproduction.slab.com/posts/abstracts-digests-and-impact-statements-tiau2k6x#final-custom-meta-test-9" test="matches(.,'[Ww]e show|[Ww]e present|[Tt]his study|[Tt]his paper| et al\.')" role="error" id="final-custom-meta-test-9">[final-custom-meta-test-9] Impact statement contains a possessive phrase. This is not allowed.</report>
       
       <report see="https://elifeproduction.slab.com/posts/abstracts-digests-and-impact-statements-tiau2k6x#custom-meta-test-10" test="matches(.,'^[\d]+$')" role="error" id="custom-meta-test-10">[custom-meta-test-10] Impact statement is comprised entirely of numbers, which must be incorrect.</report>
       

--- a/src/final-JATS-schematron.xsl
+++ b/src/final-JATS-schematron.xsl
@@ -12595,8 +12595,8 @@
       </xsl:if>
 
 		    <!--REPORT error-->
-      <xsl:if test="matches(.,'[Ww]e show|[Ww]e present|[Tt]his study|[Tt]his paper')">
-         <svrl:successful-report xmlns:svrl="http://purl.oclc.org/dsdl/svrl" test="matches(.,'[Ww]e show|[Ww]e present|[Tt]his study|[Tt]his paper')">
+      <xsl:if test="matches(.,'[Ww]e show|[Ww]e present|[Tt]his study|[Tt]his paper| et al\.')">
+         <svrl:successful-report xmlns:svrl="http://purl.oclc.org/dsdl/svrl" test="matches(.,'[Ww]e show|[Ww]e present|[Tt]his study|[Tt]his paper| et al\.')">
             <xsl:attribute name="id">final-custom-meta-test-9</xsl:attribute>
             <xsl:attribute name="see">https://elifeproduction.slab.com/posts/abstracts-digests-and-impact-statements-tiau2k6x#final-custom-meta-test-9</xsl:attribute>
             <xsl:attribute name="role">error</xsl:attribute>

--- a/src/final-package-JATS-schematron.sch
+++ b/src/final-package-JATS-schematron.sch
@@ -2713,7 +2713,7 @@
       
       
       
-      <report see="https://elifeproduction.slab.com/posts/abstracts-digests-and-impact-statements-tiau2k6x#final-custom-meta-test-9" test="matches(.,'[Ww]e show|[Ww]e present|[Tt]his study|[Tt]his paper')" role="error" id="final-custom-meta-test-9">Impact statement contains a possessive phrase. This is not allowed.</report>
+      <report see="https://elifeproduction.slab.com/posts/abstracts-digests-and-impact-statements-tiau2k6x#final-custom-meta-test-9" test="matches(.,'[Ww]e show|[Ww]e present|[Tt]his study|[Tt]his paper| et al\.')" role="error" id="final-custom-meta-test-9">Impact statement contains a possessive phrase. This is not allowed.</report>
       
       <report see="https://elifeproduction.slab.com/posts/abstracts-digests-and-impact-statements-tiau2k6x#custom-meta-test-10" test="matches(.,'^[\d]+$')" role="error" id="custom-meta-test-10">Impact statement is comprised entirely of numbers, which must be incorrect.</report>
       

--- a/src/pre-JATS-schematron.sch
+++ b/src/pre-JATS-schematron.sch
@@ -2580,7 +2580,7 @@
       
       <report see="https://elifeproduction.slab.com/posts/abstracts-digests-and-impact-statements-tiau2k6x#custom-meta-test-8" test="not($subj = 'Replication Study') and matches(.,'[:;]')" role="warning" id="custom-meta-test-8">[custom-meta-test-8] Impact statement contains a colon or semi-colon, which is likely incorrect. It needs to be a proper sentence.</report>
       
-      <report see="https://elifeproduction.slab.com/posts/abstracts-digests-and-impact-statements-tiau2k6x#pre-custom-meta-test-9" test="matches(.,'[Ww]e show|[Ww]e present|[Tt]his study|[Tt]his paper')" role="warning" id="pre-custom-meta-test-9">[pre-custom-meta-test-9] Impact statement contains a possessive phrase. This is not allowed.</report>
+      <report see="https://elifeproduction.slab.com/posts/abstracts-digests-and-impact-statements-tiau2k6x#pre-custom-meta-test-9" test="matches(.,'[Ww]e show|[Ww]e present|[Tt]his study|[Tt]his paper| et al\.')" role="warning" id="pre-custom-meta-test-9">[pre-custom-meta-test-9] Impact statement contains a possessive phrase. This is not allowed.</report>
       
       
       

--- a/src/pre-JATS-schematron.xsl
+++ b/src/pre-JATS-schematron.xsl
@@ -12500,8 +12500,8 @@
       </xsl:if>
 
 		    <!--REPORT warning-->
-      <xsl:if test="matches(.,'[Ww]e show|[Ww]e present|[Tt]his study|[Tt]his paper')">
-         <svrl:successful-report xmlns:svrl="http://purl.oclc.org/dsdl/svrl" test="matches(.,'[Ww]e show|[Ww]e present|[Tt]his study|[Tt]his paper')">
+      <xsl:if test="matches(.,'[Ww]e show|[Ww]e present|[Tt]his study|[Tt]his paper| et al\.')">
+         <svrl:successful-report xmlns:svrl="http://purl.oclc.org/dsdl/svrl" test="matches(.,'[Ww]e show|[Ww]e present|[Tt]his study|[Tt]his paper| et al\.')">
             <xsl:attribute name="id">pre-custom-meta-test-9</xsl:attribute>
             <xsl:attribute name="see">https://elifeproduction.slab.com/posts/abstracts-digests-and-impact-statements-tiau2k6x#pre-custom-meta-test-9</xsl:attribute>
             <xsl:attribute name="role">warning</xsl:attribute>

--- a/src/schematron.sch
+++ b/src/schematron.sch
@@ -3452,12 +3452,12 @@
         id="custom-meta-test-8">Impact statement contains a colon or semi-colon, which is likely incorrect. It needs to be a proper sentence.</report>
       
       <report see="https://elifeproduction.slab.com/posts/abstracts-digests-and-impact-statements-tiau2k6x#pre-custom-meta-test-9" 
-        test="matches(.,'[Ww]e show|[Ww]e present|[Tt]his study|[Tt]his paper')" 
+        test="matches(.,'[Ww]e show|[Ww]e present|[Tt]his study|[Tt]his paper| et al\.')" 
         role="warning" 
         id="pre-custom-meta-test-9">Impact statement contains a possessive phrase. This is not allowed.</report>
       
       <report see="https://elifeproduction.slab.com/posts/abstracts-digests-and-impact-statements-tiau2k6x#final-custom-meta-test-9" 
-        test="matches(.,'[Ww]e show|[Ww]e present|[Tt]his study|[Tt]his paper')" 
+        test="matches(.,'[Ww]e show|[Ww]e present|[Tt]his study|[Tt]his paper| et al\.')" 
         role="error" 
         id="final-custom-meta-test-9">Impact statement contains a possessive phrase. This is not allowed.</report>
       

--- a/test/tests/gen/event-desc-tests/event-desc-content-2/fail.xml
+++ b/test/tests/gen/event-desc-tests/event-desc-content-2/fail.xml
@@ -60,9 +60,11 @@ Message:  that's a child of an event with an eLife DOI must contain the text 'Th
 
 
 
+
 <!--Context: event-desc
 Test: report    matches(parent::event/self-uri[1]/@xlink:href,'elifesciences\.org|10.7554/e[lL]ife') and not(.=('This manuscript was published as a reviewed preprint.','The reviewed preprint was revised.'))
 Message:  that's a child of an event with an eLife DOI must contain the text 'This manuscript was published as a reviewed preprint.' or 'The reviewed preprint was revised.' -->
+
 
 
 

--- a/test/tests/gen/event-desc-tests/event-desc-content-2/pass.xml
+++ b/test/tests/gen/event-desc-tests/event-desc-content-2/pass.xml
@@ -60,9 +60,11 @@ Message:  that's a child of an event with an eLife DOI must contain the text 'Th
 
 
 
+
 <!--Context: event-desc
 Test: report    matches(parent::event/self-uri[1]/@xlink:href,'elifesciences\.org|10.7554/e[lL]ife') and not(.=('This manuscript was published as a reviewed preprint.','The reviewed preprint was revised.'))
 Message:  that's a child of an event with an eLife DOI must contain the text 'This manuscript was published as a reviewed preprint.' or 'The reviewed preprint was revised.' -->
+
 
 
 

--- a/test/tests/gen/meta-value-tests/final-custom-meta-test-9/fail.xml
+++ b/test/tests/gen/meta-value-tests/final-custom-meta-test-9/fail.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="final-custom-meta-test-9.sch"?>
 <!--Context: article-meta/custom-meta-group/custom-meta[meta-name='Author impact statement']/meta-value
-Test: report    matches(.,'[Ww]e show|[Ww]e present|[Tt]his study|[Tt]his paper')
+Test: report    matches(.,'[Ww]e show|[Ww]e present|[Tt]his study|[Tt]his paper| et al\.')
 Message: Impact statement contains a possessive phrase. This is not allowed. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>

--- a/test/tests/gen/meta-value-tests/final-custom-meta-test-9/final-custom-meta-test-9.sch
+++ b/test/tests/gen/meta-value-tests/final-custom-meta-test-9/final-custom-meta-test-9.sch
@@ -1224,7 +1224,7 @@
       <let name="count" value="count(for $x in tokenize(normalize-space(replace(.,'\p{P}','')),' ') return $x)"/>
       <let name="we-token" value="substring-before(substring-after(lower-case(.),' we '),' ')"/>
       <let name="verbs" value="('name', 'named', 'can', 'progress', 'progressed', 'explain', 'explained', 'found', 'founded', 'present', 'presented', 'have', 'describe', 'described', 'showed', 'report', 'reported', 'miss', 'missed', 'identify', 'identified', 'better', 'bettered', 'validate', 'validated', 'use', 'used', 'listen', 'listened', 'demonstrate', 'demonstrated', 'argue', 'argued', 'will', 'assess', 'assessed', 'are', 'may', 'observe', 'observed', 'find', 'found', 'previously', 'should', 'rely', 'relied', 'reflect', 'reflected', 'recognise', 'recognised', 'attend', 'attended', 'first', 'define', 'defined', 'here', 'need', 'needed')"/>
-      <report see="https://elifeproduction.slab.com/posts/abstracts-digests-and-impact-statements-tiau2k6x#final-custom-meta-test-9" test="matches(.,'[Ww]e show|[Ww]e present|[Tt]his study|[Tt]his paper')" role="error" id="final-custom-meta-test-9">Impact statement contains a possessive phrase. This is not allowed.</report>
+      <report see="https://elifeproduction.slab.com/posts/abstracts-digests-and-impact-statements-tiau2k6x#final-custom-meta-test-9" test="matches(.,'[Ww]e show|[Ww]e present|[Tt]his study|[Tt]his paper| et al\.')" role="error" id="final-custom-meta-test-9">Impact statement contains a possessive phrase. This is not allowed.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/meta-value-tests/final-custom-meta-test-9/pass.xml
+++ b/test/tests/gen/meta-value-tests/final-custom-meta-test-9/pass.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="final-custom-meta-test-9.sch"?>
 <!--Context: article-meta/custom-meta-group/custom-meta[meta-name='Author impact statement']/meta-value
-Test: report    matches(.,'[Ww]e show|[Ww]e present|[Tt]his study|[Tt]his paper')
+Test: report    matches(.,'[Ww]e show|[Ww]e present|[Tt]his study|[Tt]his paper| et al\.')
 Message: Impact statement contains a possessive phrase. This is not allowed. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>

--- a/test/tests/gen/meta-value-tests/pre-custom-meta-test-9/fail.xml
+++ b/test/tests/gen/meta-value-tests/pre-custom-meta-test-9/fail.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="pre-custom-meta-test-9.sch"?>
 <!--Context: article-meta/custom-meta-group/custom-meta[meta-name='Author impact statement']/meta-value
-Test: report    matches(.,'[Ww]e show|[Ww]e present|[Tt]his study|[Tt]his paper')
+Test: report    matches(.,'[Ww]e show|[Ww]e present|[Tt]his study|[Tt]his paper| et al\.')
 Message: Impact statement contains a possessive phrase. This is not allowed. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>

--- a/test/tests/gen/meta-value-tests/pre-custom-meta-test-9/pass.xml
+++ b/test/tests/gen/meta-value-tests/pre-custom-meta-test-9/pass.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="pre-custom-meta-test-9.sch"?>
 <!--Context: article-meta/custom-meta-group/custom-meta[meta-name='Author impact statement']/meta-value
-Test: report    matches(.,'[Ww]e show|[Ww]e present|[Tt]his study|[Tt]his paper')
+Test: report    matches(.,'[Ww]e show|[Ww]e present|[Tt]his study|[Tt]his paper| et al\.')
 Message: Impact statement contains a possessive phrase. This is not allowed. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
   <article>

--- a/test/tests/gen/meta-value-tests/pre-custom-meta-test-9/pre-custom-meta-test-9.sch
+++ b/test/tests/gen/meta-value-tests/pre-custom-meta-test-9/pre-custom-meta-test-9.sch
@@ -1224,7 +1224,7 @@
       <let name="count" value="count(for $x in tokenize(normalize-space(replace(.,'\p{P}','')),' ') return $x)"/>
       <let name="we-token" value="substring-before(substring-after(lower-case(.),' we '),' ')"/>
       <let name="verbs" value="('name', 'named', 'can', 'progress', 'progressed', 'explain', 'explained', 'found', 'founded', 'present', 'presented', 'have', 'describe', 'described', 'showed', 'report', 'reported', 'miss', 'missed', 'identify', 'identified', 'better', 'bettered', 'validate', 'validated', 'use', 'used', 'listen', 'listened', 'demonstrate', 'demonstrated', 'argue', 'argued', 'will', 'assess', 'assessed', 'are', 'may', 'observe', 'observed', 'find', 'found', 'previously', 'should', 'rely', 'relied', 'reflect', 'reflected', 'recognise', 'recognised', 'attend', 'attended', 'first', 'define', 'defined', 'here', 'need', 'needed')"/>
-      <report see="https://elifeproduction.slab.com/posts/abstracts-digests-and-impact-statements-tiau2k6x#pre-custom-meta-test-9" test="matches(.,'[Ww]e show|[Ww]e present|[Tt]his study|[Tt]his paper')" role="warning" id="pre-custom-meta-test-9">Impact statement contains a possessive phrase. This is not allowed.</report>
+      <report see="https://elifeproduction.slab.com/posts/abstracts-digests-and-impact-statements-tiau2k6x#pre-custom-meta-test-9" test="matches(.,'[Ww]e show|[Ww]e present|[Tt]his study|[Tt]his paper| et al\.')" role="warning" id="pre-custom-meta-test-9">Impact statement contains a possessive phrase. This is not allowed.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/tests/gen/ro-kwd-tests/kwd-dupe-test/fail.xml
+++ b/test/tests/gen/ro-kwd-tests/kwd-dupe-test/fail.xml
@@ -6,7 +6,7 @@ Message: research-organism keywords must be distinct. This one containing  is no
   <article>
     <front>
       <article-meta>
-        <kwd-group kwd-group-type='research-organism'>
+        <kwd-group kwd-group-type="research-organism">
           <kwd>C. Elegans</kwd>
           <kwd>C. Elegans</kwd>
           <kwd>Drosophila</kwd>

--- a/test/tests/gen/ro-kwd-tests/kwd-dupe-test/pass.xml
+++ b/test/tests/gen/ro-kwd-tests/kwd-dupe-test/pass.xml
@@ -6,7 +6,7 @@ Message: research-organism keywords must be distinct. This one containing  is no
   <article>
     <front>
       <article-meta>
-        <kwd-group kwd-group-type='research-organism'>
+        <kwd-group kwd-group-type="research-organism">
           <kwd>C. Elegans</kwd>
           <kwd>D. Elegans</kwd>
           <kwd>Drosophila</kwd>

--- a/test/xspec/schematron.sch
+++ b/test/xspec/schematron.sch
@@ -2707,9 +2707,9 @@
       
       <report see="https://elifeproduction.slab.com/posts/abstracts-digests-and-impact-statements-tiau2k6x#custom-meta-test-8" test="not($subj = 'Replication Study') and matches(.,'[:;]')" role="warning" id="custom-meta-test-8">Impact statement contains a colon or semi-colon, which is likely incorrect. It needs to be a proper sentence.</report>
       
-      <report see="https://elifeproduction.slab.com/posts/abstracts-digests-and-impact-statements-tiau2k6x#pre-custom-meta-test-9" test="matches(.,'[Ww]e show|[Ww]e present|[Tt]his study|[Tt]his paper')" role="warning" id="pre-custom-meta-test-9">Impact statement contains a possessive phrase. This is not allowed.</report>
+      <report see="https://elifeproduction.slab.com/posts/abstracts-digests-and-impact-statements-tiau2k6x#pre-custom-meta-test-9" test="matches(.,'[Ww]e show|[Ww]e present|[Tt]his study|[Tt]his paper| et al\.')" role="warning" id="pre-custom-meta-test-9">Impact statement contains a possessive phrase. This is not allowed.</report>
       
-      <report see="https://elifeproduction.slab.com/posts/abstracts-digests-and-impact-statements-tiau2k6x#final-custom-meta-test-9" test="matches(.,'[Ww]e show|[Ww]e present|[Tt]his study|[Tt]his paper')" role="error" id="final-custom-meta-test-9">Impact statement contains a possessive phrase. This is not allowed.</report>
+      <report see="https://elifeproduction.slab.com/posts/abstracts-digests-and-impact-statements-tiau2k6x#final-custom-meta-test-9" test="matches(.,'[Ww]e show|[Ww]e present|[Tt]his study|[Tt]his paper| et al\.')" role="error" id="final-custom-meta-test-9">Impact statement contains a possessive phrase. This is not allowed.</report>
       
       <report see="https://elifeproduction.slab.com/posts/abstracts-digests-and-impact-statements-tiau2k6x#custom-meta-test-10" test="matches(.,'^[\d]+$')" role="error" id="custom-meta-test-10">Impact statement is comprised entirely of numbers, which must be incorrect.</report>
       


### PR DESCRIPTION
fire `custom-meta-test-9` variants if `et al.` is in impact statement