### PR TITLE
chore: change scope of given-names and surname checks

### DIFF
--- a/src/final-JATS-schematron.sch
+++ b/src/final-JATS-schematron.sch
@@ -1845,7 +1845,7 @@
 	  </rule>
   </pattern>
   <pattern id="given-names-tests-pattern">
-    <rule context="contrib-group//name/given-names" id="given-names-tests">
+    <rule context="name/given-names" id="given-names-tests">
 		
 	  <report test="not(*) and (normalize-space(.)='')" role="error" id="given-names-test-3">[given-names-test-3] given-names must not be empty.</report>
 		

--- a/src/final-JATS-schematron.xsl
+++ b/src/final-JATS-schematron.xsl
@@ -8437,7 +8437,7 @@
 
 
 	  <!--RULE given-names-tests-->
-   <xsl:template match="contrib-group//name/given-names" priority="1000" mode="M92">
+   <xsl:template match="name/given-names" priority="1000" mode="M92">
 
 		<!--REPORT error-->
       <xsl:if test="not(*) and (normalize-space(.)='')">

--- a/src/final-package-JATS-schematron.sch
+++ b/src/final-package-JATS-schematron.sch
@@ -1866,7 +1866,7 @@
 	  </rule>
   </pattern>
   <pattern id="given-names-tests-pattern">
-    <rule context="contrib-group//name/given-names" id="given-names-tests">
+    <rule context="name/given-names" id="given-names-tests">
 		
 	  <report test="not(*) and (normalize-space(.)='')" role="error" id="given-names-test-3">given-names must not be empty.</report>
 		

--- a/src/pre-JATS-schematron.sch
+++ b/src/pre-JATS-schematron.sch
@@ -1790,7 +1790,7 @@
 	  </rule>
   </pattern>
   <pattern id="given-names-tests-pattern">
-    <rule context="contrib-group//name/given-names" id="given-names-tests">
+    <rule context="name/given-names" id="given-names-tests">
 		
 	  <report test="not(*) and (normalize-space(.)='')" role="error" id="given-names-test-3">[given-names-test-3] given-names must not be empty.</report>
 		

--- a/src/pre-JATS-schematron.xsl
+++ b/src/pre-JATS-schematron.xsl
@@ -8322,7 +8322,7 @@
 
 
 	  <!--RULE given-names-tests-->
-   <xsl:template match="contrib-group//name/given-names" priority="1000" mode="M90">
+   <xsl:template match="name/given-names" priority="1000" mode="M90">
 
 		<!--REPORT error-->
       <xsl:if test="not(*) and (normalize-space(.)='')">

--- a/src/schematron.sch
+++ b/src/schematron.sch
@@ -2159,7 +2159,7 @@
 		
 	  </rule>
     
-    <rule context="contrib-group//name/given-names" id="given-names-tests">
+    <rule context="name/given-names" id="given-names-tests">
 		
 	  <report test="not(*) and (normalize-space(.)='')" 
         role="error" 

--- a/test/tests/gen/given-names-tests/final-given-names-test-16/fail.xml
+++ b/test/tests/gen/given-names-tests/final-given-names-test-16/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="final-given-names-test-16.sch"?>
-<!--Context: contrib-group//name/given-names
+<!--Context: name/given-names
 Test: report    matches(.,'[\(\)\[\]]')
 Message: given-names contains brackets - ''. This will be flagged by Crossref (although will not actually cause any significant problems). -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">

--- a/test/tests/gen/given-names-tests/final-given-names-test-16/final-given-names-test-16.sch
+++ b/test/tests/gen/given-names-tests/final-given-names-test-16/final-given-names-test-16.sch
@@ -1282,13 +1282,13 @@
     
   </xsl:function>
   <pattern id="article-metadata">
-    <rule context="contrib-group//name/given-names" id="given-names-tests">
+    <rule context="name/given-names" id="given-names-tests">
       <report test="matches(.,'[\(\)\[\]]')" role="warning" id="final-given-names-test-16">given-names contains brackets - '<value-of select="."/>'. This will be flagged by Crossref (although will not actually cause any significant problems).</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::contrib-group//name/given-names" role="error" id="given-names-tests-xspec-assert">contrib-group//name/given-names must be present.</assert>
+      <assert test="descendant::name/given-names" role="error" id="given-names-tests-xspec-assert">name/given-names must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/given-names-tests/final-given-names-test-16/pass.xml
+++ b/test/tests/gen/given-names-tests/final-given-names-test-16/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="final-given-names-test-16.sch"?>
-<!--Context: contrib-group//name/given-names
+<!--Context: name/given-names
 Test: report    matches(.,'[\(\)\[\]]')
 Message: given-names contains brackets - ''. This will be flagged by Crossref (although will not actually cause any significant problems). -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">

--- a/test/tests/gen/given-names-tests/given-names-test-10/fail.xml
+++ b/test/tests/gen/given-names-tests/given-names-test-10/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="given-names-test-10.sch"?>
-<!--Context: contrib-group//name/given-names
+<!--Context: name/given-names
 Test: report    matches(.,'[A-Za-z] [Dd]e[rn]?$')
 Message: given-names ends with de, der, or den - should this be captured as the beginning of the surname instead? - ''. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">

--- a/test/tests/gen/given-names-tests/given-names-test-10/given-names-test-10.sch
+++ b/test/tests/gen/given-names-tests/given-names-test-10/given-names-test-10.sch
@@ -1282,13 +1282,13 @@
     
   </xsl:function>
   <pattern id="article-metadata">
-    <rule context="contrib-group//name/given-names" id="given-names-tests">
+    <rule context="name/given-names" id="given-names-tests">
       <report test="matches(.,'[A-Za-z] [Dd]e[rn]?$')" role="warning" id="given-names-test-10">given-names ends with de, der, or den - should this be captured as the beginning of the surname instead? - '<value-of select="."/>'.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::contrib-group//name/given-names" role="error" id="given-names-tests-xspec-assert">contrib-group//name/given-names must be present.</assert>
+      <assert test="descendant::name/given-names" role="error" id="given-names-tests-xspec-assert">name/given-names must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/given-names-tests/given-names-test-10/pass.xml
+++ b/test/tests/gen/given-names-tests/given-names-test-10/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="given-names-test-10.sch"?>
-<!--Context: contrib-group//name/given-names
+<!--Context: name/given-names
 Test: report    matches(.,'[A-Za-z] [Dd]e[rn]?$')
 Message: given-names ends with de, der, or den - should this be captured as the beginning of the surname instead? - ''. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">

--- a/test/tests/gen/given-names-tests/given-names-test-11/fail.xml
+++ b/test/tests/gen/given-names-tests/given-names-test-11/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="given-names-test-11.sch"?>
-<!--Context: contrib-group//name/given-names
+<!--Context: name/given-names
 Test: report    matches(.,'[A-Za-z] [Vv]an$')
 Message: given-names ends with ' van' - should this be captured as the beginning of the surname instead? - ''. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">

--- a/test/tests/gen/given-names-tests/given-names-test-11/given-names-test-11.sch
+++ b/test/tests/gen/given-names-tests/given-names-test-11/given-names-test-11.sch
@@ -1282,13 +1282,13 @@
     
   </xsl:function>
   <pattern id="article-metadata">
-    <rule context="contrib-group//name/given-names" id="given-names-tests">
+    <rule context="name/given-names" id="given-names-tests">
       <report test="matches(.,'[A-Za-z] [Vv]an$')" role="warning" id="given-names-test-11">given-names ends with ' van' - should this be captured as the beginning of the surname instead? - '<value-of select="."/>'.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::contrib-group//name/given-names" role="error" id="given-names-tests-xspec-assert">contrib-group//name/given-names must be present.</assert>
+      <assert test="descendant::name/given-names" role="error" id="given-names-tests-xspec-assert">name/given-names must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/given-names-tests/given-names-test-11/pass.xml
+++ b/test/tests/gen/given-names-tests/given-names-test-11/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="given-names-test-11.sch"?>
-<!--Context: contrib-group//name/given-names
+<!--Context: name/given-names
 Test: report    matches(.,'[A-Za-z] [Vv]an$')
 Message: given-names ends with ' van' - should this be captured as the beginning of the surname instead? - ''. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">

--- a/test/tests/gen/given-names-tests/given-names-test-12/fail.xml
+++ b/test/tests/gen/given-names-tests/given-names-test-12/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="given-names-test-12.sch"?>
-<!--Context: contrib-group//name/given-names
+<!--Context: name/given-names
 Test: report    matches(.,'[A-Za-z] [Vv]on$')
 Message: given-names ends with ' von' - should this be captured as the beginning of the surname instead? - ''. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">

--- a/test/tests/gen/given-names-tests/given-names-test-12/given-names-test-12.sch
+++ b/test/tests/gen/given-names-tests/given-names-test-12/given-names-test-12.sch
@@ -1282,13 +1282,13 @@
     
   </xsl:function>
   <pattern id="article-metadata">
-    <rule context="contrib-group//name/given-names" id="given-names-tests">
+    <rule context="name/given-names" id="given-names-tests">
       <report test="matches(.,'[A-Za-z] [Vv]on$')" role="warning" id="given-names-test-12">given-names ends with ' von' - should this be captured as the beginning of the surname instead? - '<value-of select="."/>'.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::contrib-group//name/given-names" role="error" id="given-names-tests-xspec-assert">contrib-group//name/given-names must be present.</assert>
+      <assert test="descendant::name/given-names" role="error" id="given-names-tests-xspec-assert">name/given-names must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/given-names-tests/given-names-test-12/pass.xml
+++ b/test/tests/gen/given-names-tests/given-names-test-12/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="given-names-test-12.sch"?>
-<!--Context: contrib-group//name/given-names
+<!--Context: name/given-names
 Test: report    matches(.,'[A-Za-z] [Vv]on$')
 Message: given-names ends with ' von' - should this be captured as the beginning of the surname instead? - ''. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">

--- a/test/tests/gen/given-names-tests/given-names-test-13/fail.xml
+++ b/test/tests/gen/given-names-tests/given-names-test-13/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="given-names-test-13.sch"?>
-<!--Context: contrib-group//name/given-names
+<!--Context: name/given-names
 Test: report    matches(.,'[A-Za-z] [Ee]l$')
 Message: given-names ends with ' el' - should this be captured as the beginning of the surname instead? - ''. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">

--- a/test/tests/gen/given-names-tests/given-names-test-13/given-names-test-13.sch
+++ b/test/tests/gen/given-names-tests/given-names-test-13/given-names-test-13.sch
@@ -1282,13 +1282,13 @@
     
   </xsl:function>
   <pattern id="article-metadata">
-    <rule context="contrib-group//name/given-names" id="given-names-tests">
+    <rule context="name/given-names" id="given-names-tests">
       <report test="matches(.,'[A-Za-z] [Ee]l$')" role="warning" id="given-names-test-13">given-names ends with ' el' - should this be captured as the beginning of the surname instead? - '<value-of select="."/>'.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::contrib-group//name/given-names" role="error" id="given-names-tests-xspec-assert">contrib-group//name/given-names must be present.</assert>
+      <assert test="descendant::name/given-names" role="error" id="given-names-tests-xspec-assert">name/given-names must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/given-names-tests/given-names-test-13/pass.xml
+++ b/test/tests/gen/given-names-tests/given-names-test-13/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="given-names-test-13.sch"?>
-<!--Context: contrib-group//name/given-names
+<!--Context: name/given-names
 Test: report    matches(.,'[A-Za-z] [Ee]l$')
 Message: given-names ends with ' el' - should this be captured as the beginning of the surname instead? - ''. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">

--- a/test/tests/gen/given-names-tests/given-names-test-14/fail.xml
+++ b/test/tests/gen/given-names-tests/given-names-test-14/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="given-names-test-14.sch"?>
-<!--Context: contrib-group//name/given-names
+<!--Context: name/given-names
 Test: report    matches(.,'[A-Za-z] [Tt]e[rn]?$')
 Message: given-names ends with te, ter, or ten - should this be captured as the beginning of the surname instead? - ''. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">

--- a/test/tests/gen/given-names-tests/given-names-test-14/given-names-test-14.sch
+++ b/test/tests/gen/given-names-tests/given-names-test-14/given-names-test-14.sch
@@ -1282,13 +1282,13 @@
     
   </xsl:function>
   <pattern id="article-metadata">
-    <rule context="contrib-group//name/given-names" id="given-names-tests">
+    <rule context="name/given-names" id="given-names-tests">
       <report test="matches(.,'[A-Za-z] [Tt]e[rn]?$')" role="warning" id="given-names-test-14">given-names ends with te, ter, or ten - should this be captured as the beginning of the surname instead? - '<value-of select="."/>'.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::contrib-group//name/given-names" role="error" id="given-names-tests-xspec-assert">contrib-group//name/given-names must be present.</assert>
+      <assert test="descendant::name/given-names" role="error" id="given-names-tests-xspec-assert">name/given-names must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/given-names-tests/given-names-test-14/pass.xml
+++ b/test/tests/gen/given-names-tests/given-names-test-14/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="given-names-test-14.sch"?>
-<!--Context: contrib-group//name/given-names
+<!--Context: name/given-names
 Test: report    matches(.,'[A-Za-z] [Tt]e[rn]?$')
 Message: given-names ends with te, ter, or ten - should this be captured as the beginning of the surname instead? - ''. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">

--- a/test/tests/gen/given-names-tests/given-names-test-15/fail.xml
+++ b/test/tests/gen/given-names-tests/given-names-test-15/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="given-names-test-15.sch"?>
-<!--Context: contrib-group//name/given-names
+<!--Context: name/given-names
 Test: report    matches(normalize-space(.),'[A-Za-z]\p{Zs}[A-za-z]\p{Zs}[A-za-z]\p{Zs}[A-za-z]|[A-Za-z]\p{Zs}[A-za-z]\p{Zs}[A-za-z]$|^[A-za-z]\p{Zs}[A-za-z]$')
 Message: given-names contains initials with spaces. Ensure that the space(s) is removed between initials - ''. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">

--- a/test/tests/gen/given-names-tests/given-names-test-15/given-names-test-15.sch
+++ b/test/tests/gen/given-names-tests/given-names-test-15/given-names-test-15.sch
@@ -1282,13 +1282,13 @@
     
   </xsl:function>
   <pattern id="article-metadata">
-    <rule context="contrib-group//name/given-names" id="given-names-tests">
+    <rule context="name/given-names" id="given-names-tests">
       <report test="matches(normalize-space(.),'[A-Za-z]\p{Zs}[A-za-z]\p{Zs}[A-za-z]\p{Zs}[A-za-z]|[A-Za-z]\p{Zs}[A-za-z]\p{Zs}[A-za-z]$|^[A-za-z]\p{Zs}[A-za-z]$')" role="info" id="given-names-test-15">given-names contains initials with spaces. Ensure that the space(s) is removed between initials - '<value-of select="."/>'.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::contrib-group//name/given-names" role="error" id="given-names-tests-xspec-assert">contrib-group//name/given-names must be present.</assert>
+      <assert test="descendant::name/given-names" role="error" id="given-names-tests-xspec-assert">name/given-names must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/given-names-tests/given-names-test-15/pass.xml
+++ b/test/tests/gen/given-names-tests/given-names-test-15/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="given-names-test-15.sch"?>
-<!--Context: contrib-group//name/given-names
+<!--Context: name/given-names
 Test: report    matches(normalize-space(.),'[A-Za-z]\p{Zs}[A-za-z]\p{Zs}[A-za-z]\p{Zs}[A-za-z]|[A-Za-z]\p{Zs}[A-za-z]\p{Zs}[A-za-z]$|^[A-za-z]\p{Zs}[A-za-z]$')
 Message: given-names contains initials with spaces. Ensure that the space(s) is removed between initials - ''. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">

--- a/test/tests/gen/given-names-tests/given-names-test-3/fail.xml
+++ b/test/tests/gen/given-names-tests/given-names-test-3/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="given-names-test-3.sch"?>
-<!--Context: contrib-group//name/given-names
+<!--Context: name/given-names
 Test: report    not(*) and (normalize-space(.)='')
 Message: given-names must not be empty. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">

--- a/test/tests/gen/given-names-tests/given-names-test-3/given-names-test-3.sch
+++ b/test/tests/gen/given-names-tests/given-names-test-3/given-names-test-3.sch
@@ -1282,13 +1282,13 @@
     
   </xsl:function>
   <pattern id="article-metadata">
-    <rule context="contrib-group//name/given-names" id="given-names-tests">
+    <rule context="name/given-names" id="given-names-tests">
       <report test="not(*) and (normalize-space(.)='')" role="error" id="given-names-test-3">given-names must not be empty.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::contrib-group//name/given-names" role="error" id="given-names-tests-xspec-assert">contrib-group//name/given-names must be present.</assert>
+      <assert test="descendant::name/given-names" role="error" id="given-names-tests-xspec-assert">name/given-names must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/given-names-tests/given-names-test-3/pass.xml
+++ b/test/tests/gen/given-names-tests/given-names-test-3/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="given-names-test-3.sch"?>
-<!--Context: contrib-group//name/given-names
+<!--Context: name/given-names
 Test: report    not(*) and (normalize-space(.)='')
 Message: given-names must not be empty. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">

--- a/test/tests/gen/given-names-tests/given-names-test-4/fail.xml
+++ b/test/tests/gen/given-names-tests/given-names-test-4/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="given-names-test-4.sch"?>
-<!--Context: contrib-group//name/given-names
+<!--Context: name/given-names
 Test: report    descendant::bold or descendant::sub or descendant::sup or descendant::italic or descendant::sc
 Message: given-names must not contain any formatting (bold, or italic emphasis, or smallcaps, superscript or subscript) - ''. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">

--- a/test/tests/gen/given-names-tests/given-names-test-4/given-names-test-4.sch
+++ b/test/tests/gen/given-names-tests/given-names-test-4/given-names-test-4.sch
@@ -1282,13 +1282,13 @@
     
   </xsl:function>
   <pattern id="article-metadata">
-    <rule context="contrib-group//name/given-names" id="given-names-tests">
+    <rule context="name/given-names" id="given-names-tests">
       <report test="descendant::bold or descendant::sub or descendant::sup or descendant::italic or descendant::sc" role="error" id="given-names-test-4">given-names must not contain any formatting (bold, or italic emphasis, or smallcaps, superscript or subscript) - '<value-of select="."/>'.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::contrib-group//name/given-names" role="error" id="given-names-tests-xspec-assert">contrib-group//name/given-names must be present.</assert>
+      <assert test="descendant::name/given-names" role="error" id="given-names-tests-xspec-assert">name/given-names must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/given-names-tests/given-names-test-4/pass.xml
+++ b/test/tests/gen/given-names-tests/given-names-test-4/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="given-names-test-4.sch"?>
-<!--Context: contrib-group//name/given-names
+<!--Context: name/given-names
 Test: report    descendant::bold or descendant::sub or descendant::sup or descendant::italic or descendant::sc
 Message: given-names must not contain any formatting (bold, or italic emphasis, or smallcaps, superscript or subscript) - ''. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">

--- a/test/tests/gen/given-names-tests/given-names-test-5/fail.xml
+++ b/test/tests/gen/given-names-tests/given-names-test-5/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="given-names-test-5.sch"?>
-<!--Context: contrib-group//name/given-names
+<!--Context: name/given-names
 Test: assert    matches(.,"^[\p{L}\p{M}\(\)\s'’-]*$")
 Message: given-names should usually only contain letters, spaces, or hyphens.  contains other characters. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">

--- a/test/tests/gen/given-names-tests/given-names-test-5/given-names-test-5.sch
+++ b/test/tests/gen/given-names-tests/given-names-test-5/given-names-test-5.sch
@@ -1282,13 +1282,13 @@
     
   </xsl:function>
   <pattern id="article-metadata">
-    <rule context="contrib-group//name/given-names" id="given-names-tests">
+    <rule context="name/given-names" id="given-names-tests">
       <assert test="matches(.,&quot;^[\p{L}\p{M}\(\)\s'’-]*$&quot;)" role="error" id="given-names-test-5">given-names should usually only contain letters, spaces, or hyphens. <value-of select="."/> contains other characters.</assert>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::contrib-group//name/given-names" role="error" id="given-names-tests-xspec-assert">contrib-group//name/given-names must be present.</assert>
+      <assert test="descendant::name/given-names" role="error" id="given-names-tests-xspec-assert">name/given-names must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/given-names-tests/given-names-test-5/pass.xml
+++ b/test/tests/gen/given-names-tests/given-names-test-5/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="given-names-test-5.sch"?>
-<!--Context: contrib-group//name/given-names
+<!--Context: name/given-names
 Test: assert    matches(.,"^[\p{L}\p{M}\(\)\s'’-]*$")
 Message: given-names should usually only contain letters, spaces, or hyphens.  contains other characters. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">

--- a/test/tests/gen/given-names-tests/given-names-test-6/fail.xml
+++ b/test/tests/gen/given-names-tests/given-names-test-6/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="given-names-test-6.sch"?>
-<!--Context: contrib-group//name/given-names
+<!--Context: name/given-names
 Test: assert    matches(.,'^\p{Lu}')
 Message: given-names doesn't begin with a capital letter - ''. Is this correct? -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">

--- a/test/tests/gen/given-names-tests/given-names-test-6/given-names-test-6.sch
+++ b/test/tests/gen/given-names-tests/given-names-test-6/given-names-test-6.sch
@@ -1282,13 +1282,13 @@
     
   </xsl:function>
   <pattern id="article-metadata">
-    <rule context="contrib-group//name/given-names" id="given-names-tests">
+    <rule context="name/given-names" id="given-names-tests">
       <assert test="matches(.,'^\p{Lu}')" role="warning" id="given-names-test-6">given-names doesn't begin with a capital letter - '<value-of select="."/>'. Is this correct?</assert>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::contrib-group//name/given-names" role="error" id="given-names-tests-xspec-assert">contrib-group//name/given-names must be present.</assert>
+      <assert test="descendant::name/given-names" role="error" id="given-names-tests-xspec-assert">name/given-names must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/given-names-tests/given-names-test-6/pass.xml
+++ b/test/tests/gen/given-names-tests/given-names-test-6/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="given-names-test-6.sch"?>
-<!--Context: contrib-group//name/given-names
+<!--Context: name/given-names
 Test: assert    matches(.,'^\p{Lu}')
 Message: given-names doesn't begin with a capital letter - ''. Is this correct? -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">

--- a/test/tests/gen/given-names-tests/given-names-test-7/fail.xml
+++ b/test/tests/gen/given-names-tests/given-names-test-7/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="given-names-test-7.sch"?>
-<!--Context: contrib-group//name/given-names
+<!--Context: name/given-names
 Test: report    matches(.,'^[\p{L}]{1}\.$|^[\p{L}]{1}\.\p{Zs}?[\p{L}]{1}\.\p{Zs}?$')
 Message: given-names contains initialised full stop(s) which is incorrect -  -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">

--- a/test/tests/gen/given-names-tests/given-names-test-7/given-names-test-7.sch
+++ b/test/tests/gen/given-names-tests/given-names-test-7/given-names-test-7.sch
@@ -1282,14 +1282,14 @@
     
   </xsl:function>
   <pattern id="article-metadata">
-    <rule context="contrib-group//name/given-names" id="given-names-tests">
+    <rule context="name/given-names" id="given-names-tests">
       <report test="matches(.,'^[\p{L}]{1}\.$|^[\p{L}]{1}\.\p{Zs}?[\p{L}]{1}\.\p{Zs}?$')" role="error" id="given-names-test-7">given-names contains initialised full stop(s) which is incorrect - <value-of select="."/>
       </report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::contrib-group//name/given-names" role="error" id="given-names-tests-xspec-assert">contrib-group//name/given-names must be present.</assert>
+      <assert test="descendant::name/given-names" role="error" id="given-names-tests-xspec-assert">name/given-names must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/given-names-tests/given-names-test-7/pass.xml
+++ b/test/tests/gen/given-names-tests/given-names-test-7/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="given-names-test-7.sch"?>
-<!--Context: contrib-group//name/given-names
+<!--Context: name/given-names
 Test: report    matches(.,'^[\p{L}]{1}\.$|^[\p{L}]{1}\.\p{Zs}?[\p{L}]{1}\.\p{Zs}?$')
 Message: given-names contains initialised full stop(s) which is incorrect -  -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">

--- a/test/tests/gen/given-names-tests/given-names-test-8/fail.xml
+++ b/test/tests/gen/given-names-tests/given-names-test-8/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="given-names-test-8.sch"?>
-<!--Context: contrib-group//name/given-names
+<!--Context: name/given-names
 Test: report    matches(.,'^\p{Zs}')
 Message: given-names starts with a space, which cannot be correct - ''. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">

--- a/test/tests/gen/given-names-tests/given-names-test-8/given-names-test-8.sch
+++ b/test/tests/gen/given-names-tests/given-names-test-8/given-names-test-8.sch
@@ -1282,13 +1282,13 @@
     
   </xsl:function>
   <pattern id="article-metadata">
-    <rule context="contrib-group//name/given-names" id="given-names-tests">
+    <rule context="name/given-names" id="given-names-tests">
       <report test="matches(.,'^\p{Zs}')" role="error" id="given-names-test-8">given-names starts with a space, which cannot be correct - '<value-of select="."/>'.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::contrib-group//name/given-names" role="error" id="given-names-tests-xspec-assert">contrib-group//name/given-names must be present.</assert>
+      <assert test="descendant::name/given-names" role="error" id="given-names-tests-xspec-assert">name/given-names must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/given-names-tests/given-names-test-8/pass.xml
+++ b/test/tests/gen/given-names-tests/given-names-test-8/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="given-names-test-8.sch"?>
-<!--Context: contrib-group//name/given-names
+<!--Context: name/given-names
 Test: report    matches(.,'^\p{Zs}')
 Message: given-names starts with a space, which cannot be correct - ''. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">

--- a/test/tests/gen/given-names-tests/given-names-test-9/fail.xml
+++ b/test/tests/gen/given-names-tests/given-names-test-9/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="given-names-test-9.sch"?>
-<!--Context: contrib-group//name/given-names
+<!--Context: name/given-names
 Test: report    matches(.,'\p{Zs}$')
 Message: given-names ends with a space, which cannot be correct - ''. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">

--- a/test/tests/gen/given-names-tests/given-names-test-9/given-names-test-9.sch
+++ b/test/tests/gen/given-names-tests/given-names-test-9/given-names-test-9.sch
@@ -1282,13 +1282,13 @@
     
   </xsl:function>
   <pattern id="article-metadata">
-    <rule context="contrib-group//name/given-names" id="given-names-tests">
+    <rule context="name/given-names" id="given-names-tests">
       <report test="matches(.,'\p{Zs}$')" role="error" id="given-names-test-9">given-names ends with a space, which cannot be correct - '<value-of select="."/>'.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::contrib-group//name/given-names" role="error" id="given-names-tests-xspec-assert">contrib-group//name/given-names must be present.</assert>
+      <assert test="descendant::name/given-names" role="error" id="given-names-tests-xspec-assert">name/given-names must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/gen/given-names-tests/given-names-test-9/pass.xml
+++ b/test/tests/gen/given-names-tests/given-names-test-9/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="given-names-test-9.sch"?>
-<!--Context: contrib-group//name/given-names
+<!--Context: name/given-names
 Test: report    matches(.,'\p{Zs}$')
 Message: given-names ends with a space, which cannot be correct - ''. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0">

--- a/test/tests/gen/given-names-tests/pre-given-names-test-16/fail.xml
+++ b/test/tests/gen/given-names-tests/pre-given-names-test-16/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="pre-given-names-test-16.sch"?>
-<!--Context: contrib-group//name/given-names
+<!--Context: name/given-names
 Test: report    matches(.,'[\(\)\[\]]')
 Message: given-names contains brackets - ''. This will be flagged by Crossref (although will not actually cause any significant problems). Please add the following author query: Please confirm whether you are happy to remove the brackets around (one of) your given names - ''. This will cause minor issues at Crossref, although they can be retained if desired. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">

--- a/test/tests/gen/given-names-tests/pre-given-names-test-16/pass.xml
+++ b/test/tests/gen/given-names-tests/pre-given-names-test-16/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="pre-given-names-test-16.sch"?>
-<!--Context: contrib-group//name/given-names
+<!--Context: name/given-names
 Test: report    matches(.,'[\(\)\[\]]')
 Message: given-names contains brackets - ''. This will be flagged by Crossref (although will not actually cause any significant problems). Please add the following author query: Please confirm whether you are happy to remove the brackets around (one of) your given names - ''. This will cause minor issues at Crossref, although they can be retained if desired. -->
 <root xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ali="http://www.niso.org/schemas/ali/1.0/">

--- a/test/tests/gen/given-names-tests/pre-given-names-test-16/pre-given-names-test-16.sch
+++ b/test/tests/gen/given-names-tests/pre-given-names-test-16/pre-given-names-test-16.sch
@@ -1282,13 +1282,13 @@
     
   </xsl:function>
   <pattern id="article-metadata">
-    <rule context="contrib-group//name/given-names" id="given-names-tests">
+    <rule context="name/given-names" id="given-names-tests">
       <report test="matches(.,'[\(\)\[\]]')" role="warning" id="pre-given-names-test-16">given-names contains brackets - '<value-of select="."/>'. This will be flagged by Crossref (although will not actually cause any significant problems). Please add the following author query: Please confirm whether you are happy to remove the brackets around (one of) your given names - '<value-of select="."/>'. This will cause minor issues at Crossref, although they can be retained if desired.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::contrib-group//name/given-names" role="error" id="given-names-tests-xspec-assert">contrib-group//name/given-names must be present.</assert>
+      <assert test="descendant::name/given-names" role="error" id="given-names-tests-xspec-assert">name/given-names must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/xspec/schematron.sch
+++ b/test/xspec/schematron.sch
@@ -1861,7 +1861,7 @@
 	  </rule>
   </pattern>
   <pattern id="given-names-tests-pattern">
-    <rule context="contrib-group//name/given-names" id="given-names-tests">
+    <rule context="name/given-names" id="given-names-tests">
 		
 	  <report test="not(*) and (normalize-space(.)='')" role="error" id="given-names-test-3">given-names must not be empty.</report>
 		
@@ -9460,7 +9460,7 @@
       <assert test="descendant::article-meta//contrib[@contrib-type='author']/xref" role="error" id="author-xref-tests-xspec-assert">article-meta//contrib[@contrib-type='author']/xref must be present.</assert>
       <assert test="descendant::contrib-group//name" role="error" id="name-tests-xspec-assert">contrib-group//name must be present.</assert>
       <assert test="descendant::contrib-group//name/surname" role="error" id="surname-tests-xspec-assert">contrib-group//name/surname must be present.</assert>
-      <assert test="descendant::contrib-group//name/given-names" role="error" id="given-names-tests-xspec-assert">contrib-group//name/given-names must be present.</assert>
+      <assert test="descendant::name/given-names" role="error" id="given-names-tests-xspec-assert">name/given-names must be present.</assert>
       <assert test="descendant::contrib-group//name/suffix" role="error" id="suffix-tests-xspec-assert">contrib-group//name/suffix must be present.</assert>
       <assert test="descendant::contrib-group//name/*" role="error" id="name-child-tests-xspec-assert">contrib-group//name/* must be present.</assert>
       <assert test="descendant::article-meta//contrib" role="error" id="contrib-tests-xspec-assert">article-meta//contrib must be present.</assert>


### PR DESCRIPTION
To include checks on these elements in ref lists and elsewhere, not just in contribs