### PR TITLE
RP: refine scope of p-ref-checks

### DIFF
--- a/src/rp-schematron-base.sch
+++ b/src/rp-schematron-base.sch
@@ -2831,7 +2831,7 @@
         id="p-all-bold">Content of p element is entirely in <value-of select="child::*[1]/local-name()"/> - '<value-of select="."/>'. Is this correct?</report>
       </rule>
       
-      <rule context="p[not(ancestor::sub-article)]" id="p-ref-checks">
+      <rule context="article[descendant::xref[@ref-type='bibr'][matches(.,'\p{L}')]]//p[not(ancestor::sub-article)]" id="p-ref-checks">
         <let name="text" value="string-join(for $x in self::*/(*|text())
                                             return if ($x/local-name()='xref') then ()
                                                    else if ($x//*:p) then ($x/text())

--- a/src/rp-schematron.sch
+++ b/src/rp-schematron.sch
@@ -2022,7 +2022,7 @@
     <pattern id="p-bold-checks-pattern"><rule context="p[not(ancestor::sub-article or ancestor::def) and (count(*)=1) and (child::bold or child::italic)]" id="p-bold-checks">
         <let name="free-text" value="replace(normalize-space(string-join(for $x in self::*/text() return $x,'')),' ','')"/>
         <report test="$free-text=''" role="warning" id="p-all-bold">[p-all-bold] Content of p element is entirely in <value-of select="child::*[1]/local-name()"/> - '<value-of select="."/>'. Is this correct?</report>
-      </rule></pattern><pattern id="p-ref-checks-pattern"><rule context="p[not(ancestor::sub-article)]" id="p-ref-checks">
+      </rule></pattern><pattern id="p-ref-checks-pattern"><rule context="article[descendant::xref[@ref-type='bibr'][matches(.,'\p{L}')]]//p[not(ancestor::sub-article)]" id="p-ref-checks">
         <let name="text" value="string-join(for $x in self::*/(*|text())                                             return if ($x/local-name()='xref') then ()                                                    else if ($x//*:p) then ($x/text())                                                    else string($x),'')"/>
         <let name="missing-ref-regex" value="'\p{Lu}\p{L}\p{L}+( et al\.?)?\p{P}?\s*\p{Ps}?([1][7-9][0-9][0-9]|[2][0-2][0-9][0-9])'"/>
         

--- a/src/rp-schematron.xsl
+++ b/src/rp-schematron.xsl
@@ -7512,7 +7512,7 @@
    </xsl:template>
    <!--PATTERN p-ref-checks-pattern-->
    <!--RULE p-ref-checks-->
-   <xsl:template match="p[not(ancestor::sub-article)]" priority="1000" mode="M114">
+   <xsl:template match="article[descendant::xref[@ref-type='bibr'][matches(.,'\p{L}')]]//p[not(ancestor::sub-article)]" priority="1000" mode="M114">
       <xsl:variable name="text" select="string-join(for $x in self::*/(*|text())                                             return if ($x/local-name()='xref') then ()                                                    else if ($x//*:p) then ($x/text())                                                    else string($x),'')"/>
       <xsl:variable name="missing-ref-regex" select="'\p{Lu}\p{L}\p{L}+( et al\.?)?\p{P}?\s*\p{Ps}?([1][7-9][0-9][0-9]|[2][0-2][0-9][0-9])'"/>
       <!--REPORT warning-->

--- a/test/tests/rp/p-ref-checks/missing-ref-in-text-test/fail.xml
+++ b/test/tests/rp/p-ref-checks/missing-ref-in-text-test/fail.xml
@@ -4,6 +4,9 @@ Test: report    matches($text,$missing-ref-regex)
 Message:  element contains possible citation which is unlinked or a missing reference - search -  -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">
     <article>
+        <xref ref-type="bibr">something</xref>
         <p>Smith et al. 2025</p>
+        <p>Smith and Smith 2025</p>
+        <p>Smith, 2025</p>
     </article>
 </root>

--- a/test/tests/rp/p-ref-checks/missing-ref-in-text-test/fail.xml
+++ b/test/tests/rp/p-ref-checks/missing-ref-in-text-test/fail.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="missing-ref-in-text-test.sch"?>
-<!--Context: p[not(ancestor::sub-article)]
+<!--Context: article[descendant::xref[@ref-type='bibr'][matches(.,'\p{L}')]]//p[not(ancestor::sub-article)]
 Test: report    matches($text,$missing-ref-regex)
 Message:  element contains possible citation which is unlinked or a missing reference - search -  -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/rp/p-ref-checks/missing-ref-in-text-test/missing-ref-in-text-test.sch
+++ b/test/tests/rp/p-ref-checks/missing-ref-in-text-test/missing-ref-in-text-test.sch
@@ -1085,7 +1085,7 @@
     </sqf:fix>
   </sqf:fixes>
   <pattern id="p-ref-checks-pattern">
-    <rule context="p[not(ancestor::sub-article)]" id="p-ref-checks">
+    <rule context="article[descendant::xref[@ref-type='bibr'][matches(.,'\p{L}')]]//p[not(ancestor::sub-article)]" id="p-ref-checks">
       <let name="text" value="string-join(for $x in self::*/(*|text())                                             return if ($x/local-name()='xref') then ()                                                    else if ($x//*:p) then ($x/text())                                                    else string($x),'')"/>
       <let name="missing-ref-regex" value="'\p{Lu}\p{L}\p{L}+( et al\.?)?\p{P}?\s*\p{Ps}?([1][7-9][0-9][0-9]|[2][0-2][0-9][0-9])'"/>
       <report test="matches($text,$missing-ref-regex)" role="warning" id="missing-ref-in-text-test">[missing-ref-in-text-test] <name/> element contains possible citation which is unlinked or a missing reference - search - <value-of select="string-join(e:analyze-string($text,$missing-ref-regex)//*:match,'; ')"/>
@@ -1094,7 +1094,7 @@
   </pattern>
   <pattern id="root-pattern">
     <rule context="root" id="root-rule">
-      <assert test="descendant::p[not(ancestor::sub-article)]" role="error" id="p-ref-checks-xspec-assert">p[not(ancestor::sub-article)] must be present.</assert>
+      <assert test="descendant::article[descendant::xref[@ref-type='bibr'][matches(.,'\p{L}')]]//p[not(ancestor::sub-article)]" role="error" id="p-ref-checks-xspec-assert">article[descendant::xref[@ref-type='bibr'][matches(.,'\p{L}')]]//p[not(ancestor::sub-article)] must be present.</assert>
     </rule>
   </pattern>
 </schema>

--- a/test/tests/rp/p-ref-checks/missing-ref-in-text-test/pass.xml
+++ b/test/tests/rp/p-ref-checks/missing-ref-in-text-test/pass.xml
@@ -1,5 +1,5 @@
 <?oxygen SCHSchema="missing-ref-in-text-test.sch"?>
-<!--Context: p[not(ancestor::sub-article)]
+<!--Context: article[descendant::xref[@ref-type='bibr'][matches(.,'\p{L}')]]//p[not(ancestor::sub-article)]
 Test: report    matches($text,$missing-ref-regex)
 Message:  element contains possible citation which is unlinked or a missing reference - search -  -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/test/tests/rp/p-ref-checks/missing-ref-in-text-test/pass.xml
+++ b/test/tests/rp/p-ref-checks/missing-ref-in-text-test/pass.xml
@@ -4,6 +4,7 @@ Test: report    matches($text,$missing-ref-regex)
 Message:  element contains possible citation which is unlinked or a missing reference - search -  -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">
     <article>
+        <xref ref-type="bibr">something</xref>
         <p>Smith et al.</p>
     </article>
 </root>

--- a/test/xspec/rp-schematron.sch
+++ b/test/xspec/rp-schematron.sch
@@ -2321,7 +2321,7 @@
       </rule>
   </pattern>
   <pattern id="p-ref-checks-pattern">
-    <rule context="p[not(ancestor::sub-article)]" id="p-ref-checks">
+    <rule context="article[descendant::xref[@ref-type='bibr'][matches(.,'\p{L}')]]//p[not(ancestor::sub-article)]" id="p-ref-checks">
         <let name="text" value="string-join(for $x in self::*/(*|text())                                             return if ($x/local-name()='xref') then ()                                                    else if ($x//*:p) then ($x/text())                                                    else string($x),'')"/>
         <let name="missing-ref-regex" value="'\p{Lu}\p{L}\p{L}+( et al\.?)?\p{P}?\s*\p{Ps}?([1][7-9][0-9][0-9]|[2][0-2][0-9][0-9])'"/>
         
@@ -3502,7 +3502,7 @@
       <assert test="descendant::title" role="error" id="title-checks-xspec-assert">title must be present.</assert>
       <assert test="descendant::article/body/sec/title or descendant::article/back/sec/title" role="error" id="title-toc-checks-xspec-assert">article/body/sec/title|article/back/sec/title must be present.</assert>
       <assert test="descendant::p[not(ancestor::sub-article or ancestor::def) and (count(*)=1) and (child::bold or child::italic)]" role="error" id="p-bold-checks-xspec-assert">p[not(ancestor::sub-article or ancestor::def) and (count(*)=1) and (child::bold or child::italic)] must be present.</assert>
-      <assert test="descendant::p[not(ancestor::sub-article)]" role="error" id="p-ref-checks-xspec-assert">p[not(ancestor::sub-article)] must be present.</assert>
+      <assert test="descendant::article[descendant::xref[@ref-type='bibr'][matches(.,'\p{L}')]]//p[not(ancestor::sub-article)]" role="error" id="p-ref-checks-xspec-assert">article[descendant::xref[@ref-type='bibr'][matches(.,'\p{L}')]]//p[not(ancestor::sub-article)] must be present.</assert>
       <assert test="descendant::article/front/article-meta" role="error" id="general-article-meta-checks-xspec-assert">article/front/article-meta must be present.</assert>
       <assert test="descendant::article/front/article-meta/article-id" role="error" id="general-article-id-checks-xspec-assert">article/front/article-meta/article-id must be present.</assert>
       <assert test="descendant::article/front[journal-meta/lower-case(journal-id[1])='elife']/article-meta/article-id[@pub-id-type='publisher-id']" role="error" id="publisher-article-id-checks-xspec-assert">article/front[journal-meta/lower-case(journal-id[1])='elife']/article-meta/article-id[@pub-id-type='publisher-id'] must be present.</assert>


### PR DESCRIPTION
- Exclude cases where the article exclusively uses digits for reference citations