### PR TITLE
RP: Fix for ref-doi-openrxiv-doi-source

### DIFF
--- a/src/rp-schematron-base.sch
+++ b/src/rp-schematron-base.sch
@@ -2293,7 +2293,7 @@
           role="warning" 
           id="ref-doi-elife-doi-source">Ref has an eLife DOI (<value-of select="."/>), but it does not have a source containing 'eLife'.</report>
         
-        <report test="matches(normalize-space(lower-case(.)),'^(10\.1101|10\.64898)/') and not(
+        <report test="matches(normalize-space(lower-case(.)),'^(10\.1101|10\.64898)/(\d{5,6}|20[1-3][0-9]\.)') and not(
           parent::mixed-citation/source[matches(lower-case(.),'(bio|med)rxiv')]
           or
           parent::element-citation/source[matches(lower-case(.),'(bio|med)rxiv')]

--- a/src/rp-schematron.sch
+++ b/src/rp-schematron.sch
@@ -1811,7 +1811,7 @@
         
         <report test="matches(normalize-space(lower-case(.)),'^10\.7554/elife\.\d{5,6}') and not(           parent::mixed-citation/source[normalize-space(lower-case(.)) = 'elife']           or           parent::element-citation/source[normalize-space(lower-case(.)) = 'elife']           )" role="warning" id="ref-doi-elife-doi-source">[ref-doi-elife-doi-source] Ref has an eLife DOI (<value-of select="."/>), but it does not have a source containing 'eLife'.</report>
         
-        <report test="matches(normalize-space(lower-case(.)),'^(10\.1101|10\.64898)/') and not(           parent::mixed-citation/source[matches(lower-case(.),'(bio|med)rxiv')]           or           parent::element-citation/source[matches(lower-case(.),'(bio|med)rxiv')]           )" role="warning" id="ref-doi-openrxiv-doi-source">[ref-doi-openrxiv-doi-source] Ref has an openRxiv DOI (<value-of select="."/>), but it does not have a source containing 'bioRxiv' or 'medRxiv'.</report>
+        <report test="matches(normalize-space(lower-case(.)),'^(10\.1101|10\.64898)/(\d{5,6}|20[1-3][0-9]\.)') and not(           parent::mixed-citation/source[matches(lower-case(.),'(bio|med)rxiv')]           or           parent::element-citation/source[matches(lower-case(.),'(bio|med)rxiv')]           )" role="warning" id="ref-doi-openrxiv-doi-source">[ref-doi-openrxiv-doi-source] Ref has an openRxiv DOI (<value-of select="."/>), but it does not have a source containing 'bioRxiv' or 'medRxiv'.</report>
       </rule></pattern><pattern id="isbn-conformity-pattern"><rule context="ref//pub-id[@pub-id-type='isbn']|isbn" id="isbn-conformity">
         <let name="t" value="translate(.,'-','')"/>
       

--- a/src/rp-schematron.xsl
+++ b/src/rp-schematron.xsl
@@ -5850,8 +5850,8 @@
          </svrl:successful-report>
       </xsl:if>
       <!--REPORT warning-->
-      <xsl:if test="matches(normalize-space(lower-case(.)),'^(10\.1101|10\.64898)/') and not(           parent::mixed-citation/source[matches(lower-case(.),'(bio|med)rxiv')]           or           parent::element-citation/source[matches(lower-case(.),'(bio|med)rxiv')]           )">
-         <svrl:successful-report xmlns:svrl="http://purl.oclc.org/dsdl/svrl" test="matches(normalize-space(lower-case(.)),'^(10\.1101|10\.64898)/') and not( parent::mixed-citation/source[matches(lower-case(.),'(bio|med)rxiv')] or parent::element-citation/source[matches(lower-case(.),'(bio|med)rxiv')] )">
+      <xsl:if test="matches(normalize-space(lower-case(.)),'^(10\.1101|10\.64898)/(\d{5,6}|20[1-3][0-9]\.)') and not(           parent::mixed-citation/source[matches(lower-case(.),'(bio|med)rxiv')]           or           parent::element-citation/source[matches(lower-case(.),'(bio|med)rxiv')]           )">
+         <svrl:successful-report xmlns:svrl="http://purl.oclc.org/dsdl/svrl" test="matches(normalize-space(lower-case(.)),'^(10\.1101|10\.64898)/(\d{5,6}|20[1-3][0-9]\.)') and not( parent::mixed-citation/source[matches(lower-case(.),'(bio|med)rxiv')] or parent::element-citation/source[matches(lower-case(.),'(bio|med)rxiv')] )">
             <xsl:attribute name="id">ref-doi-openrxiv-doi-source</xsl:attribute>
             <xsl:attribute name="role">warning</xsl:attribute>
             <xsl:attribute name="location">

--- a/test/tests/rp/ref-doi-checks/ref-doi-openrxiv-doi-source/fail.xml
+++ b/test/tests/rp/ref-doi-checks/ref-doi-openrxiv-doi-source/fail.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="ref-doi-openrxiv-doi-source.sch"?>
 <!--Context: ref//pub-id[@pub-id-type='doi']
-Test: report    matches(normalize-space(lower-case(.)),'^(10\.1101|10\.64898)/') and not( parent::mixed-citation/source[matches(lower-case(.),'(bio|med)rxiv')] or parent::element-citation/source[matches(lower-case(.),'(bio|med)rxiv')] )
+Test: report    matches(normalize-space(lower-case(.)),'^(10\.1101|10\.64898)/(\d{5,6}|20[1-3][0-9]\.)') and not( parent::mixed-citation/source[matches(lower-case(.),'(bio|med)rxiv')] or parent::element-citation/source[matches(lower-case(.),'(bio|med)rxiv')] )
 Message: Ref has an openRxiv DOI (), but it does not have a source containing 'bioRxiv' or 'medRxiv'. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">
     <article>

--- a/test/tests/rp/ref-doi-checks/ref-doi-openrxiv-doi-source/pass.xml
+++ b/test/tests/rp/ref-doi-checks/ref-doi-openrxiv-doi-source/pass.xml
@@ -1,6 +1,6 @@
 <?oxygen SCHSchema="ref-doi-openrxiv-doi-source.sch"?>
 <!--Context: ref//pub-id[@pub-id-type='doi']
-Test: report    matches(normalize-space(lower-case(.)),'^(10\.1101|10\.64898)/') and not( parent::mixed-citation/source[matches(lower-case(.),'(bio|med)rxiv')] or parent::element-citation/source[matches(lower-case(.),'(bio|med)rxiv')] )
+Test: report    matches(normalize-space(lower-case(.)),'^(10\.1101|10\.64898)/(\d{5,6}|20[1-3][0-9]\.)') and not( parent::mixed-citation/source[matches(lower-case(.),'(bio|med)rxiv')] or parent::element-citation/source[matches(lower-case(.),'(bio|med)rxiv')] )
 Message: Ref has an openRxiv DOI (), but it does not have a source containing 'bioRxiv' or 'medRxiv'. -->
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">
     <article>

--- a/test/tests/rp/ref-doi-checks/ref-doi-openrxiv-doi-source/ref-doi-openrxiv-doi-source.sch
+++ b/test/tests/rp/ref-doi-checks/ref-doi-openrxiv-doi-source/ref-doi-openrxiv-doi-source.sch
@@ -1198,7 +1198,7 @@
   </sqf:fixes>
   <pattern id="ref-doi-checks-pattern">
     <rule context="ref//pub-id[@pub-id-type='doi']" id="ref-doi-checks">
-      <report test="matches(normalize-space(lower-case(.)),'^(10\.1101|10\.64898)/') and not(           parent::mixed-citation/source[matches(lower-case(.),'(bio|med)rxiv')]           or           parent::element-citation/source[matches(lower-case(.),'(bio|med)rxiv')]           )" role="warning" id="ref-doi-openrxiv-doi-source">[ref-doi-openrxiv-doi-source] Ref has an openRxiv DOI (<value-of select="."/>), but it does not have a source containing 'bioRxiv' or 'medRxiv'.</report>
+      <report test="matches(normalize-space(lower-case(.)),'^(10\.1101|10\.64898)/(\d{5,6}|20[1-3][0-9]\.)') and not(           parent::mixed-citation/source[matches(lower-case(.),'(bio|med)rxiv')]           or           parent::element-citation/source[matches(lower-case(.),'(bio|med)rxiv')]           )" role="warning" id="ref-doi-openrxiv-doi-source">[ref-doi-openrxiv-doi-source] Ref has an openRxiv DOI (<value-of select="."/>), but it does not have a source containing 'bioRxiv' or 'medRxiv'.</report>
     </rule>
   </pattern>
   <pattern id="root-pattern">

--- a/test/xspec/rp-schematron.sch
+++ b/test/xspec/rp-schematron.sch
@@ -1962,7 +1962,7 @@
         
         <report test="matches(normalize-space(lower-case(.)),'^10\.7554/elife\.\d{5,6}') and not(           parent::mixed-citation/source[normalize-space(lower-case(.)) = 'elife']           or           parent::element-citation/source[normalize-space(lower-case(.)) = 'elife']           )" role="warning" id="ref-doi-elife-doi-source">Ref has an eLife DOI (<value-of select="."/>), but it does not have a source containing 'eLife'.</report>
         
-        <report test="matches(normalize-space(lower-case(.)),'^(10\.1101|10\.64898)/') and not(           parent::mixed-citation/source[matches(lower-case(.),'(bio|med)rxiv')]           or           parent::element-citation/source[matches(lower-case(.),'(bio|med)rxiv')]           )" role="warning" id="ref-doi-openrxiv-doi-source">Ref has an openRxiv DOI (<value-of select="."/>), but it does not have a source containing 'bioRxiv' or 'medRxiv'.</report>
+        <report test="matches(normalize-space(lower-case(.)),'^(10\.1101|10\.64898)/(\d{5,6}|20[1-3][0-9]\.)') and not(           parent::mixed-citation/source[matches(lower-case(.),'(bio|med)rxiv')]           or           parent::element-citation/source[matches(lower-case(.),'(bio|med)rxiv')]           )" role="warning" id="ref-doi-openrxiv-doi-source">Ref has an openRxiv DOI (<value-of select="."/>), but it does not have a source containing 'bioRxiv' or 'medRxiv'.</report>
       </rule>
   </pattern>
   <pattern id="isbn-conformity-pattern">


### PR DESCRIPTION
Include DOI suffix convention to avoid false matches with CSHL journals