### PR TITLE
RP: Add a warning for unchanged assessment text

### DIFF
--- a/src/rp-schematron-base.sch
+++ b/src/rp-schematron-base.sch
@@ -5068,7 +5068,7 @@
   
   <!-- These are purely for oXygen validation -->
     <pattern id="api-calls">
-        <rule context="article[descendant::article-meta/pub-history/event/self-uri[@content-type='reviewed-preprint']]/sub-article[@article-type='editor-report']/front-stub" flag="local-only" id="assessment-api-check">
+        <rule context="article[descendant::article-meta/pub-history/event/self-uri[@content-type='reviewed-preprint']]/sub-article[@article-type='editor-report']" flag="local-only" id="assessment-api-check">
           <let name="article-id" value="ancestor::article//article-meta/article-id[@pub-id-type='publisher-id']"/>
           <let name="rp-version" value="replace(ancestor::article//article-meta[1]/article-id[@specific-use='version'][1],'^.*\.','')"/>
           <let name="prev-version" value="if (matches($rp-version,'^\d$')) then number($rp-version) - 1
@@ -5076,6 +5076,11 @@
           <let name="epp-response" value="if ($article-id and $prev-version) then parse-json(cache:getRPData($article-id,string($prev-version)))
                                           else ()"/>
           <let name="epp-assessment-data" value="if (exists($epp-response)) then $epp-response?elifeAssessment else ()"/>
+          <let name="epp-assessment-paragraphs" value="if (exists($epp-assessment-data)) then
+            $epp-assessment-data?content?*[?type = 'paragraph']?text
+            else ()"/>
+          <let name="prev-assessment-text" value="if (exists($epp-assessment-paragraphs)) then normalize-space(string-join($epp-assessment-paragraphs,' '))
+            else ()"/>
           <let name="prev-strength-terms" value="if (exists($epp-assessment-data)) then $epp-assessment-data?strength?* else ()"/>
           <let name="prev-strength-rank" value="if (exists($prev-strength-terms)) then sum(for $term in $prev-strength-terms[.!=''] return e:assessment-term-to-number($term))
             else ()"/>
@@ -5083,14 +5088,17 @@
           <let name="prev-significance-rank" value="if (exists($prev-significance-terms)) then sum(for $term in $prev-significance-terms[.!=''] return e:assessment-term-to-number($term))
             else ()"/>
           
-          <let name="curr-strength-terms" value="if (kwd-group[@kwd-group-type='evidence-strength']/kwd) then kwd-group[@kwd-group-type='evidence-strength']/kwd
+          <let name="curr-strength-terms" value="if (front-stub/kwd-group[@kwd-group-type='evidence-strength']/kwd) 
+            then front-stub/kwd-group[@kwd-group-type='evidence-strength']/kwd
             else '(None)'"/>
           <let name="curr-strength-rank" value="sum(for $term in $curr-strength-terms
             return e:assessment-term-to-number($term))"/>
-          <let name="curr-significance-terms" value="if (kwd-group[@kwd-group-type='claim-importance']/kwd) then kwd-group[@kwd-group-type='claim-importance']/kwd
+          <let name="curr-significance-terms" value="if (front-stub/kwd-group[@kwd-group-type='claim-importance']/kwd) 
+            then front-stub/kwd-group[@kwd-group-type='claim-importance']/kwd
             else '(None)'"/>
           <let name="curr-significance-rank" value="sum(for $term in $curr-significance-terms
             return e:assessment-term-to-number($term))"/>
+          <let name="curr-assessment-text" value="normalize-space(body)"/>
           
           <report test="($prev-strength-rank gt $curr-strength-rank)" 
             role="warning" 
@@ -5099,6 +5107,10 @@
           <report test="($prev-significance-rank gt $curr-significance-rank)" 
             role="warning" 
             id="sig-kwd-api-check">The Assessment significance term(s) in this revised Reviewed Preprint (version <value-of select="$rp-version"/>) are lower than those in the previous version (version <value-of select="$prev-version"/>). Is that correct? Current: <value-of select="string-join($curr-significance-terms,'; ')"/>. Previous: <value-of select="string-join($prev-significance-terms,'; ')"/>.</report>
+          
+          <report test="$prev-assessment-text = $curr-assessment-text" 
+            role="warning" 
+            id="assessment-text-api-check">The Assessment text in this revised Reviewed Preprint (version <value-of select="$rp-version"/>) is the exact same as in the previous version (version <value-of select="$prev-version"/>). Is that correct?</report>
       </rule>
     </pattern>
 

--- a/src/rp-schematron.sch
+++ b/src/rp-schematron.sch
@@ -3195,25 +3195,30 @@
     </rule></pattern>
   
   <!-- These are purely for oXygen validation -->
-    <pattern id="assessment-api-check-pattern"><rule context="article[descendant::article-meta/pub-history/event/self-uri[@content-type='reviewed-preprint']]/sub-article[@article-type='editor-report']/front-stub" flag="local-only" id="assessment-api-check">
+    <pattern id="assessment-api-check-pattern"><rule context="article[descendant::article-meta/pub-history/event/self-uri[@content-type='reviewed-preprint']]/sub-article[@article-type='editor-report']" flag="local-only" id="assessment-api-check">
           <let name="article-id" value="ancestor::article//article-meta/article-id[@pub-id-type='publisher-id']"/>
           <let name="rp-version" value="replace(ancestor::article//article-meta[1]/article-id[@specific-use='version'][1],'^.*\.','')"/>
           <let name="prev-version" value="if (matches($rp-version,'^\d$')) then number($rp-version) - 1             else 1"/>
           <let name="epp-response" value="if ($article-id and $prev-version) then parse-json(cache:getRPData($article-id,string($prev-version)))                                           else ()"/>
           <let name="epp-assessment-data" value="if (exists($epp-response)) then $epp-response?elifeAssessment else ()"/>
+          <let name="epp-assessment-paragraphs" value="if (exists($epp-assessment-data)) then             $epp-assessment-data?content?*[?type = 'paragraph']?text             else ()"/>
+          <let name="prev-assessment-text" value="if (exists($epp-assessment-paragraphs)) then normalize-space(string-join($epp-assessment-paragraphs,' '))             else ()"/>
           <let name="prev-strength-terms" value="if (exists($epp-assessment-data)) then $epp-assessment-data?strength?* else ()"/>
           <let name="prev-strength-rank" value="if (exists($prev-strength-terms)) then sum(for $term in $prev-strength-terms[.!=''] return e:assessment-term-to-number($term))             else ()"/>
           <let name="prev-significance-terms" value="if (exists($epp-assessment-data)) then $epp-assessment-data?significance?* else ()"/>
           <let name="prev-significance-rank" value="if (exists($prev-significance-terms)) then sum(for $term in $prev-significance-terms[.!=''] return e:assessment-term-to-number($term))             else ()"/>
           
-          <let name="curr-strength-terms" value="if (kwd-group[@kwd-group-type='evidence-strength']/kwd) then kwd-group[@kwd-group-type='evidence-strength']/kwd             else '(None)'"/>
+          <let name="curr-strength-terms" value="if (front-stub/kwd-group[@kwd-group-type='evidence-strength']/kwd)              then front-stub/kwd-group[@kwd-group-type='evidence-strength']/kwd             else '(None)'"/>
           <let name="curr-strength-rank" value="sum(for $term in $curr-strength-terms             return e:assessment-term-to-number($term))"/>
-          <let name="curr-significance-terms" value="if (kwd-group[@kwd-group-type='claim-importance']/kwd) then kwd-group[@kwd-group-type='claim-importance']/kwd             else '(None)'"/>
+          <let name="curr-significance-terms" value="if (front-stub/kwd-group[@kwd-group-type='claim-importance']/kwd)              then front-stub/kwd-group[@kwd-group-type='claim-importance']/kwd             else '(None)'"/>
           <let name="curr-significance-rank" value="sum(for $term in $curr-significance-terms             return e:assessment-term-to-number($term))"/>
+          <let name="curr-assessment-text" value="normalize-space(body)"/>
           
           <report test="($prev-strength-rank gt $curr-strength-rank)" role="warning" id="str-kwd-api-check">[str-kwd-api-check] The Assessment strength term(s) in this revised Reviewed Preprint (version <value-of select="$rp-version"/>) are lower than those in the previous version (version <value-of select="$prev-version"/>). Is that correct? Current: <value-of select="string-join($curr-strength-terms,'; ')"/>. Previous: <value-of select="string-join($prev-strength-terms,'; ')"/>.</report>
           
           <report test="($prev-significance-rank gt $curr-significance-rank)" role="warning" id="sig-kwd-api-check">[sig-kwd-api-check] The Assessment significance term(s) in this revised Reviewed Preprint (version <value-of select="$rp-version"/>) are lower than those in the previous version (version <value-of select="$prev-version"/>). Is that correct? Current: <value-of select="string-join($curr-significance-terms,'; ')"/>. Previous: <value-of select="string-join($prev-significance-terms,'; ')"/>.</report>
+          
+          <report test="$prev-assessment-text = $curr-assessment-text" role="warning" id="assessment-text-api-check">[assessment-text-api-check] The Assessment text in this revised Reviewed Preprint (version <value-of select="$rp-version"/>) is the exact same as in the previous version (version <value-of select="$prev-version"/>). Is that correct?</report>
       </rule></pattern>
 
     <!-- Checks for the manifest file in the meca package.


### PR DESCRIPTION
When the assessment text is the exact same as the previous version, fire a warning